### PR TITLE
Make the command to run for beat configurable

### DIFF
--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -57,11 +57,7 @@ spec:
       - name: {{ .Chart.Name }}-beat
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-          - /bin/sh
-          - -c
-          - |
-            ./bin/docker-worker-beat
+        command: {{- toYaml .Values.beat.command | nindent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         env:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -150,6 +150,12 @@ beat:
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
+  # -- Command to run in beat deployment
+  command:
+  - /bin/sh
+  - -c
+  - |
+    ./bin/docker-worker-beat
 
 worker:
   hpa:


### PR DESCRIPTION
e.g setting in `values.yaml`
```yaml
beat:
  command:
  - /bin/sh
  - -c
  - |
    celery -A posthog beat -S redbeat.RedBeatScheduler --pidfile=/tmp/celery.pid
```
allows the beat deployment to run on OpenShift as it has permissions to write the pidfile into `/tmp`.

I'm less sure about this PR. It might be more useful to change/make configurable the pidfile location in https://github.com/PostHog/posthog/blob/master/bin/docker-worker-beat instead.