### PR TITLE
Fix deployment type defaulting in chart template

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -350,7 +350,7 @@ Create the name of the service account to use
 {{- $info := set $info "hostname" .Values.ingress.hostname -}}
 {{- $info := set $info "operation" (include "posthog.helmOperation" .) -}}
 {{- $info := set $info "ingress_type" (include "ingress.type" .) -}}
-{{- $info := set $info "deployment_type" (default .Values.deploymentType "helm") -}}
+{{- $info := set $info "deployment_type" (.Values.deploymentType | default "helm") -}}
 {{ toJson $info | quote }}
 {{- end -}}
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: IfNotPresent
 
 # -- Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
-cloud:
+cloud: ""
 # -- Sentry endpoint to send errors to
 sentryDSN:
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -14,7 +14,7 @@ image:
   pullPolicy: IfNotPresent
 
 # -- Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
-cloud: ""
+cloud:
 # -- Sentry endpoint to send errors to
 sentryDSN:
 


### PR DESCRIPTION
We were always sending "helm" as the deployment type because of the args ordering ... the default function `default DEFAULT_VALUE GIVEN_VALUE` [docs](https://helm.sh/docs/chart_template_guide/function_list/#default), but it's easier to just use [pipelines](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function) everywhere.

Also changed the cloud value to "" so without providing it the chart compiles

before
```
> helm template posthog ../charts-clickhouse2/charts/posthog | tail
Error: template: posthog/templates/clickhouse_instance.yaml:2:7: executing "posthog/templates/clickhouse_instance.yaml" at <eq .Values.cloud "gcp">: error calling eq: incompatible types for comparison

Use --debug flag to render out invalid YAML

> helm template posthog ../charts-clickhouse2/charts/posthog --values ../marketplace-kubernetes/stacks/posthog/values.yml | tail
          value: "false"
        - name: DEFAULT_FROM_EMAIL
          value: "hey@posthog.com"
        - name: HELM_INSTALL_INFO
          value: "{\"chart_version\":\"2.0.1\",\"cloud\":\"do\",\"deployment_type\":\"helm\",\"hostname\":null,\"ingress_type\":\"nginx\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"
        resources:
          limits:
            memory: 1000Mi
          requests:
            memory: 1000Mi
```

After
```
helm template posthog charts/posthog | tail
          value: "false"
        - name: DEFAULT_FROM_EMAIL
          value: "hey@posthog.com"
        - name: HELM_INSTALL_INFO
          value: "{\"chart_version\":\"2.0.1\",\"cloud\":\"\",\"deployment_type\":\"helm\",\"hostname\":null,\"ingress_type\":\"nginx\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"
        resources:
          limits:
            memory: 1000Mi
          requests:
            memory: 1000Mi

> helm template posthog charts/posthog --values ../marketplace-kubernetes/stacks/posthog/values.yml | tail
          value: "false"
        - name: DEFAULT_FROM_EMAIL
          value: "hey@posthog.com"
        - name: HELM_INSTALL_INFO
          value: "{\"chart_version\":\"2.0.1\",\"cloud\":\"do\",\"deployment_type\":\"DigitalOcean 1-click\",\"hostname\":null,\"ingress_type\":\"nginx\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"
        resources:
          limits:
            memory: 1000Mi
          requests:
            memory: 1000Mi
```