### PR TITLE
Bump sha to include fixes for instance status reports

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Posthog image tag, e.g. release-1.25.0
   tag:
   # -- Default image or tag
-  default: ":release-1.28.0"
+  default: "@sha256:68184c13fedc920c79b95f2dac938cbd6d6d5c2635553ae51c309604683b7de6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Include fixes in posthog/product-internal#141 that fix issues with instance status report payloads
