### PR TITLE
Add unit test for Kafka service definition

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,37 @@
+name: Unit tests
+on: push
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # ct needs history to compare
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1.1
+        with:
+          version: v3.7.0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed="$(ct list-changed --config ct.yaml)"
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Install Helm unittest plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm env
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.7
+
+      - name: Run test suite
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' charts/posthog

--- a/charts/posthog/.helmignore
+++ b/charts/posthog/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests

--- a/charts/posthog/tests/kafka-service.yaml
+++ b/charts/posthog/tests/kafka-service.yaml
@@ -1,0 +1,111 @@
+suite: Kafka service definition
+templates:
+  - templates/kafka-service.yaml
+
+tests:
+  - it: should be empty if kafka.service.enabled is set to false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    set:
+      kafka.service.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    set:
+      kafka.service.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should have the correct metadata values
+    set:
+      kafka.service.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: -kafka$
+      - equal:
+          path: metadata.labels.app
+          value: RELEASE-NAME-posthog
+      - matchRegex:
+          path: metadata.labels.chart
+          pattern: ^posthog-
+      - equal:
+          path: metadata.labels.release
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm
+
+  - it: should have the correct optional metadata values
+    set:
+      kafka.service.enabled: true
+      kafka.service.labels.key1: value1
+      kafka.service.labels.key2: value2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels.key1
+          value: value1
+      - equal:
+          path: metadata.labels.key2
+          value: value2
+
+  - it: should have the correct default specs
+    set:
+      kafka.service.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.type
+          value: NodePort
+      - contains:
+          path: spec.ports
+          content:
+            port: 9092
+            targetPort: 9092
+            protocol: TCP
+            name: kafka
+      - equal:
+          path: spec.selector
+          value:
+            app: RELEASE-NAME-posthog
+            release: RELEASE-NAME
+            role: kafka
+
+  - it: should have the correct specs with overrides
+    set:
+      kafka.service.enabled: true
+      kafka.port: 123
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.type
+          value: NodePort
+      - contains:
+          path: spec.ports
+          content:
+            port: 123
+            targetPort: 123
+            protocol: TCP
+            name: kafka
+      - equal:
+          path: spec.selector
+          value:
+            app: RELEASE-NAME-posthog
+            release: RELEASE-NAME
+            role: kafka

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+additional-commands:
+  - helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' {{ .Path }}


### PR DESCRIPTION
As I'm new to both k8s and Helm, I'm finding pretty difficult to make changes without a test suite running. 

This PR adds a new `Unit tests` GitHub action to verify if the manifest definition is rendered as we expect. This is just a starting point and the plan is to add more tests as we go. 

