### PR TITLE
Bug template to ask for more info about setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,8 @@ labels: bug
 ## Bug description
 
 *Please describe.*
-*If this affects the front-end, screenshots would be of great help.*
+
+*If helm install or upgrade failed include your `values.yaml` (without sensitive data) and output from `kubectl describe nodes`.*
 
 ## Expected behavior
 
@@ -21,6 +22,7 @@ labels: bug
 
 ## Environment
 
+- [ ] Deployment platform (gcp/aws/...): _please provide_
 - [ ] Chart version/commit: _please provide_
 - [ ] Posthog version: _please provide_
 


### PR DESCRIPTION
Any UI problems should likely be in Posthog main repo not here.
For `values.yaml` it's pretty obvious to remove passwords etc and `kubectl describe nodes` didn't seem to contain any sensitive info and gives us info about resources etc for faster debugging. If there's a better command to use I'd be happy to change (note that `kubectl cluster-info dump` has a lot more info, but a lot more sensitive data too)