### PR TITLE
pgbouncer extension points

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -81,3 +81,9 @@ spec:
             port: 6543
           initialDelaySeconds: 15
           periodSeconds: 20
+      {{- if .Values.pgbouncer.extraVolumeMounts }}
+        volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}
+      {{- end }}
+    {{- if .Values.pgbouncer.extraVolumes }}
+      volumes: {{- toYaml .Values.pgbouncer.extraVolumes | nindent 6 }}
+    {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -68,6 +68,9 @@ spec:
           value: "1000"
         - name: POOL_MODE
           value: "transaction"
+{{- if .Values.pgbouncer.env }}
+{{ toYaml .Values.pgbouncer.env | indent 8 }}
+{{- end }}
         readinessProbe:
           tcpSocket:
             port: 6543

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -55,6 +55,10 @@ pgbouncer:
   replicacount: 1
   # -- Additional env vars to be added to the pgbouncer deployment
   env: []
+  # -- Additional volumeMounts to be added to the pgbouncer deployment
+  extraVolumeMounts: []
+  # -- Additional volumes to be added to the pgbouncer deployment
+  extraVolumes: []
 
 web:
   # -- Web horizontal pod autoscaler settings

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -53,6 +53,8 @@ pgbouncer:
     maxpods: 10
   # -- How many replicas of pgbouncer to run. Ignored if hpa is used
   replicacount: 1
+  # -- Additional env vars to be added to the pgbouncer deployment
+  env: []
 
 web:
   # -- Web horizontal pod autoscaler settings


### PR DESCRIPTION
e.g. setting in `values.yaml`:
```yaml
pgbouncer:
  env:
  - name: SERVER_TLS_SSLMODE
    value: require
  extraVolumeMounts:
  - name: config
    mountPath: /etc/pgbouncer
  extraVolumes:
  - name: config
    emptyDir: {}
```
now results in `server_tls_sslmode = require` in `pgbouncer.ini` and uses an `emptyDir` rather than writing files in the container. This is useful for OpenShift as the entrypoint script can't write files to `/etc/pgbouncer`. It is not sufficient on its own - a custom entrypoint script or `pgbouncer.ini` is also required so that `user = postgres` is replaced with `user =` as per https://github.com/edoburu/docker-pgbouncer/pull/23