### PR TITLE
Add unsafeHttpDirectAccess option as a quick way to allow ip access

### DIFF
--- a/charts/posthog/templates/NOTES.txt
+++ b/charts/posthog/templates/NOTES.txt
@@ -4,10 +4,10 @@
 To access your PostHog site from outside the cluster follow the steps below:
 
 {{- if .Values.ingress.enabled }}
-{{- if .Values.ingress.hostname }}
+{{- if and (.Values.ingress.hostname) (not .Values.ingress.unsafeHttpDirectAccess) }}
 1. Your application will be hosted at http{{ if (or .Values.ingress.tls .Values.ingress.gcp.forceHttps) }}s{{ end }}://{{ .Values.ingress.hostname }}/
 {{- else }}
-1. Your application will be hosted at an ingress IP because hostname was not supplied. Run these commands to get your installation location:
+1. Your application will be hosted at an ingress IP because hostname was not supplied or unsafeHttpDirectAccess was set. Run these commands to get your installation location:
 export INGRESS_IP=$(kubectl get --namespace {{ .Release.Namespace }} ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
 echo "Visit http://$INGRESS_IP to use PostHog\!"
 {{- end }}

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -378,7 +378,9 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "ingress.letsencrypt" -}}
-{{- if ne (.Values.ingress.letsencrypt | toString) "<nil>" -}}
+{{- if not .Values.ingress.unsafeHttpDirectAccess -}}
+  false
+{{- else if ne (.Values.ingress.letsencrypt | toString) "<nil>" -}}
   {{ .Values.ingress.letsencrypt }}
 {{- else if and (and (.Values.ingress.nginx.enabled) (.Values.certManager.enabled)) (ne (.Values.ingress.hostname | toString) "<nil>")  -}}
   true

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -83,7 +83,7 @@ spec:
           value: '1'
         - name: IS_BEHIND_PROXY
           value: '1'
-      {{- if eq .Values.web.secureCookies false }}
+      {{- if or (eq .Values.web.secureCookies false) (eq .Values.ingress.unsafeHttpDirectAccess false) }}
         - name: SECURE_COOKIES
           value: '0'
       {{- end }}

--- a/charts/posthog/templates/gce-frontend-config.yaml
+++ b/charts/posthog/templates/gce-frontend-config.yaml
@@ -6,5 +6,5 @@ metadata:
   name: "{{ .Release.Name }}-frontend-config"
 spec:
   redirectToHttps:
-    enabled: {{ .Values.ingress.gcp.forceHttps }}
+    enabled: {{ and (.Values.ingress.gcp.forceHttps) (not .Values.ingress.unsafeHttpDirectAccess) }}
 {{- end -}}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.ip_name | quote }}
     {{- end }}
    {{- end }}
-   {{- if (and (eq (include "ingress.type" .) "nginx") .Values.ingress.nginx.redirectToTLS "true") }}
+   {{- if (and (eq (include "ingress.type" .) "nginx") (and .Values.ingress.nginx.redirectToTLS (not .Values.ingress.unsafeHttpDirectAccess))) }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    {{- if eq (include "ingress.letsencrypt" .) "true"}}
@@ -49,7 +49,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-  {{- if .Values.ingress.hostname }}
+  {{- if and .Values.ingress.hostname (not .Values.ingress.unsafeHttpDirectAccess)}}
     - host: {{ .Values.ingress.hostname }}
       http:
   {{- else }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.ip_name | quote }}
     {{- end }}
    {{- end }}
-   {{- if (and (eq (include "ingress.type" .) "nginx") (and .Values.ingress.nginx.redirectToTLS (not .Values.ingress.unsafeHttpDirectAccess))) }}
+   {{- if (and (eq (include "ingress.type" .) "nginx") .Values.ingress.nginx.redirectToTLS (not .Values.ingress.unsafeHttpDirectAccess)) }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    {{- if eq (include "ingress.letsencrypt" .) "true"}}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -83,7 +83,7 @@ spec:
           value: '1'
         - name: IS_BEHIND_PROXY
           value: '1'
-      {{- if eq .Values.web.secureCookies false }}
+      {{- if or (eq .Values.web.secureCookies false) (eq .Values.ingress.unsafeHttpDirectAccess false) }}
         - name: SECURE_COOKIES
           value: '0'
       {{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -338,6 +338,8 @@ ingress:
   annotations: {}
   # -- TLS secret to be used by the ingress.
   secretName:
+  # -- Troubleshooting tool to swich to http direct access to the IP. This overrides hostname, nginx.redirectToTLS, gcp.forceHttps, letsencrypt and web.secureCookies to false. Don't use in Production.
+  unsafeHttpDirectAccess: false
 
 postgresql:
   # -- Install postgres server on kubernetes (see below)


### PR DESCRIPTION
Inspired from https://github.com/PostHog/charts-clickhouse/pull/141 but I wanted to make it even simpler & to have it work for all platforms. So we can just say that they should run a `helm upgrade` with `--set ingress.unsafeHttpDirectAccess=true` in the troubleshooting sections.

Tested in DigitalOcean that it still worked to have hostname set etc & that after the update with this flag I could access via IP directly (before couldn't)