### PR TITLE
nginx and GCP compatible ingress controller

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -56,8 +56,13 @@ spec:
     - http:
   {{- end }}
         paths:
-          - pathType: ImplementationSpecific
+          {{- if (eq (include "ingress.type" .) "nginx") }}
+          - pathType: Prefix
+            path: "/"
+          {{- else }}
+          - pathType: ImplementationSpecific 
             path: "/*"
+          {{- end }}
             backend:
               {{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.Version }}
               service:
@@ -68,8 +73,13 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-web
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
-          - pathType: ImplementationSpecific
+          {{- if (eq (include "ingress.type" .) "nginx") }}
+          - pathType: Prefix
+            path: "/batch"
+          {{- else }}
+          - pathType: ImplementationSpecific 
             path: "/batch/*"
+          {{- end }}
             backend: &INGESTION
               {{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.Version }}
               service:
@@ -80,6 +90,23 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-events
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
+          {{- if (eq (include "ingress.type" .) "nginx") }}
+          - pathType: Prefix
+            path: "/capture"
+            backend: *INGESTION
+          - pathType: Prefix
+            path: "/decide"
+            backend: *INGESTION
+          - pathType: Prefix
+            path: "/e"
+            backend: *INGESTION
+          - pathType: Prefix
+            path: "/track"
+            backend: *INGESTION
+          - pathType: Prefix
+            path: "/s"
+            backend: *INGESTION 
+          {{- else }}
           - pathType: ImplementationSpecific
             path: "/capture/*"
             backend: *INGESTION
@@ -94,7 +121,8 @@ spec:
             backend: *INGESTION
           - pathType: ImplementationSpecific
             path: "/s/*"
-            backend: *INGESTION
+            backend: *INGESTION 
+          {{- end }}
 {{- if .Values.ingress.tls }}
 {{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end -}}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -56,7 +56,7 @@ spec:
     - http:
   {{- end }}
         paths:
-          {{- if (eq (include "ingress.type" .) "nginx") }}
+          {{- if (ne (include "ingress.type" .) "clb") }}
           - pathType: Prefix
             path: "/"
           {{- else }}
@@ -73,7 +73,7 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-web
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
-          {{- if (eq (include "ingress.type" .) "nginx") }}
+          {{- if (ne (include "ingress.type" .) "clb") }}
           - pathType: Prefix
             path: "/batch"
           {{- else }}
@@ -90,7 +90,7 @@ spec:
               serviceName: {{ template "posthog.fullname" . }}-events
               servicePort: {{ .Values.service.externalPort }}
               {{- end }}
-          {{- if (eq (include "ingress.type" .) "nginx") }}
+          {{- if (ne (include "ingress.type" .) "clb") }}
           - pathType: Prefix
             path: "/capture"
             backend: *INGESTION

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -60,7 +60,7 @@ spec:
           - pathType: Prefix
             path: "/"
           {{- else }}
-          - pathType: ImplementationSpecific 
+          - pathType: ImplementationSpecific
             path: "/*"
           {{- end }}
             backend:
@@ -77,7 +77,7 @@ spec:
           - pathType: Prefix
             path: "/batch"
           {{- else }}
-          - pathType: ImplementationSpecific 
+          - pathType: ImplementationSpecific
             path: "/batch/*"
           {{- end }}
             backend: &INGESTION
@@ -105,7 +105,7 @@ spec:
             backend: *INGESTION
           - pathType: Prefix
             path: "/s"
-            backend: *INGESTION 
+            backend: *INGESTION
           {{- else }}
           - pathType: ImplementationSpecific
             path: "/capture/*"
@@ -121,7 +121,7 @@ spec:
             backend: *INGESTION
           - pathType: ImplementationSpecific
             path: "/s/*"
-            backend: *INGESTION 
+            backend: *INGESTION
           {{- end }}
 {{- if .Values.ingress.tls }}
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,9 @@
+cloud: "do"
+deploymentType: "DigitalOcean 1-click"
+ingress:
+  nginx:
+    enabled: true
+    redirectToTLS: false
+  letsencrypt: false
+web:
+  secureCookies: false

--- a/values.yaml
+++ b/values.yaml
@@ -1,9 +1,0 @@
-cloud: "do"
-deploymentType: "DigitalOcean 1-click"
-ingress:
-  nginx:
-    enabled: true
-    redirectToTLS: false
-  letsencrypt: false
-web:
-  secureCookies: false


### PR DESCRIPTION
Nginx works with `Prefix` path definitions.
GCP requires `ImplementationSpecific` path definitions.
Switch between the two here based on Ingress that is configured

