### PR TITLE
Change Kafka to NodePort instead of LoadBalancer

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -347,7 +347,7 @@ kafka:
   port:
   service:
     enabled: false
-    type: LoadBalancer
+    type: NodePort
   persistence:
     # -- Enable persistence using PVC
     enabled: true


### PR DESCRIPTION
Part 1 of https://github.com/PostHog/vpc/issues/166 (cheaper & safer)

Note that this is [the commit](https://github.com/PostHog/vpc/commit/fed2504ed2cb2103e21ad3e083073eec878bdf48), where we changed it to LB and by default it's ClusterIP (https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml#L605)

Tested (checking k9s that everything is up properly & I was able to use the python capture & see it in the UI)
* installing a new chart on DigitalOcean - saw only 2 LBs, was able to send a simple test event.
* updated to prior change & updated again to remove the LB, things worked as expected (there was an extra LB & then removed).