### PR TITLE
Add default cluster name as posthog to clickhouse deployments

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -47,7 +47,7 @@ spec:
     profiles:
       default/allow_experimental_window_functions: "1"
     clusters:
-      - name: {{ .Values.clickhouse.database | quote }}
+      - name: {{ .Values.clickhouse.database | default "posthog" | quote }}
         templates:
           podTemplate: pod-template-with-volumes
         layout:


### PR DESCRIPTION
This is a base requirement for changing how migrations work for clickhouse so we can use `ON CLUSTER` command for DDLs.
