### PR TITLE
Make upgrading with custom ingress.gcp.ip_name work

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -331,7 +331,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "ingress.type" -}}
-{{- if ne (.Values.ingress.type | toString) "<nil>" -}}
+{{- if hasKey .Values.ingress "type" -}}
   {{ .Values.ingress.type }}
 {{- else if .Values.ingress.nginx.enabled -}}
   nginx

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     kubernetes.io/ingress.class: "gce"
     networking.gke.io/managed-certificates: "{{ .Release.Name }}-gke-cert"
     networking.gke.io/v1beta1.FrontendConfig: "{{ .Release.Name }}-frontend-config"
-    {{- if .Values.ingress.gcp.ip_name -}}
+    {{- if .Values.ingress.gcp.ip_name }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.ip_name | quote }}
     {{- end }}
    {{- end }}


### PR DESCRIPTION
The go template had a bug where it removed all preceding whitespace
before static-ip-name, resulting in invalid yaml.

Also used a more standard way to check for if value exists.
