### PR TITLE
Add deploymentKind to helm info

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -350,6 +350,9 @@ Create the name of the service account to use
 {{- $info := set $info "hostname" .Values.ingress.hostname -}}
 {{- $info := set $info "operation" (include "posthog.helmOperation" .) -}}
 {{- $info := set $info "ingress_type" (include "ingress.type" .) -}}
+{{- if .Values.deploymentKind -}}
+{{- $info := set $info "deployment_kind" .Values.deploymentKind -}}
+{{- end -}}
 {{ toJson $info | quote }}
 {{- end -}}
 

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -350,9 +350,7 @@ Create the name of the service account to use
 {{- $info := set $info "hostname" .Values.ingress.hostname -}}
 {{- $info := set $info "operation" (include "posthog.helmOperation" .) -}}
 {{- $info := set $info "ingress_type" (include "ingress.type" .) -}}
-{{- if .Values.deploymentKind -}}
-{{- $info := set $info "deployment_kind" .Values.deploymentKind -}}
-{{- end -}}
+{{- $info := set $info "deployment_type" (default .Values.deploymentType "helm") -}}
 {{ toJson $info | quote }}
 {{- end -}}
 


### PR DESCRIPTION
Follow-up to this will be setting it to "DigitalOcean 1-Click" in the values file in their marketplace.

Verified that we get the info by checking recent `helm install` events [here](https://app.posthog.com/events)

<img width="459" alt="Screen Shot 2021-07-15 at 02 28 18" src="https://user-images.githubusercontent.com/890921/125709472-7c615beb-51c4-4a9a-8d69-3bd8ac2c03b7.png">
