### PR TITLE
Remove hooks resource limits

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -473,10 +473,7 @@ hooks:
     env: []
     # -- Hook job resource limits/requests
     resources:
-      limits:
-        memory: 1000Mi
-      requests:
-        memory: 1000Mi
+      {}
 
 serviceAccount:
   # -- Configures if a ServiceAccount with this name should be created


### PR DESCRIPTION
We aren't specifying resources for anything else. Only specifying them for hooks doesn't really add much value, we don't really even need the 1GB most likely and this causes deployment failures. Longer term we should look into setting resources properly for everything.

After this change I was able to install Posthog on the DO default cluster (3 small nodes, also installs fine with 2 smallest nodes, making it possible to reduce the cost to by 20$) successfully, which previously failed due to scheduling error for migrations pod because of memory