### PR TITLE
Revert ingress.type if check to default to being inferred if not provided 

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -331,14 +331,12 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "ingress.type" -}}
-{{- if hasKey .Values.ingress "type" -}}
+{{- if ne (.Values.ingress.type | toString) "<nil>" -}}
   {{ .Values.ingress.type }}
 {{- else if .Values.ingress.nginx.enabled -}}
   nginx
 {{- else if (eq .Values.cloud "gcp") -}}
   clb
-{{- else -}}
-  undefined
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Revert the change from https://github.com/PostHog/charts-clickhouse/pull/26

Though I'll note that our defaults are not great atm - we enable nginx and have cloud be gcp
```
helm template posthog charts/posthog| grep -A1 "HELM_INSTALL_INFO"
        - name: HELM_INSTALL_INFO
          value: "{\"chart_version\":\"1.4.36\",\"cloud\":\"gcp\",\"hostname\":null,\"ingress_type\":\"nginx\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"
```