### PR TITLE
Remove posthog specific email values

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -215,11 +215,11 @@ plugins:
 # Outbound E-mails
 email:
   # -- Outbound email sender
-  from_email: hey@posthog.com
+  from_email:
   # -- STMP host
-  host: smtp.eu.mailgun.org
+  host:
   # -- STMP port
-  port: 587
+  port:
   # -- STMP login user
   user:
   # -- STMP password


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/5464

To know if email is enabled we check if hostname is specified https://github.com/PostHog/posthog/blob/dae1d86edb305f95692fb23c52e47b17f39204a0/posthog/email.py#L36
our default values had it specified, so we thought email was set up for everyone.

#### Before
forgot password link gets to 502 or tells the email was sent if user didn't exist
Instance Status page was wrong
<img width="770" alt="Screen Shot 2021-08-11 at 21 53 05" src="https://user-images.githubusercontent.com/890921/129095575-9c8d0a5e-c6e6-43a6-8f00-78bbbb691ee6.png">

#### Now
<img width="769" alt="Screen Shot 2021-08-11 at 21 59 41" src="https://user-images.githubusercontent.com/890921/129095537-a0df3a84-200a-4a44-9a3c-3b04ca523009.png">
<img width="382" alt="Screen Shot 2021-08-11 at 22 00 08" src="https://user-images.githubusercontent.com/890921/129095550-1fb0c2e8-8dd0-47bf-9d7b-72538807adad.png">


