### PR TITLE
Add plugins hpa template

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.0
+version: 3.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.plugins.hpa.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-plugins
+  labels:
+    app: {{ template "posthog.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-plugins
+  minReplicas: {{ .Values.plugins.hpa.minpods }}
+  maxReplicas: {{ .Values.plugins.hpa.maxpods }}
+  targetCPUUtilizationPercentage: {{ .Values.plugins.hpa.cputhreshold }}
+{{- end }}


### PR DESCRIPTION
I noticed today that the plugins deployment wasn't scaling as expected when the hpa was enabled. It turns out the plugins hpa template didn't exist. 

After updating chart you can see the hpa has been created:

![image](https://user-images.githubusercontent.com/2300103/128222063-17f65d8a-3462-492b-b503-166021d9bf9f.png)


@tiina303 @fuziontech 