### PR TITLE
Clickhouse from LB to a Nodeport

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -36,6 +36,7 @@ spec:
   defaults:
     templates:
       dataVolumeClaimTemplate: data-volumeclaim-template
+      serviceTemplate: chi-service-template
   configuration:
     users:
       admin/password: {{ .Values.clickhouse.password }}
@@ -105,6 +106,16 @@ spec:
               nodeSelector:
                 clickhouse: true
               {{- end }}
+    serviceTemplates:
+      - name: chi-service-template
+        generateName: {{ template "posthog.clickhouse.fullname" . }}
+        spec:
+          ports:
+            - name: http
+              port: 8123
+            - name: tcp
+              port: 9000
+          type: NodePort
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -115,7 +115,7 @@ spec:
               port: 8123
             - name: tcp
               port: 9000
-          type: NodePort
+          type: {{ .Values.clickhouseOperator.serviceType }}
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -27,6 +27,9 @@ clickhouseOperator:
   storage: 20Gi
   # -- If enabled, operator will prefer k8s nodes with tag `clickhouse:true`
   useNodeSelector: false
+  # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
+  serviceType: NodePort
+
 
 # -- Env vars to throw into every deployment (web, beat, worker, and plugin server)
 env:


### PR DESCRIPTION
It's safer and cheaper. Part 2 of & closes https://github.com/PostHog/vpc/issues/166

Config info: ​​https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/99-clickhouseinstallation-max.yaml

Tested with a helm upgrade.
Before
```
> kubectl get svc | grep "clickhouse"
clickhouse-operator-metrics                  ClusterIP      10.245.155.249   <none>          8888/TCP                        133m
clickhouse-posthog                           LoadBalancer   10.245.30.169    139.59.207.61   8123:32317/TCP,9000:32110/TCP   12m
```
After
```
> kubectl get svc | grep "clickhouse"
clickhouse-operator-metrics                  ClusterIP      10.245.155.249   <none>          8888/TCP                        138m
clickhouse-posthog                           NodePort       10.245.30.169    <none>          8123:30329/TCP,9000:31230/TCP   17m
```
Also nuked web task & it came back up fine & verified that the UI works displaying previously existing data.
