### PR TITLE
Update redis configuration for plugins deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.0
+version: 3.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -90,7 +90,7 @@ spec:
         - name: USING_PGBOUNCER
           value: 'true'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
-        - name: REDIS_PASSWORD
+        - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}
         - name: REDIS_URL
           value: "redis://:$(REDIS_PASSWORD)@{{- template "posthog.redis.host" . -}}:{{-  template "posthog.redis.port" . -}}"
@@ -99,6 +99,10 @@ spec:
           #     name: {{ template "posthog.fullname" . }}
           #     key: redis-url
         {{- end }}
+        - name: POSTHOG_REDIS_HOST
+          value: {{ template "posthog.redis.host" . }}
+        - name: POSTHOG_REDIS_PORT
+          value: {{ include "posthog.redis.port" . | quote }}
         {{- if .Values.statsd.enabled }}
         - name: STATSD_HOST
           value: {{ template "posthog.statsd.host" . }}


### PR DESCRIPTION
The posthog plugins deployment is not configured correctly when using a cloud based redis instance (gcp managed redis for example). I've been manually updating the deployment to include these values as per the other deployments but figured I would take the toil out of my day by making a pull request. 

Note, that I also update the environment variable for the redis password as that doesn't look to align with the server configuration: https://github.com/PostHog/plugin-server/blob/0dcde9372d10b3c045c9d29464970edd8534b01b/src/config/config.ts#L44

@fuziontech @tiina303 