### PR TITLE
DigitalOcean values.yaml changes

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -38,15 +38,11 @@ dependencies:
     version: 3.25.0
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress.nginx.enabled
-    tags:
-      - nginxAndCertmanager
     namespace: ingress-nginx
   - name: cert-manager
     version: 1.2
     repository: https://charts.jetstack.io
     condition: certManager.enabled
-    tags:
-      - nginxAndCertmanager
     namespace: cert-manager
   - name: prometheus
     version: 14.1.1

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -38,11 +38,15 @@ dependencies:
     version: 3.25.0
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress.nginx.enabled
+    tags:
+      - nginxAndCertmanager
     namespace: ingress-nginx
   - name: cert-manager
     version: 1.2
     repository: https://charts.jetstack.io
     condition: certManager.enabled
+    tags:
+      - nginxAndCertmanager
     namespace: cert-manager
   - name: prometheus
     version: 14.1.1

--- a/charts/posthog/templates/NOTES.txt
+++ b/charts/posthog/templates/NOTES.txt
@@ -5,7 +5,7 @@ To access your PostHog site from outside the cluster follow the steps below:
 
 {{- if .Values.ingress.enabled }}
 1. Your application will be hosted at http{{ if (or .Values.ingress.tls .Values.ingress.gcp.forceHttps) }}s{{ end }}://{{ .Values.ingress.hostname }}/
-{{- if (and .Values.ingress.gcp (eq .Values.ingress.type "clb") .Values.ingress.gcp.ip_name) }}
+{{- if (and .Values.ingress.gcp (eq (include "ingress.type" .) "clb") .Values.ingress.gcp.ip_name) }}
 2. Get the application IP by running:
   gcloud compute addresses list
 3. Update your DNS

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -330,6 +330,18 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{- define "ingress.type" -}}
+{{- if ne (.Values.ingress.type | toString) "<nil>" -}}
+  {{ .Values.ingress.type }}
+{{- else if .Values.ingress.nginx.enabled -}}
+  nginx
+{{- else if (eq .Values.cloud "gcp") -}}
+  clb
+{{- else -}}
+  undefined
+{{- end -}}
+{{- end -}}
+
 {{- define "posthog.helmInstallInfo" -}}
 {{- $info := dict }}
 {{- $info := set $info "cloud" .Values.cloud -}}
@@ -338,7 +350,7 @@ Create the name of the service account to use
 {{- $info := set $info "release_revision" .Release.Revision -}}
 {{- $info := set $info "hostname" .Values.ingress.hostname -}}
 {{- $info := set $info "operation" (include "posthog.helmOperation" .) -}}
-{{- $info := set $info "ingress_type" .Values.ingress.type -}}
+{{- $info := set $info "ingress_type" (include "ingress.type" .) -}}
 {{ toJson $info | quote }}
 {{- end -}}
 
@@ -346,7 +358,12 @@ Create the name of the service account to use
     helm_{{ .Values.cloud }}_ha
 {{- end -}}
 
-{{- define "letsencrypt" -}}
-{{- hasKey .Values.ingress "letsencrypt" | ternary .Values.ingress.letsencrypt .Values.tags.nginxAndCertmanager | default false}}
-}}
+{{- define "ingress.letsencrypt" -}}
+{{- if ne (.Values.ingress.letsencrypt | toString) "<nil>" -}}
+  {{ .Values.ingress.letsencrypt }}
+{{- else if .Values.ingress.nginx.enabled -}}
+  true
+{{- else -}}
+  false
+{{- end -}}
 {{- end -}}

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -345,3 +345,8 @@ Create the name of the service account to use
 {{- define "posthog.deploymentEnv" -}}
     helm_{{ .Values.cloud }}_ha
 {{- end -}}
+
+{{- define "letsencrypt" -}}
+{{- hasKey .Values.ingress "letsencrypt" | ternary .Values.ingress.letsencrypt .Values.tags.nginxAndCertmanager | default false}}
+}}
+{{- end -}}

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if include "letsencrypt" .}}
+{{- if eq (include "ingress.letsencrypt" .) "true"}}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.letsencrypt }}
+{{- if include "letsencrypt" .}}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -6,7 +6,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: james.g@posthog.com 
+    email: james.g@posthog.com
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/templates/gce-frontend-config.yaml
+++ b/charts/posthog/templates/gce-frontend-config.yaml
@@ -1,5 +1,5 @@
 
-{{- if and .Values.ingress.enabled (eq .Values.ingress.type "clb")  -}}
+{{- if and .Values.ingress.enabled (eq (include "ingress.type" .) "clb")  -}}
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:

--- a/charts/posthog/templates/gke-cert-issuer.yaml
+++ b/charts/posthog/templates/gke-cert-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.ingress.gcp (eq .Values.ingress.type "clb")) -}}
+{{- if (and .Values.ingress.gcp (eq (include "ingress.type" .) "clb")) -}}
 {{- if .Values.ingress.gcp.ip_name -}}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -9,13 +9,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
  annotations:
