### PR TITLE
Fix duplicate entries within clickhouse yaml

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -83,10 +83,6 @@ spec:
     podTemplates:
       - name: pod-template-with-volumes
         spec:
-          securityContext:
-            runAsUser: 101
-            runAsGroup: 101
-            fsGroup: 101
           {{- if .Values.clickhouse.affinity }}
           affinity:
 {{ toYaml .Values.clickhouse.affinity | indent 12 }}
@@ -102,7 +98,7 @@ spec:
                 claimName: {{ .Values.clickhouse.persistentVolumeClaim }}
           {{- end }}
           {{- if .Values.clickhouse.securityContext.enabled }}
-          securityContext: {{- omit .Values.clickhouse.securityContext "enabled" | toYaml | nindent 10 }}
+          securityContext: {{- omit .Values.clickhouse.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           containers:
             - name: clickhouse


### PR DESCRIPTION
Fix the indentation
Duplicate entries for security context

These issues were introduced within: https://github.com/PostHog/charts-clickhouse/pull/135

@fuziontech @tiina303 