### PR TITLE
Add kubeversion to helm install info

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -358,6 +358,7 @@ Create the name of the service account to use
 {{- $info := set $info "operation" (include "posthog.helmOperation" .) -}}
 {{- $info := set $info "ingress_type" (include "ingress.type" .) -}}
 {{- $info := set $info "deployment_type" (.Values.deploymentType | default "helm") -}}
+{{- $info := set $info "kube_version" .Capabilities.KubeVersion.Version -}}
 {{ toJson $info | quote }}
 {{- end -}}
 


### PR DESCRIPTION
So we know what versions people are using which makes it easier to know what we need to keep supporting in the chart

Verified by deploying to my DigitalOcean instance:
<img width="1260" alt="Screen Shot 2021-09-15 at 01 54 51" src="https://user-images.githubusercontent.com/890921/133349001-abfa373b-8207-4681-aea7-b99ddc018777.png">
