### PR TITLE
Add chart version env to web deployment

### DIFF
--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -182,6 +182,8 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
+        - name: CHART_VERSION
+          value: {{ .Chart.Version | quote }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Part 1 of https://github.com/PostHog/charts-clickhouse/issues/97

verification:
```
helm template posthog ~/Posthog/charts-clickhouse/charts/posthog --set cloud=na | grep "CHART_VERSION" -C2
        - name: HELM_INSTALL_INFO
          value: "{\"chart_version\":\"3.7.1\",\"cloud\":\"na\",\"deployment_type\":\"helm\",\"hostname\":null,\"ingress_type\":\"\",\"operation\":\"install\",\"release_name\":\"posthog\",\"release_revision\":1}"
        - name: CHART_VERSION
          value: "3.7.1"
        - name: ASYNC_EVENT_PROPERTY_USAGE
```