### PR TITLE
Have migration task bypass pgbouncer and connect direct to pg for session stickiness

### DIFF
--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -82,6 +82,7 @@ spec:
               name: {{ template "posthog.postgresql.secret" . }}
             {{- end }}
               key: {{ template "posthog.postgresql.secretKey" . }}
+        # Connect directly to postgres (without pgbouncer) to avoid statement_timeout for longer-running queries
         - name: POSTHOG_POSTGRES_HOST
           value: {{ template "posthog.postgresql.host" . }}
         - name: POSTHOG_POSTGRES_PORT

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -83,11 +83,11 @@ spec:
             {{- end }}
               key: {{ template "posthog.postgresql.secretKey" . }}
         - name: POSTHOG_POSTGRES_HOST
-          value: {{ template "posthog.pgbouncer.host" . }}
+          value: {{ template "posthog.postgresql.host" . }}
         - name: POSTHOG_POSTGRES_PORT
-          value: {{ include "posthog.pgbouncer.port" . | quote }}
+          value: {{ include "posthog.postgresql.port" . | quote }}
         - name: USING_PGBOUNCER
-          value: 'true'
+          value: 'false'
           {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: POSTHOG_REDIS_PASSWORD
           value: {{ .Values.redis.password | quote }}


### PR DESCRIPTION
This is in preparation for issue posthog/posthog#4941 where we want to create an index concurrently that will exceed our statement_timeout time.
