### PR TITLE
Default the image to release 1.28.0

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Posthog image tag, e.g. release-1.25.0
   tag:
   # -- Default image or tag
-  default: "@sha256:20af35fca6756d689d6705911a49dd6f2f6631e001ad43377b605cfc7c133eb4"
+  default: ":release-1.28.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
We'll likely want to push this just before the Array post

Verified it's fine by deploying to my test instance in DigitalOcean & checked the /instance/status page:
<img width="728" alt="Screen Shot 2021-09-14 at 18 57 32" src="https://user-images.githubusercontent.com/890921/133301694-1360384b-f5f4-429f-9739-5b080adb2db4.png">
