### PR TITLE
Removed warning notice from readme

### DIFF
--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -5,8 +5,6 @@
 [![MIT License](https://img.shields.io/badge/License-MIT-red.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Slack](https://img.shields.io/badge/PostHog_chat-slack-blue?logo=slack)](https://posthog.com/slack)
 
-### :warning: This chart is still under development! Proceed with caution.
-
 -----
 
 🦔 [PostHog](https://posthog.com/) is developer-friendly, open-source product analytics.


### PR DESCRIPTION
given this is now the main way to deploy posthog self hosted (address feedback in the [deployathon review](https://docs.google.com/document/d/1bzgs5TQri85gYZSHWRQNON49MfdVMQ19SRw77X23qNE/edit#))