### PR TITLE
Update kafka storage values

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -417,10 +417,10 @@ kafka:
     # -- Enable persistence using PVC
     enabled: true
     # -- PVC Storage Request for kafka volume
-    size: 5Gi
+    size: 20Gi
   # -- A size-based retention policy for logs
-  # -- Should be less than kafka.persistence.size, ideally 70-80%
-  logRetentionBytes: _4_000_000_000
+  # -- Should be less than kafka.persistence.size, minimum 1GB
+  logRetentionBytes: _15_000_000_000
   # -- The minimum age of a log file to be eligible for deletion due to age
   logRetentionHours: 24
   zookeeper:


### PR DESCRIPTION
I don't know a thing about k8s/helm charts really so just putting this up as a way of bringing visibility to this discussion.

We just had a customer run out of space on the Kafka pod. This is highly problematic as it can lead us to drop events. It also crashes the plugin server.

We need a few things:

- A way to resize this easily (maybe a doc at first?)
- More storage allocated to this by deafult (the customer this happened to really does not have a lot of events at this stage)

@guidoiaquinti also pointed out we probably want to be on the safe side in terms of Kafka retention to pod storage ratio.

This PR requests more storage by default and makes the ratio 50%. Again, what do I know? Not a thing. So just giving this visibility.
