### PR TITLE
Set USING_PGBOUNCER to true by default

### DIFF
--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -93,6 +93,8 @@ spec:
           value: {{ template "posthog.pgbouncer.host" . }}
         - name: POSTHOG_POSTGRES_PORT
           value: {{ include "posthog.pgbouncer.port" . | quote }}
+        - name: USING_PGBOUNCER
+          value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -86,6 +86,8 @@ spec:
           value: {{ template "posthog.pgbouncer.host" . }}
         - name: POSTHOG_POSTGRES_PORT
           value: {{ include "posthog.pgbouncer.port" . | quote }}
+        - name: USING_PGBOUNCER
+          value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -87,6 +87,8 @@ spec:
               key: posthog-secret
         - name: DATABASE_URL
           value: {{ template "posthog.pgbouncer.url" . }}
+        - name: USING_PGBOUNCER
+          value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -109,6 +109,8 @@ spec:
           value: {{ template "posthog.pgbouncer.host" . }}
         - name: POSTHOG_POSTGRES_PORT
           value: {{ include "posthog.pgbouncer.port" . | quote }}
+        - name: USING_PGBOUNCER
+          value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -104,6 +104,8 @@ spec:
           value: {{ template "posthog.pgbouncer.host" . }}
         - name: POSTHOG_POSTGRES_PORT
           value: {{ include "posthog.pgbouncer.port" . | quote }}
+        - name: USING_PGBOUNCER
+          value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}


### PR DESCRIPTION
Without it we can run into pgbouncer cursor issues.

Reported by a client using the chart directly

Cloud PR: https://github.com/PostHog/posthog/pull/5120
