### PR TITLE
Remove password and restrict to localhost for CH default user

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -42,8 +42,6 @@ spec:
       admin/networks/ip: "0.0.0.0/0"
       admin/profile: default
       admin/quota: default
-      default/password: {{ .Values.clickhouse.password }}
-      default/networks/ip: "0.0.0.0/0"
     profiles:
       default/allow_experimental_window_functions: "1"
     clusters:


### PR DESCRIPTION
The default settings for default user don't have a password & restrict to local host access only. They seem better compared to what we currently have (a hardcoded password that's in our public repo and access available from everywhere).

Checked the `users.xml` file to confirm no pass & only localhost access (`kubectl exec chi-posthog-posthog-0-0-0 -- cat /var/lib/clickhouse/preprocessed_configs/users.xml`). Also checked that if I shelled into the clickhouse pod I didn't need a password, i.e. `clickhouse-client` alone works.

We don't use the default account anywhere, so this should be safe.