-   {{- if (eq .Values.ingress.type "clb") }}
+   {{- if (eq (include "ingress.type" .) "clb") }}
     kubernetes.io/ingress.class: "gce"
     networking.gke.io/managed-certificates: "{{ .Release.Name }}-gke-cert"
     networking.gke.io/v1beta1.FrontendConfig: "{{ .Release.Name }}-frontend-config"
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.ip_name | quote }}
    {{- end }}
-   {{- if (eq .Values.ingress.type "alb") }}
+   {{- if (eq (include "ingress.type" .) "alb") }}
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/target-type: ip
     # example: arn:aws:acm:eu-west-1:118330671040:certificate/a6cae86a-47f6-40b8-ab9e-f35bf1b736e0
@@ -25,10 +25,10 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/healthcheck-path: "/_health"
    {{- end }}
-   {{- if (eq .Values.ingress.type "nginx") }}
+   {{- if (eq (include "ingress.type" .) "nginx") }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-   {{- if include "letsencrypt" .}}
+   {{- if eq (include "ingress.letsencrypt" .) "true"}}
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
    {{- end }}
    {{- end }}
@@ -38,7 +38,7 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
-   {{- if include "letsencrypt" .}}
+   {{- if eq (include "ingress.letsencrypt" .) "true"}}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -28,7 +28,7 @@ metadata:
    {{- if (eq .Values.ingress.type "nginx") }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-   {{- if .Values.ingress.letsencrypt }}
+   {{- if include "letsencrypt" .}}
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
    {{- end }}
    {{- end }}
@@ -38,7 +38,7 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
-  {{- if .Values.ingress.letsencrypt }}
+   {{- if include "letsencrypt" .}}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -22,7 +22,7 @@ clickhouseOperator:
   # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
   enabled: true
   # -- Which namespace to install clickhouse operator to
-  namespace:
+  namespace: "posthog"
   # -- How much storage space to preallocate for clickhouse
   storage: 20Gi
 
@@ -305,6 +305,8 @@ redis:
   enabled: true
   # -- Name override for redis app
   nameOverride: posthog-redis
+  # Don't require password by default
+  usePassword: false
   # The following variables are only used when internal PG is disabled
   # host: redis
   # Just omit the password field if your redis cluster doesn't use password

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
-# -- Cloud service being deployed on. Either `gcp` or `aws`
+# -- Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
 cloud: "gcp"
 # -- Sentry endpoint to send errors to
 sentryDSN:
@@ -28,10 +28,10 @@ clickhouseOperator:
 
 # -- Env vars to throw into every deployment (web, beat, worker, and plugin server)
 env:
-- name: ASYNC_EVENT_PROPERTY_USAGE
-  value: "true"
-- name: EVENT_PROPERTY_USAGE_INTERVAL_SECONDS
-  value: "86400"
+  - name: ASYNC_EVENT_PROPERTY_USAGE
+    value: "true"
+  - name: EVENT_PROPERTY_USAGE_INTERVAL_SECONDS
+    value: "86400"
 
 # -- PgBouncer setup
 pgbouncer:
@@ -74,15 +74,15 @@ web:
     #   memory: 300Mi
   # -- Env variables for web container
   env:
-  # -- Set google oauth 2 key. Requires posthog ee license.
-  - name: SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
-    value:
-  # -- Set google oauth 2 secret. Requires posthog ee license.
-  - name: SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET
-    value:
-  # -- Set google oauth 2 whitelisted domains users can log in from
-  - name: SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS
-    value: "posthog.com"
+    # -- Set google oauth 2 key. Requires posthog ee license.
+    - name: SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
+      value:
+    # -- Set google oauth 2 secret. Requires posthog ee license.
+    - name: SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET
+      value:
+    # -- Set google oauth 2 whitelisted domains users can log in from
+    - name: SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS
+      value: "posthog.com"
 
   internalMetrics:
     # -- Whether to capture information on operation of posthog into posthog, exposed in /instance/status page
@@ -222,7 +222,7 @@ email:
   # -- SMTP TLS for security
   use_tls: true
   # -- SMTP SSL for security
-  use_tls:
+  use_ssl:
   # -- SMTP password from an existing secret. When defined the `password` field is ignored
   existingSecret:
   # -- Key to get from the `email.existingSecret` secret
@@ -230,7 +230,6 @@ email:
   # When defined the `password` field is ignored
   # existingSecret: secret-name
   # existingSecretKey: smtp-password
-
 
 # -- Name of the service and what port to expose on the pod. Don't change these unless you know what you're doing
 service:
@@ -252,9 +251,8 @@ service:
   # loadBalancerSourceRanges: []
 
 certManager:
-  # :TODO: When should be this true?
-  # -- Whether to install cert-manager
-  enabled: false
+  # -- Whether to install cert-manager. Validates certs for nginx ingress
+  enabled:
 
 ingress:
   # -- Enable ingress controller resource
@@ -268,11 +266,14 @@ ingress:
     ip_name: "posthog"
     # -- If true, will force a https redirect when accessed over http
     forceHttps: true
-  # -- Whether to enable letsencrypt. Set to true for type nginx
-  letsencrypt: false
+  # -- Whether to enable letsencrypt. By default true with nginx-and-certmanager tag and false otherwise
+  letsencrypt:
   nginx:
     # -- Whether nginx is enabled
-    enabled: false
+    enabled:
+
+tags:
+  nginx-and-certmanager: false
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)
@@ -500,7 +501,6 @@ prometheus:
       requests:
         cpu: 50m
 
-
   kubeStateMetrics:
     # -- If false, kube-state-metrics sub-chart will not be installed
     enabled: true
@@ -553,7 +553,8 @@ prometheus:
               labels:
                 severity: warning
               annotations:
-                description: Pod {{$labels.namespace}}/{{$labels.pod}} was restarted {{$value}}
+                description:
+                  Pod {{$labels.namespace}}/{{$labels.pod}} was restarted {{$value}}
                   times within the last hour
                 summary: Pod is restarting frequently
             # Requires nodeExporter.enabled
@@ -563,8 +564,8 @@ prometheus:
               labels:
                 severity: page
               annotations:
-                description: 'Persistent volume claim {{ $labels.persistentvolumeclaim }} disk usage is above 85% for past 5 minutes'
-                summary: 'Kubernetes {{ $labels.persistentvolumeclaim }} is full (host {{ $labels.kubernetes_io_hostname }})'
+                description: "Persistent volume claim {{ $labels.persistentvolumeclaim }} disk usage is above 85% for past 5 minutes"
+                summary: "Kubernetes {{ $labels.persistentvolumeclaim }} is full (host {{ $labels.kubernetes_io_hostname }})"
 
 # -- Prometheus StatsD configuration, see https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-statsd-exporter
 statsd:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -252,13 +252,13 @@ service:
 
 certManager:
   # -- Whether to install cert-manager. Validates certs for nginx ingress
-  enabled:
+  enabled: true
 
 ingress:
   # -- Enable ingress controller resource
   enabled: true
-  # -- Ingress handler type. Either `clb` on gcp or `nginx` elsewhere
-  type: "clb"
+  # -- Ingress handler type. Defaults to `nginx` if nginx is enabled and to `clb` on gcp.
+  type:
   # -- URL to address your PostHog installation. You will need to set up DNS after installation
   hostname:
   gcp:
@@ -266,14 +266,11 @@ ingress:
     ip_name: "posthog"
     # -- If true, will force a https redirect when accessed over http
     forceHttps: true
-  # -- Whether to enable letsencrypt. By default true with nginx-and-certmanager tag and false otherwise
+  # -- Whether to enable letsencrypt. Defaults to true if nginx enabled and false otherwise.
   letsencrypt:
   nginx:
     # -- Whether nginx is enabled
-    enabled:
-
-tags:
-  nginx-and-certmanager: false
+    enabled: true
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)

