### PR TITLE
Clearer way to specify external cert and secret

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -32,11 +32,13 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
-  {{- if or (eq (include "ingress.letsencrypt" .) "true") (.Values.ingress.gcp.secretName) }}
+  {{- if or (eq (include "ingress.letsencrypt" .) "true") (or (.Values.ingress.secretName) (.Values.ingress.gcp.secretName)) }}
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}
-    {{- if eq (include "ingress.letsencrypt" .) "true" }}
+    {{- if .Values.ingress.secretName }}
+    secretName: {{ .Values.ingress.secretName }}
+    {{- else if eq (include "ingress.letsencrypt" .) "true" }}
     secretName: nginx-letsencrypt-{{ template "posthog.fullname" . }}
     {{- else }}
     secretName: {{ .Values.ingress.gcp.secretName }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -286,6 +286,10 @@ ingress:
     enabled: false
     # -- Whether to redirect to TLS with nginx ingress.
     redirectToTLS: true
+  # -- Extra annotations
+  annotations: {}
+  # -- TLS secret to be used by the ingress.
+  secretName:
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)


### PR DESCRIPTION
Closes https://github.com/PostHog/charts-clickhouse/issues/108

Currently it's possible to provide an external cert and secret name, but it's not obvious (need to use `ingress.annotations` which isn't listed in the values file and `ingress.gcp.secretName` though might not be on gcp).

It's a bit suboptimal that we now have `secretName` in both `ingress` & `ingress.gcp`, but removing things is hard without breaking anyone :( We could remove it from the values and gcp folks can start using `ingress.secretName` & in templates still handle `ingress.gcp.secretName` too.

Verified things work:
```
helm template posthog charts/posthog --set cloud=na --set ingress.hostname=blah.com --set ingress.secretName=gdewr | grep "ingress.yaml" -A20
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-3.7.0"
    release: "posthog"
    heritage: "Helm"
 annotations:
spec:
  tls:
  - hosts:
    - blah.com
    secretName: gdewr
  rules:
    - host: blah.com
      http:
        paths:
          - pathType: Prefix
```

```
$ helm template posthog charts/posthog --set cloud=na --set ingress.nginx.enabled=true --set ingress.hostname=blah.com --set certManager.enabled=true | grep "ingress.yaml" -A20
# Source: posthog/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
 name: posthog
 labels:
    app: posthog
    chart: "posthog-3.7.0"
    release: "posthog"
    heritage: "Helm"
 annotations:
    nginx.ingress.kubernetes.io/ssl-redirect: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    cert-manager.io/cluster-issuer: "letsencrypt-prod"
spec:
  tls:
  - hosts:
    - blah.com
    secretName: nginx-letsencrypt-posthog
  rules:
    - host: blah.com
```