### PR TITLE
Fix redirectToTLS usage in helm templates and add to values

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -344,11 +344,7 @@ Create the name of the service account to use
 Should we redirect HTTP to TLS?
 */}}
 {{- define "ingress.redirectToTLS" -}}
-{{- if ne (.Values.ingress.redirectToTLS | toString) "<nil>" -}}
     {{ .Values.ingress.redirectToTLS }}
-{{- else -}}
-    true
-{{- end -}}
 {{- end -}}
 
 

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -344,10 +344,10 @@ Create the name of the service account to use
 Should we redirect HTTP to TLS?
 */}}
 {{- define "ingress.redirectToTLS" -}}
-{{- if hasKey .Values.ingress "redirectToTLS" -}}
-    {{ .Values.ingress.redirectToTLS | quote }}
+{{- if ne (.Values.ingress.redirectToTLS | toString) "<nil>" -}}
+    {{ .Values.ingress.redirectToTLS }}
 {{- else -}}
-    "true"
+    true
 {{- end -}}
 {{- end -}}
 

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -340,13 +340,6 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{/*
-Should we redirect HTTP to TLS?
-*/}}
-{{- define "ingress.redirectToTLS" -}}
-    {{ .Values.ingress.redirectToTLS }}
-{{- end -}}
-
 
 {{- define "posthog.helmInstallInfo" -}}
 {{- $info := dict }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/healthcheck-path: "/_health"
    {{- end }}
-   {{- if (and (eq (include "ingress.type" .) "nginx") (eq (include "ingress.redirectToTLS" .) "true" )) }}
+   {{- if (and (eq (include "ingress.type" .) "nginx") .Values.ingress.nginx.redirectToTLS "true") }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    {{- if eq (include "ingress.letsencrypt" .) "true"}}
@@ -47,7 +47,7 @@ spec:
     secretName: nginx-letsencrypt-{{ template "posthog.fullname" . }}
   {{- end }}
   rules:
-  {{- if .Values.ingress.hostname }} 
+  {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}
       http:
   {{- else }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -271,8 +271,8 @@ ingress:
   nginx:
     # -- Whether nginx is enabled
     enabled: true
-  # -- Whether to redirect to TLS. Defaults to true.
-  redirectToTLS:
+  # -- Whether to redirect to TLS with nginx ingress.
+  redirectToTLS: true
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -271,8 +271,8 @@ ingress:
   nginx:
     # -- Whether nginx is enabled
     enabled: true
-  # -- Whether to redirect to TLS with nginx ingress.
-  redirectToTLS: true
+    # -- Whether to redirect to TLS with nginx ingress.
+    redirectToTLS: true
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -271,6 +271,8 @@ ingress:
   nginx:
     # -- Whether nginx is enabled
     enabled: true
+  # -- Whether to redirect to TLS. Defaults to true.
+  redirectToTLS:
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)


### PR DESCRIPTION
2 things: fix the way redirectToTLS is used (needs to not be quoted in the define) & adds it to values (so it's documented in our ALL_VALUES readme etc).

Fixes the way https://github.com/PostHog/charts-clickhouse/pull/29 works. Specifically currently we never add the annotations
```
> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
spec:
  tls:
  - hosts:

> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
  redirectToTLS: true
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
spec:
  tls:
  - hosts:

> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
  redirectToTLS: false
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
spec:
  tls:
  - hosts:
```

After this diff annos are added either if it's explicitly set to true or if not defined
```
> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
    nginx.ingress.kubernetes.io/ssl-redirect: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 

> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
  redirectToTLS: true
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
    nginx.ingress.kubernetes.io/ssl-redirect: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    cert-manager.io/cluster-issuer: "letsencrypt-prod"


> cat ../values.yaml && helm template posthog charts/posthog -f ../values.yaml | grep -A13 "# Source: posthog/templates/ingress.yaml"
cloud: "do"
ingress:
  type: "nginx"
  redirectToTLS: false
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-1.4.36"
    release: "posthog"
    heritage: "Helm"
 annotations:
spec:
  tls:
  - hosts:
```