--- a/digital-ocean-values.yaml
+++ b/digital-ocean-values.yaml
@@ -1,0 +1,24 @@
+cloud: "digital-ocean"
+ingress:
+  enabled: true
+  type: "nginx"
+  hostname: "posthog.click"
+  path: /*
+  letsencrypt: true
+  nginx:
+    enabled: true
+
+hooks:
+  migrate:
+    resources:
+      limits:
+        memory: 500Mi
+      requests:
+        memory: 500Mi
+
+redis:
+  usePassword: false
+  password: ""
+
+certManager:
+  enabled: true

--- a/digital-ocean-values.yaml
+++ b/digital-ocean-values.yaml
@@ -1,24 +1,8 @@
-cloud: "digital-ocean"
+cloud: "do"
 ingress:
-  enabled: true
-  type: "nginx"
+  type: "nginx" # can make this also come from the tag also
+  # "PROVIDE_YOUR_HOSTNAME"
   hostname: "posthog.click"
-  path: /*
-  letsencrypt: true
-  nginx:
-    enabled: true
 
-hooks:
-  migrate:
-    resources:
-      limits:
-        memory: 500Mi
-      requests:
-        memory: 500Mi
-
-redis:
-  usePassword: false
-  password: ""
-
-certManager:
-  enabled: true
+tags:
+  nginxAndCertmanager: true

--- a/digital-ocean-values.yaml
+++ b/digital-ocean-values.yaml
@@ -1,8 +1,8 @@
 cloud: "do"
 ingress:
-  type: "nginx" # can make this also come from the tag also
-  # "PROVIDE_YOUR_HOSTNAME"
   hostname: "posthog.click"
 
-tags:
-  nginxAndCertmanager: true
+# smtp login and key ommited as it's a public repo
+# email:
+#   user: # TODO
+#   password: # TODO


### PR DESCRIPTION
Changed a couple of things about values files:
1. `use_ssl` <- looks like a typo we had `use_tls` twice
2. ingress type to be evaluated from other fields if not defined directly (nginx if nginx is enabled, clb if cloud is gcp)
3. letsencrypt to be evaluated based on nginx enabled or not (if not explicitly defined)
4. clickhouse operator to default to posthog namespace
5. certmanager & nginx to be enabled by default to disable set `certManager.enabled: false` & `ingress.nginx.enabled: false`
6. Redis default `usePassword: false`

Also added the digital-ocean-values.yaml for us here to use with test DO setup