### PR TITLE
Set persistent sizes for volumes for ci tests

### DIFF
--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -16,6 +16,19 @@ clickhouseOperator:
   namespace: default
   storage: 2Gi
 
+postgresql:
+  persistence:
+    size: 1Gi
+
+redis:
+  master:
+    persistence:
+      size: 1Gi
+
+kafka:
+  persistence:
+    size: 1Gi
+
 plugins:
   replicacount: 1
 


### PR DESCRIPTION
I was trying to change the sizes for defaults in our values files & ran into an error in the upgrade test. It seems best to define sizes here and they likely should be smaller compared to what we have in the values file.
```
Error: UPGRADE FAILED: cannot patch "posthog-posthog-kafka" with kind StatefulSet: StatefulSet.apps "posthog-posthog-kafka" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden && cannot patch "posthog-posthog-postgresql" with kind StatefulSet: StatefulSet.apps "posthog-posthog-postgresql" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden && cannot patch "posthog-posthog-redis-master" with kind StatefulSet: StatefulSet.apps "posthog-posthog-redis-master" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```