### PR TITLE
Update instructions for upgrading to v3

### DIFF
--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -543,7 +543,7 @@ The error you will see from Kafka pod while upgrading:
 kafka.common.InconsistentClusterIdException: The Cluster ID TYP8xsIWRFWkzSYmO_YWEA doesn't match stored clusterId Some(CizxEcefTou4Ehu65rmpuA) in meta.properties. The broker is trying to join the wrong cluster. Configured zookeeper.connect may be wrong.
   ```
 How to fix?
-- Delete Kafka stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-posthog-zookeeper`
+- Delete Kafka and Zookeeper stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-posthog-zookeeper`
 - Delete kafka persistent volume claim `kubectl -n posthog delete pvc data-posthog-posthog-kafka-0`
 - Wait for Kafka and Zookeeper pods to spin down (deleting sts in step 1 will also trigger the pods deletion)
 - Upgrade helm chart `helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog`

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -543,7 +543,7 @@ The error you will see from Kafka pod while upgrading:
 kafka.common.InconsistentClusterIdException: The Cluster ID TYP8xsIWRFWkzSYmO_YWEA doesn't match stored clusterId Some(CizxEcefTou4Ehu65rmpuA) in meta.properties. The broker is trying to join the wrong cluster. Configured zookeeper.connect may be wrong.
   ```
 How to fix?
-- Delete Kafka and Zookeeper stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-posthog-zookeeper`
+- Delete Kafka and Zookeeper stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-zookeeper`
 - Delete kafka persistent volume claim `kubectl -n posthog delete pvc data-posthog-posthog-kafka-0`
 - Wait for Kafka and Zookeeper pods to spin down (deleting sts in step 1 will also trigger the pods deletion)
 - Upgrade helm chart `helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog`

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -544,5 +544,6 @@ kafka.common.InconsistentClusterIdException: The Cluster ID TYP8xsIWRFWkzSYmO_YW
   ```
 How to fix?
 - Delete Kafka stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-posthog-zookeeper`
-- Wait for Kafka and Zookeeper pods to spin down
+- Delete kafka persistent volume claim `kubectl -n posthog delete pvc data-posthog-posthog-kafka-0`
+- Wait for Kafka and Zookeeper pods to spin down (deleting sts in step 1 will also trigger the pods deletion)
 - Upgrade helm chart `helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog`

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -543,8 +543,6 @@ The error you will see from Kafka pod while upgrading:
 kafka.common.InconsistentClusterIdException: The Cluster ID TYP8xsIWRFWkzSYmO_YWEA doesn't match stored clusterId Some(CizxEcefTou4Ehu65rmpuA) in meta.properties. The broker is trying to join the wrong cluster. Configured zookeeper.connect may be wrong.
   ```
 How to fix?
-- Delete Kafka stateful set `kubectl -n posthog delete sts posthog-posthog-kafka`
-- Delete Kafka pods `kubectl -n posthog delete pod posthog-posthog-kafka-0`
-- Delete old zk pod `kubectl -n posthog delete pod posthog-zookeeper-0`
-- Wait for pods to spin down
+- Delete Kafka stateful set `kubectl -n posthog delete sts posthog-posthog-kafka posthog-posthog-zookeeper`
+- Wait for Kafka and Zookeeper pods to spin down
 - Upgrade helm chart `helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog`


### PR DESCRIPTION
The pods get deleted if stateful sets get deleted and they get recreated otherwise, so the best strategy here seems to be 
1) delete kafka & zookeeper sts (so the pods won't restart)
2) delete kafka pvc (without this we still ran into the error about cluster ID) 
3) make sure kafka & zk pods shut down
4) run the upgrade.