### PR TITLE
Add support for using a kubernetes secret with the gcp ingress

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | ingress.hostname | string | `nil` | URL to address your PostHog installation. You will need to set up DNS after installation |
 | ingress.gcp.ip_name | string | `"posthog"` | Specifies the name of the global IP address resource to be associated with the google clb |
 | ingress.gcp.forceHttps | bool | `true` | If true, will force a https redirect when accessed over http |
+| ingress.gcp.secretName | string | `nil` | Specifies the name of the tls secret to be used by the ingress. If not specified a managed certificate will be generated. |
 | ingress.letsencrypt | string | `nil` | Whether to enable letsencrypt. Defaults to true if hostname is defined and nginx and certManager are enabled otherwise false. |
 | ingress.nginx.enabled | bool | `false` | Whether nginx is enabled |
 | ingress.nginx.redirectToTLS | bool | `true` | Whether to redirect to TLS with nginx ingress. |

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.4.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.0
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/gke-cert-issuer.yaml
+++ b/charts/posthog/templates/gke-cert-issuer.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   domains:
     - {{ .Values.ingress.hostname }}
-    - {{ .Values.ingress.gcp.secretName }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/posthog/templates/gke-cert-issuer.yaml
+++ b/charts/posthog/templates/gke-cert-issuer.yaml
@@ -1,5 +1,6 @@
 {{- if (and .Values.ingress.gcp (eq (include "ingress.type" .) "clb")) -}}
-{{- if .Values.ingress.gcp.ip_name -}}
+{{- if (.Values.ingress.gcp.ip_name) -}}
+{{- if not (.Values.ingress.gcp.secretName) }}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
@@ -7,6 +8,8 @@ metadata:
 spec:
   domains:
     - {{ .Values.ingress.hostname }}
+    - {{ .Values.ingress.gcp.secretName }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -11,7 +11,9 @@ metadata:
  annotations:
    {{- if (eq (include "ingress.type" .) "clb") }}
     kubernetes.io/ingress.class: "gce"
+    {{- if not (.Values.ingress.gcp.secretName) }}
     networking.gke.io/managed-certificates: "{{ .Release.Name }}-gke-cert"
+    {{- end }}
     networking.gke.io/v1beta1.FrontendConfig: "{{ .Release.Name }}-frontend-config"
     {{- if .Values.ingress.gcp.ip_name }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.ip_name | quote }}
@@ -30,11 +32,15 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
-  {{- if eq (include "ingress.letsencrypt" .) "true"}}
+  {{- if or (eq (include "ingress.letsencrypt" .) "true") (.Values.ingress.gcp.secretName) }}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}
+    {{- if eq (include "ingress.letsencrypt" .) "true" }}
     secretName: nginx-letsencrypt-{{ template "posthog.fullname" . }}
+    {{- else }}
+    secretName: {{ .Values.ingress.gcp.secretName }}
+    {{- end }}
   {{- end }}
   rules:
   {{- if .Values.ingress.hostname }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -271,6 +271,8 @@ ingress:
     ip_name: "posthog"
     # -- If true, will force a https redirect when accessed over http
     forceHttps: true
+    # -- Specifies the name of the tls secret to be used by the ingress. If not specified a managed certificate will be generated.
+    secretName: ""
   # -- Whether to enable letsencrypt. Defaults to true if hostname is defined and nginx and certManager are enabled otherwise false.
   letsencrypt:
   nginx:


### PR DESCRIPTION
Allow a tls secret to be specified rather than using the gke certificate manager: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls

For all of our ingress objects within GKE we specify tls configurations via kubernetes secrets. When using a gcp ingress object and a user has specified the tls name this will provision the ingress object accordingly and suppress the managed certificate from being created. 

@fuziontech @tiina303 