### PR TITLE
Fix: The ingress specified is invalid on GCP

### DIFF
--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.web.hpa.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-events
+  labels:
+    app: {{ template "posthog.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-events
+  minReplicas: {{ .Values.web.hpa.minpods }}
+  maxReplicas: {{ .Values.web.hpa.maxpods }}
+  targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+{{- end }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -56,7 +56,7 @@ spec:
     - http:
   {{- end }}
         paths:
-          - pathType: Prefix
+          - pathType: ImplementationSpecific
             path: "/"
             backend:
               {{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.Version }}
@@ -68,8 +68,8 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-web
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
-          - pathType: Prefix
-            path: "/batch"
+          - pathType: ImplementationSpecific
+            path: "/batch/*"
             backend: &INGESTION
               {{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.Version }}
               service:
@@ -80,20 +80,20 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-events
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
-          - pathType: Prefix
-            path: "/capture"
+          - pathType: ImplementationSpecific
+            path: "/capture/*"
             backend: *INGESTION
-          - pathType: Prefix
-            path: "/decide"
+          - pathType: ImplementationSpecific
+            path: "/decide/*"
             backend: *INGESTION
-          - pathType: Prefix
-            path: "/e"
+          - pathType: ImplementationSpecific
+            path: "/e/*"
             backend: *INGESTION
-          - pathType: Prefix
-            path: "/track"
+          - pathType: ImplementationSpecific
+            path: "/track/*"
             backend: *INGESTION
-          - pathType: Prefix
-            path: "/s"
+          - pathType: ImplementationSpecific
+            path: "/s/*"
             backend: *INGESTION
 {{- if .Values.ingress.tls }}
 {{ toYaml .Values.ingress.tls | indent 4 }}


### PR DESCRIPTION
When applying the new helm chart the following error is thrown:

```
 Warning  Translate  17s (x16 over 3m1s)     loadbalancer-controller  Translation failed: invalid ingress spec: only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported; only "ImplementationSpecific" path type is supported
 ```
 
 Kubernetes spec: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 
 Googles docs: https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress
 
```
 The only supported path types for the pathType field is ImplementationSpecific.
 ```
 
With the above changes applied, the ingress is correctly updated and the events start routing to the events pod. (i think we need an hpa here as the new update only has one pod running). 

I quickly copied the web hpa to have some redundancy here:

```
---
# Source: posthog/templates/events-hpa.yaml
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: posthog-events
  labels:
    app: posthog
    chart: "posthog-3.13.0"
    release: "posthog"
    heritage: "Helm"
spec:
  scaleTargetRef:
    kind: Deployment
    apiVersion: apps/v1
    name: posthog-events
  minReplicas: 5
  maxReplicas: 10
  targetCPUUtilizationPercentage: 100
```


@tiina303 @fuziontech 