### PR TITLE
Make the error nicer when cloud isn't provided

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -353,13 +353,10 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{- define "cloud" -}}
-{{- required "'cloud' value is required, e.g. 'gcp', 'aws', 'do', 'private', ..." .Values.cloud -}}
-{{- end -}}
 
 {{- define "posthog.helmInstallInfo" -}}
 {{- $info := dict }}
-{{- $info := set $info "cloud" (include "cloud" .) -}}
+{{- $info := set $info "cloud" (required "'cloud' value is required, e.g. 'gcp', 'aws', 'do', 'private', ..." .Values.cloud) -}}
 {{- $info := set $info "chart_version" .Chart.Version -}}
 {{- $info := set $info "release_name" .Release.Name -}}
 {{- $info := set $info "release_revision" .Release.Revision -}}

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -348,15 +348,18 @@ Create the name of the service account to use
   {{ .Values.ingress.type }}
 {{- else if .Values.ingress.nginx.enabled -}}
   nginx
-{{- else if (eq .Values.cloud "gcp") -}}
+{{- else if (eq (.Values.cloud | toString) "gcp") -}}
   clb
 {{- end -}}
 {{- end -}}
 
+{{- define "cloud" -}}
+{{- required "'cloud' value is required, e.g. 'gcp', 'aws', 'do', 'private', ..." .Values.cloud -}}
+{{- end -}}
 
 {{- define "posthog.helmInstallInfo" -}}
 {{- $info := dict }}
-{{- $info := set $info "cloud" .Values.cloud -}}
+{{- $info := set $info "cloud" (include "cloud" .) -}}
 {{- $info := set $info "chart_version" .Chart.Version -}}
 {{- $info := set $info "release_name" .Release.Name -}}
 {{- $info := set $info "release_revision" .Release.Revision -}}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.clickhouseOperator.enabled }}
-{{ if (eq .Values.cloud "gcp" )}}
+{{ if (eq (.Values.cloud | toString) "gcp" )}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -12,7 +12,7 @@ parameters:
 reclaimPolicy: Retain
 #volumeBindingMode: Immediate
 allowVolumeExpansion: true
-{{- else if (eq .Values.cloud "aws") }}
+{{- else if (eq (.Values.cloud | toString) "aws") }}
 #
 # AWS resizable disk example
 #
@@ -75,7 +75,7 @@ spec:
       {{- else }}
         - host: {{ template "posthog.zookeeper.host" . }}
           port: {{ template "posthog.zookeeper.port" . }}
-      {{- end }} 
+      {{- end }}
   templates:
     podTemplates:
       - name: pod-template-with-volumes
@@ -108,9 +108,9 @@ spec:
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:
-          {{- if (eq .Values.cloud "gcp" )}}
+          {{- if (eq (.Values.cloud | toString) "gcp" )}}
           storageClassName: gce-resizable
-          {{- else if (eq .Values.cloud "aws") }}
+          {{- else if (eq (.Values.cloud | toString) "aws") }}
           storageClassName: gp2-resizable
           {{- end }}
           accessModes:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
-# -- Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
+# -- Required: Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean
 cloud:
 # -- Sentry endpoint to send errors to
 sentryDSN:


### PR DESCRIPTION
Just making the error nicer if cloud parameter isn't defined. Note the required function needs to be executed for it to actually error out and this seemed like the best way to accomplish it.

before
```
> helm template posthog ~/Posthog/charts-clickhouse2/charts/posthog
Error: template: posthog/templates/clickhouse_instance.yaml:2:7: executing "posthog/templates/clickhouse_instance.yaml" at <eq .Values.cloud "gcp">: error calling eq: incompatible types for comparison
```
after
```
> helm template posthog ~/Posthog/charts-clickhouse/charts/posthog
Error: execution error at (posthog/templates/_helpers.tpl:362:32): 'cloud' value is required, e.g. 'gcp', 'aws', 'do', 'private', ...
```

We could also not require the `cloud` parameter, but the likelihood is that someone didn't provide it when they should have like happened in https://github.com/PostHog/charts-clickhouse/pull/76
There's also more discussion on how yelling loudly and failing early is better than deploying something that doesn't work tied to the cloud value specifically in  https://github.com/PostHog/charts-clickhouse/pull/56