### PR TITLE
Fixes Helm race condition with CRDs resources

### DIFF
--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -3,6 +3,9 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "99"
 spec:
   acme:
     # Email address used for ACME registration


### PR DESCRIPTION
## Description
Fixes https://github.com/PostHog/charts-clickhouse/issues/168.

## Test
```
➜  charts-clickhouse git:(fix_helm_nosense_with_crds) ✗ cat values.yaml
cloud: "do"
ingress:
  hostname: test.guido.com
  nginx:
    enabled: true
cert-manager:
  enabled: true
```

**Before**
```
➜  charts-clickhouse git:(main) ✗ helm install -f ./values.yaml --timeout 20m --create-namespace --namespace posthog posthog posthog/posthog
W1026 15:21:06.834264   41347 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1026 15:21:06.967507   41347 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"
```

**After**

```
➜  charts-clickhouse git:(main) ✗ helm install -f ./values.yaml --timeout 20m --create-namespace --namespace posthog posthog ./charts/posthog
W1026 16:08:33.186773   42315 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1026 16:08:33.352721   42315 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1026 16:08:33.577680   42315 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W1026 16:08:33.700085   42315 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
NAME: posthog
LAST DEPLOYED: Tue Oct 26 16:08:36 2021
NAMESPACE: posthog
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **

To access your PostHog site from outside the cluster follow the steps below:
1. Your application will be hosted at https://test.guido.com/
```