### PR TITLE
Disable nginx and certManager by default

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -360,7 +360,7 @@ Create the name of the service account to use
 {{- define "ingress.letsencrypt" -}}
 {{- if ne (.Values.ingress.letsencrypt | toString) "<nil>" -}}
   {{ .Values.ingress.letsencrypt }}
-{{- else if .Values.ingress.nginx.enabled -}}
+{{- else if and (and (.Values.ingress.nginx.enabled) (.Values.certManager.enabled)) (ne (.Values.ingress.hostname | toString) "<nil>")  -}}
   true
 {{- else -}}
   false

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -252,7 +252,7 @@ service:
 
 certManager:
   # -- Whether to install cert-manager. Validates certs for nginx ingress
-  enabled: true
+  enabled: false
 
 ingress:
   # -- Enable ingress controller resource
@@ -266,11 +266,11 @@ ingress:
     ip_name: "posthog"
     # -- If true, will force a https redirect when accessed over http
     forceHttps: true
-  # -- Whether to enable letsencrypt. Defaults to true if nginx enabled and false otherwise.
+  # -- Whether to enable letsencrypt. Defaults to true if hostname is defined and nginx and certManager are enabled otherwise false.
   letsencrypt:
   nginx:
     # -- Whether nginx is enabled
-    enabled: true
+    enabled: false
     # -- Whether to redirect to TLS with nginx ingress.
     redirectToTLS: true
 


### PR DESCRIPTION
## Changes

Disables nginx and certManager by default
Enable `letsencrypt` by default condition to additionally check that hostname exists and certManager is enabled

## Why?

It's odd to need to disable them for gcp + we might in the future want to use the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) (previously know as alb ingress controller)

## Ideal world

I wish we could enable/disable nginx and certManager based on the cloud variable str value (if gcp disable, if do enable both), but sadly it's not possible.
Specifically we can have boolean conditions to enable/disable or tags but not use template variables there nor expressions. Docs https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies

Based on re-reading the docs we could do sth like (note that the first path that exists is used):
```
name: nginx
  condition: ingress.nginx.enabled

name: certManager
  condition: certManager.enabled, ingress.nginx.enabled
```

Then in the values files we can by default not define certManager, but it's possible to disable it by `certManager.enabled: false`. That said this seems fragile as it's easy for someone to forgot that we're relying on the first path that exists is used and define `certManager.enabled` as empty string.