### PR TITLE
Remove gcp as default cloud value

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: IfNotPresent
 
 # -- Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
-cloud: "gcp"
+cloud:
 # -- Sentry endpoint to send errors to
 sentryDSN:
 


### PR DESCRIPTION
Currently our default settings have:
1. cloud=gcp
2. nginx and certManager enabled

Those two settings together don't make sense as on gcp we'd want to use their ingress controller, so we shouldn't enable nginx, on the other hand having cloud be gcp changes ingress configuration to not what we want when using nginx.