### PR TITLE
Make tests less flaky

### DIFF
--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  progressDeadlineSeconds: {{ .Values.worker.progressDeadlineSeconds }}
+  progressDeadlineSeconds: 1200
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  progressDeadlineSeconds: {{ .Values.worker.progressDeadlineSeconds }}
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -11,9 +11,10 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep" 
+    "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
+  progressDeadlineSeconds: {{ .Values.plugins.progressDeadlineSeconds }}
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
-  progressDeadlineSeconds: {{ .Values.plugins.progressDeadlineSeconds }}
+  progressDeadlineSeconds: 1200
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -11,9 +11,10 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep" 
+    "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
+  progressDeadlineSeconds: {{ .Values.web.progressDeadlineSeconds }}
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
-  progressDeadlineSeconds: {{ .Values.web.progressDeadlineSeconds }}
+  progressDeadlineSeconds: 1200
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -11,9 +11,10 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep" 
+    "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
+  progressDeadlineSeconds: {{ .Values.worker.progressDeadlineSeconds }}
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
-  progressDeadlineSeconds: {{ .Values.worker.progressDeadlineSeconds }}
+  progressDeadlineSeconds: 1200
   selector:
     matchLabels:
         app: {{ template "posthog.fullname" . }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -126,6 +126,9 @@ web:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
 
+  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
+  progressDeadlineSeconds: 600
+
 beat:
   # -- How many posthog 'beat' instances to run
   replicacount: 1
@@ -175,6 +178,9 @@ worker:
   # podLabels: []
   # concurrency:
 
+  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
+  progressDeadlineSeconds: 600
+
 # How many plugin server instances to run
 plugins:
   ingestion:
@@ -206,6 +212,9 @@ plugins:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
   # concurrency:
+
+  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
+  progressDeadlineSeconds: 600
 
 # Outbound E-mails
 email:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -126,9 +126,6 @@ web:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
 
-  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
-  progressDeadlineSeconds: 600
-
 beat:
   # -- How many posthog 'beat' instances to run
   replicacount: 1
@@ -178,9 +175,6 @@ worker:
   # podLabels: []
   # concurrency:
 
-  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
-  progressDeadlineSeconds: 600
-
 # How many plugin server instances to run
 plugins:
   ingestion:
@@ -212,9 +206,6 @@ plugins:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
   # concurrency:
-
-  # -- Set spec.progressDeadlineSeconds in deployment. Affects `kubectl rollout status`. Overridden in tests
-  progressDeadlineSeconds: 600
 
 # Outbound E-mails
 email:

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -16,17 +16,12 @@ clickhouseOperator:
   namespace: default
   storage: 2Gi
 
-web:
-  secureCookies: false
-  progressDeadlineSeconds: 1200
 
 plugins:
   replicacount: 1
-  progressDeadlineSeconds: 1200
 
 worker:
   replicacount: 1
-  progressDeadlineSeconds: 1200
 
 redis:
   usePassword: false
@@ -34,3 +29,6 @@ redis:
   master:
     persistence:
       size: 1Gi
+
+web:
+  secureCookies: false

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -16,11 +16,17 @@ clickhouseOperator:
   namespace: default
   storage: 2Gi
 
+web:
+  secureCookies: false
+  progressDeadlineSeconds: 1200
+
 plugins:
   replicacount: 1
+  progressDeadlineSeconds: 1200
 
 worker:
   replicacount: 1
+  progressDeadlineSeconds: 1200
 
 redis:
   usePassword: false
@@ -28,6 +34,3 @@ redis:
   master:
     persistence:
       size: 1Gi
-
-web:
-  secureCookies: false


### PR DESCRIPTION
Tests sometimes fail at exactly 10m of waiting for deployments to start
due to

```
Error: Action failure: rollout of deploy/posthog-web
The process '/usr/local/bin/kubectl' failed with exit code 1

error: deployment "posthog-web" exceeded its progress deadline
```

This is caused by a default in kubernetes - each deployment has
`spec.progressDeadlineSeconds` set to 600.

This PR increases that threshold to 1200 during tests.

This deadline seems to only affects `kubectl rollout` commands, so no
production effects here.
