### PR TITLE
Fix migrations and make TLS optional based on redirectToTLS and letsencrypt values

### DIFF
--- a/charts/posthog/templates/NOTES.txt
+++ b/charts/posthog/templates/NOTES.txt
@@ -4,7 +4,13 @@
 To access your PostHog site from outside the cluster follow the steps below:
 
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.hostname }}
 1. Your application will be hosted at http{{ if (or .Values.ingress.tls .Values.ingress.gcp.forceHttps) }}s{{ end }}://{{ .Values.ingress.hostname }}/
+{{- else }}
+1. Your application will be hosted at an ingress IP because hostname was not supplied. Run these commands to get your installation location:
+export INGRESS_IP=$(kubectl get --namespace {{ .Release.Namespace }} ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}") 
+echo "Visit http://$INGRESS_IP to use PostHog\!"
+{{- end }}
 {{- if (and .Values.ingress.gcp (eq (include "ingress.type" .) "clb") .Values.ingress.gcp.ip_name) }}
 2. Get the application IP by running:
   gcloud compute addresses list

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -342,6 +342,18 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+Should we redirect HTTP to TLS?
+*/}}
+{{- define "ingress.redirectToTLS" -}}
+{{- if hasKey .Values.ingress "redirectToTLS" -}}
+    {{ .Values.ingress.redirectToTLS | quote }}
+{{- else -}}
+    "true"
+{{- end -}}
+{{- end -}}
+
+
 {{- define "posthog.helmInstallInfo" -}}
 {{- $info := dict }}
 {{- $info := set $info "cloud" .Values.cloud -}}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/healthcheck-path: "/_health"
    {{- end }}
-   {{- if (eq (include "ingress.type" .) "nginx") }}
+   {{- if (and (eq (include "ingress.type" .) "nginx") (eq (include "ingress.redirectToTLS" .) "true" )) }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    {{- if eq (include "ingress.letsencrypt" .) "true"}}
@@ -40,15 +40,19 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
-   {{- if eq (include "ingress.letsencrypt" .) "true"}}
+  {{- if eq (include "ingress.letsencrypt" .) "true"}}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}
     secretName: nginx-letsencrypt-{{ template "posthog.fullname" . }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.hostname }}
+  {{- if .Values.ingress.hostname }} 
+    - host: {{ .Values.ingress.hostname | default "*" | quote }}
       http:
+  {{- else }}
+    - http:
+  {{- end }}
         paths:
           - backend:
               serviceName: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -11,8 +11,8 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-weight": "0"
 spec:
   template:
     metadata:

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -7,6 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/resource-policy": "keep" 
+    "helm.sh/hook-weight": "1"
 spec:
   selector:
     matchLabels:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -7,6 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/resource-policy": "keep" 
+    "helm.sh/hook-weight": "1"
 spec:
   selector:
     matchLabels:

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -7,6 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/resource-policy": "keep" 
+    "helm.sh/hook-weight": "1"
 spec:
   selector:
     matchLabels:

--- a/digital-ocean-values.yaml
+++ b/digital-ocean-values.yaml
@@ -2,7 +2,8 @@ cloud: "do"
 ingress:
   redirectToTLS: false
   letsencrypt: false 
-
+web:
+  secureCookies: false
 # smtp login and key ommited as it's a public repo
 # email:
 #   user: # TODO

--- a/digital-ocean-values.yaml
+++ b/digital-ocean-values.yaml
@@ -1,6 +1,7 @@
 cloud: "do"
 ingress:
-  hostname: "posthog.click"
+  redirectToTLS: false
+  letsencrypt: false 
 
 # smtp login and key ommited as it's a public repo
 # email:


### PR DESCRIPTION
Deployments to DigitalOcean were hanging and throwing a few errors blocking progress on getting this into the DigitalOcean Marketplace
