### PR TITLE
Fix comparisons of incompatible types

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -348,7 +348,7 @@ Create the name of the service account to use
   {{ .Values.ingress.type }}
 {{- else if .Values.ingress.nginx.enabled -}}
   nginx
-{{- else if (eq .Values.cloud "gcp") -}}
+{{- else if (eq (.Values.cloud | toString) "gcp") -}}
   clb
 {{- end -}}
 {{- end -}}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.clickhouseOperator.enabled }}
-{{ if (eq .Values.cloud "gcp" )}}
+{{ if (eq (.Values.cloud | toString) "gcp" )}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -12,7 +12,7 @@ parameters:
 reclaimPolicy: Retain
 #volumeBindingMode: Immediate
 allowVolumeExpansion: true
-{{- else if (eq .Values.cloud "aws") }}
+{{- else if (eq (.Values.cloud | toString) "aws") }}
 #
 # AWS resizable disk example
 #
@@ -108,9 +108,9 @@ spec:
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:
-          {{- if (eq .Values.cloud "gcp" )}}
+          {{- if (eq (.Values.cloud | toString) "gcp" )}}
           storageClassName: gce-resizable
-          {{- else if (eq .Values.cloud "aws") }}
+          {{- else if (eq (.Values.cloud | toString) "aws") }}
           storageClassName: gp2-resizable
           {{- end }}
           accessModes:

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
   {{- if eq (include "ingress.letsencrypt" .) "true"}}
   tls:
   - hosts:
-    - {{ .Values.ingress.hostname }}
+    - {{ .Values.ingress.hostname | toString }}
     secretName: nginx-letsencrypt-{{ template "posthog.fullname" . }}
   {{- end }}
   rules:


### PR DESCRIPTION
I had to make these changes to the chart to avoid errors like the following:
```
Error: UPGRADE FAILED: template: posthog-clickhouse/charts/posthog/templates/clickhouse_instance.yaml:2:7: executing "posthog-clickhouse/charts/posthog/templates/clickhouse_instance.yaml" at <eq .Values.cloud "gcp">: error calling eq: incompatible types for comparison
```

This is using the following tools:
- helm 3.5.2
- kubectl 1.17.17
- kubernetes v1.19.10-gke.1600