### PR TITLE
set allow_experimental_window_functions for default profile on clickhouse

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -44,6 +44,8 @@ spec:
       admin/quota: default
       default/password: {{ .Values.clickhouse.password }}
       default/networks/ip: "0.0.0.0/0"
+    profiles:
+      default/allow_experimental_window_functions: "1" 
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}
         templates:

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -45,7 +45,7 @@ spec:
       default/password: {{ .Values.clickhouse.password }}
       default/networks/ip: "0.0.0.0/0"
     profiles:
-      default/allow_experimental_window_functions: "1" 
+      default/allow_experimental_window_functions: "1"
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}
         templates:


### PR DESCRIPTION
This was requested by the core analytics team for funnel work. This setting has already been set on cloud, now just to set it on VPC deploys.

**Warning**
This is an experimental feature that is currently in development and is not ready for general use. It will change in unpredictable backwards-incompatible ways in the future releases. Set allow_experimental_window_functions = 1 to enable it.