### PR TITLE
Add resources to pgbouncer deployment

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -84,6 +84,10 @@ spec:
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}
       {{- end }}
+{{- if .Values.pgbouncer.resources }}
+        resources:
+{{ toYaml .Values.pgbouncer.resources | indent 12 }}
+{{- end }}
     {{- if .Values.pgbouncer.extraVolumes }}
       volumes: {{- toYaml .Values.pgbouncer.extraVolumes | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
Similar to the other HPA services.

Not sure if setting resources is the correct way to resolve the following issue, but it can help with:

> failed to get cpu utilization: missing request for cpu

In the Horizontal Pod Autoscaler