### PR TITLE
Add k6 perf testing

### DIFF
--- a/perf-testing/README.md
+++ b/perf-testing/README.md
@@ -1,0 +1,17 @@
+To run the perf test
+
+Set the `POSTHOG_URL` env variable, e.g.
+```
+export POSTHOG_URL="https://posthog.click"
+export POSTHOG_URL="http://localhost:8000"
+```
+
+Run k6 ([docs](https://k6.io/docs/)).
+```
+k6 run k6-capture-events.js
+```
+
+Sleep time can be customized to add more load.
+```
+CE_SLEEP=0.1 k6 run k6-capture-events.js
+```

--- a/perf-testing/README.md
+++ b/perf-testing/README.md
@@ -1,9 +1,10 @@
 To run the perf test
 
-Set the `POSTHOG_URL` env variable, e.g.
+Set the `POSTHOG_URL` and `API_KEY` env variables (the latter can be found in Posthog project/settings page), e.g.
 ```
 export POSTHOG_URL="https://posthog.click"
 export POSTHOG_URL="http://localhost:8000"
+export API_KEY='ws6xnNaSGqAbY07-Q0SVJPJrhfGtpPKSecKDiBn97ps'
 ```
 
 Run k6 ([docs](https://k6.io/docs/)).

--- a/perf-testing/k6-capture-events.js
+++ b/perf-testing/k6-capture-events.js
@@ -21,7 +21,7 @@ export let options = {
 
 export default function () {
   const res = http.post(`${__ENV.POSTHOG_URL}/e/`, JSON.stringify({
-    api_key: 'ws6xnNaSGqAbY07-Q0SVJPJrhfGtpPKSecKDiBn97ps',
+    api_key: __ENV.API_KEY,
     event: 'k6s_custom_event',
     distinct_id: __VU
   }));

--- a/perf-testing/k6-capture-events.js
+++ b/perf-testing/k6-capture-events.js
@@ -1,0 +1,40 @@
+import http from 'k6/http'
+import {check, group, sleep} from 'k6'
+import { Gauge } from 'k6/metrics'
+
+let eventsIngested = new Gauge('events_ingested')
+
+export let options = {
+  thresholds: {
+    http_req_failed: ['rate<0.01'],   // http errors should be less than 1%
+    http_req_duration: ['p(95)<500'], // 95% of requests should be below 500ms
+    events_ingested: ['value > 0', 'value > 100']
+  },
+  stages: [
+    { duration: '2m', target: 100 }, // below normal load
+    { duration: '2m', target: 100 },
+    { duration: '2m', target: 200 }, // Digital Ocean small lb connection limit is 250
+    { duration: '2m', target: 200 },
+    { duration: '5m', target: 0 }, // scale down. Recovery stage.
+  ],
+  //scenarios: {
+  //  captureEvents: {
+  //    exec: 'captureEvents',
+  //    executor: 'shared-iterations',
+  //    iterations: __ENV.CE_ITERATIONS || 10000,
+  //    vus: __ENV.CE_VUS || 20,
+  //  }
+  //}
+}
+
+export default function () {
+  const res = http.post(`${__ENV.POSTHOG_URL}/e/`, JSON.stringify({
+    api_key: 'ws6xnNaSGqAbY07-Q0SVJPJrhfGtpPKSecKDiBn97ps',
+    event: 'k6s_custom_event',
+    distinct_id: __VU
+  }));
+
+  check(res, { 'status 200': (r) => r.status === 200 })
+
+  sleep(__ENV.CE_SLEEP || 1)
+}

--- a/perf-testing/k6-capture-events.js
+++ b/perf-testing/k6-capture-events.js
@@ -11,20 +11,12 @@ export let options = {
     events_ingested: ['value > 0', 'value > 100']
   },
   stages: [
-    { duration: '2m', target: 100 }, // below normal load
+    { duration: '2m', target: 100 },
     { duration: '2m', target: 100 },
     { duration: '2m', target: 200 }, // Digital Ocean small lb connection limit is 250
     { duration: '2m', target: 200 },
     { duration: '5m', target: 0 }, // scale down. Recovery stage.
   ],
-  //scenarios: {
-  //  captureEvents: {
-  //    exec: 'captureEvents',
-  //    executor: 'shared-iterations',
-  //    iterations: __ENV.CE_ITERATIONS || 10000,
-  //    vus: __ENV.CE_VUS || 20,
-  //  }
-  //}
 }
 
 export default function () {


### PR DESCRIPTION
Ran some tests with k6 agains our DigitalOcean setup served on https://posthog.click 

## vus up to 200 ; sleep = 1
```> k6 run perf-testing/k6-capture-events.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: perf-testing/k6-capture-events.js
     output: -

  scenarios: (100.00%) 1 scenario, 200 max VUs, 13m30s max duration (incl. graceful stop):
           * default: Up to 200 looping VUs for 13m0s over 5 stages (gracefulRampDown: 30s, gracefulStop: 30s)


running (13m00.5s), 000/200 VUs, 81484 complete and 0 interrupted iterations
default ✓ [======================================] 000/200 VUs  13m0s

     ✗ status 200
      ↳  99% — ✓ 81480 / ✗ 4

     checks.........................: 99.99% ✓ 81480 ✗ 4
     data_received..................: 24 MB  31 kB/s
     data_sent......................: 17 MB  22 kB/s
     http_req_blocked...............: avg=94.22µs  min=0s    med=0s      max=198.35ms p(90)=1µs      p(95)=1µs
     http_req_connecting............: avg=35.98µs  min=0s    med=0s      max=128.44ms p(90)=0s       p(95)=0s
   ✓ http_req_duration..............: avg=106.39ms min=164µs med=65.8ms  max=697.72ms p(90)=240.83ms p(95)=292.99ms
       { expected_response:true }...: avg=106.39ms min=164µs med=65.81ms max=697.72ms p(90)=240.83ms p(95)=293ms
   ✓ http_req_failed................: 0.00%  ✓ 4     ✗ 81480
     http_req_receiving.............: avg=81.05µs  min=24µs  med=60µs    max=24.21ms  p(90)=100µs    p(95)=122µs
     http_req_sending...............: avg=88.05µs  min=27µs  med=78µs    max=10.13ms  p(90)=133µs    p(95)=158µs
     http_req_tls_handshaking.......: avg=57.13µs  min=0s    med=0s      max=157.98ms p(90)=0s       p(95)=0s
     http_req_waiting...............: avg=106.22ms min=0s    med=65.63ms max=697.52ms p(90)=240.64ms p(95)=292.8ms
     http_reqs......................: 81484  104.394798/s
     iteration_duration.............: avg=1.1s     min=1.01s med=1.06s   max=1.69s    p(90)=1.24s    p(95)=1.29s
     iterations.....................: 81484  104.394798/s
     vus............................: 1      min=1   max=200
     vus_max........................: 200    min=200 max=200
```



## vus up to 200 ; sleep = 0.1
With 200 parallel users sleeping 0.1s in between our response time was more than 0.5s average
```
> CE_SLEEP=0.1 k6 run perf-testing/k6-capture-events.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: perf-testing/k6-capture-events.js
     output: -

  scenarios: (100.00%) 1 scenario, 200 max VUs, 5m30s max duration (incl. graceful stop):
           * default: Up to 200 looping VUs for 5m0s over 5 stages (gracefulRampDown: 30s, gracefulStop: 30s)


running (5m00.1s), 000/200 VUs, 45053 complete and 0 interrupted iterations
default ✓ [======================================] 000/200 VUs  5m0s

     ✗ status 200
      ↳  99% — ✓ 45052 / ✗ 1

     checks.........................: 99.99% ✓ 45052 ✗ 1
     data_received..................: 14 MB  46 kB/s
     data_sent......................: 9.3 MB 31 kB/s
     http_req_blocked...............: avg=184.22µs min=0s       med=0s       max=221.31ms p(90)=1µs   p(95)=1µs
     http_req_connecting............: avg=70.72µs  min=0s       med=0s       max=181.03ms p(90)=0s    p(95)=0s
   ✗ http_req_duration..............: avg=699.94ms min=23.13ms  med=625.17ms max=1.81s    p(90)=1.19s p(95)=1.24s
       { expected_response:true }...: avg=699.96ms min=26.92ms  med=625.19ms max=1.81s    p(90)=1.19s p(95)=1.24s
   ✓ http_req_failed................: 0.00%  ✓ 1     ✗ 45052
     http_req_receiving.............: avg=73.28µs  min=23µs     med=54µs     max=14.08ms  p(90)=90µs  p(95)=109µs
     http_req_sending...............: avg=77.43µs  min=27µs     med=70µs     max=890µs    p(90)=116µs p(95)=139µs
     http_req_tls_handshaking.......: avg=112.36µs min=0s       med=0s       max=170.68ms p(90)=0s    p(95)=0s
     http_req_waiting...............: avg=699.79ms min=23.03ms  med=624.98ms max=1.81s    p(90)=1.19s p(95)=1.24s
     http_reqs......................: 45053  150.127952/s
     iteration_duration.............: avg=800.55ms min=123.32ms med=725.72ms max=1.91s    p(90)=1.29s p(95)=1.34s
     iterations.....................: 45053  150.127952/s
     vus............................: 1      min=1   max=200
     vus_max........................: 200    min=200 max=200

ERRO[0300] some thresholds have failed
```

## DO & posthog insights

<img width="760" alt="Screen Shot 2021-06-23 at 04 43 52" src="https://user-images.githubusercontent.com/890921/123027501-388e9180-d3de-11eb-8b2d-209def7fc335.png">

<img width="825" alt="Screen Shot 2021-06-23 at 04 49 29" src="https://user-images.githubusercontent.com/890921/123027631-71c70180-d3de-11eb-817c-329c86f2aa8f.png">


