### PR TITLE
[zookeeper] reduce the default replica count

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -437,7 +437,7 @@ zookeeper:
   # -- Name override for zookeeper app
   nameOverride: posthog-zookeeper
   # -- replica count for zookeeper
-  replicaCount: 3
+  replicaCount: 1
 
 clickhouse:
   # -- Use clickhouse as primary database


### PR DESCRIPTION
Our default config installs 1 pod for each service except for Zookeeper. 

As the default settings are not designed for HA and for a production setup, I think we should reduce the replica factor to 1 and free up some resources.

**Before**
```
➜  posthog git:(main) ✗ kubectl get pod -n posthog
NAME                                   READY   STATUS    RESTARTS   AGE
chi-posthog-posthog-0-0-0              1/1     Running   0          15m
clickhouse-operator-6b54d6b5fb-6d6bq   2/2     Running   0          15m
posthog-beat-77b6c47c89-ntl64          1/1     Running   0          15m
posthog-events-67df4598f8-jhqvk        1/1     Running   0          11m
posthog-pgbouncer-84d4654658-cncgx     1/1     Running   0          15m
posthog-plugins-668c4cf8fd-l7kjh       1/1     Running   0          11m
posthog-posthog-kafka-0                1/1     Running   0          15m
posthog-posthog-postgresql-0           1/1     Running   0          15m
posthog-posthog-redis-master-0         1/1     Running   0          15m
posthog-posthog-zookeeper-0            1/1     Running   0          15m
posthog-posthog-zookeeper-1            1/1     Running   0          15m
posthog-posthog-zookeeper-2            1/1     Running   0          15m
posthog-web-ff58dbf4c-qbcvt            1/1     Running   0          11m
posthog-worker-7bb648dcfd-hqlq5        1/1     Running   0          11m
```

**After**
```
➜  posthog git:(zookeeper_replica_count) ✗ kubectl get pod -n posthog
NAME                                   READY   STATUS    RESTARTS   AGE
chi-posthog-posthog-0-0-0              1/1     Running   0          31m
clickhouse-operator-6b54d6b5fb-6d6bq   2/2     Running   0          31m
posthog-beat-9d8c5f9b8-wgxwj           1/1     Running   0          7m33s
posthog-events-67b5778c49-ssz9m        1/1     Running   0          7m16s
posthog-pgbouncer-57887b7c74-b2knb     1/1     Running   0          7m32s
posthog-plugins-55ffddd49b-kkwhh       1/1     Running   0          7m15s
posthog-posthog-kafka-0                1/1     Running   0          31m
posthog-posthog-postgresql-0           1/1     Running   0          31m
posthog-posthog-redis-master-0         1/1     Running   0          31m
posthog-posthog-zookeeper-0            1/1     Running   0          7m19s
posthog-web-5565fff7df-6df87           1/1     Running   0          7m13s
posthog-worker-6cb4bb9c96-msmb8        1/1     Running   0          7m12s
``` 

The Zookeeper service is still healthy (see [docs](http://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html))

> **ruok**
> Tests if server is running in a non-error state. The server will respond with imok if it is running. Otherwise it will not respond at all.

```
➜  posthog git:(zookeeper_replica_count) ✗ kubectl exec --stdin --tty posthog-posthog-zookeeper-0 -n posthog -- /bin/bash -c 'echo "ruok" | timeout 2 nc -w 2 localhost 2181'
imok%
```