### PR TITLE
Clickhouse on OpenShift

### DIFF
--- a/charts/posthog/templates/clickhouse_cluster_role.yaml
+++ b/charts/posthog/templates/clickhouse_cluster_role.yaml
@@ -110,6 +110,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - clickhouse.altinity.com
+  verbs:
+  - update
+  resources:
+  - clickhouseinstallations/finalizers
+  - clickhouseinstallationtemplates/finalizers
+  - clickhouseoperatorconfigurations/finalizers
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -79,10 +79,9 @@ spec:
     podTemplates:
       - name: pod-template-with-volumes
         spec:
-          securityContext:
-            runAsUser: 101
-            runAsGroup: 101
-            fsGroup: 101
+          {{- if .Values.clickhouse.securityContext.enabled }}
+          securityContext: {{- omit .Values.clickhouse.securityContext "enabled" | toYaml | nindent 10 }}
+          {{- end }}
           containers:
             - name: clickhouse
               # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -402,6 +402,11 @@ clickhouse:
     # servers:
       # - host: posthog-posthog-zookeeper
         # port: 2181
+  securityContext:
+    enabled: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
 
 
 ## Prometheus Exporter / Metrics


### PR DESCRIPTION
* Updates the RBAC as per https://github.com/Altinity/clickhouse-operator/issues/759
* Allows turning off of the pod `securityContext` for Clickhouse given OpenShift manages the UID/GID, e.g setting in `values.yaml`:
```yaml
clickhouse:
  securityContext:
    enabled: false
```