### PR TITLE
Remove persistent sizes for volumes for ci tests

### DIFF
--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -16,14 +16,6 @@ clickhouseOperator:
   namespace: default
   storage: 2Gi
 
-postgresql:
-  persistence:
-    size: 1Gi
-
-kafka:
-  persistence:
-    size: 1Gi
-
 plugins:
   replicacount: 1
 


### PR DESCRIPTION
This reverts https://github.com/PostHog/charts-clickhouse/pull/18

The ci error being fixed by that PR was something we want to error on - if someone uses default values and we change them it is a breaking change which this test catches. 

If we change defaults randomly users can end up with a stack that's unupgradable without diving into our git history.

There's no shame in merging red PRs but this does make it explicit when we're doing breaking changes.

cc @tiina303