### PR TITLE
Remove all the (possible) Helm annotations

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -100,13 +100,26 @@ jobs:
     - name: Workaround - wait for all the k8s resources to be ready
       timeout-minutes: 15
       run: |
-        echo "Waiting for pods to be ready..."
-        while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+        echo "Waiting for jobs to be ready..."
+        while ! kubectl -n posthog wait --for=condition=Complete jobs --all --timeout 10s > /dev/null 2>&1
         do
-          echo "  pods are not yet ready"
+          sleep 1
         done
-        echo "All pods are now ready!"
+        echo "All jobs are now ready!"
 
+        echo "Waiting for all deployments to be ready..."
+        for deployment in $(kubectl -n posthog get deployments --no-headers -o custom-columns=NAME:.metadata.name)
+        do
+          while ! kubectl -n posthog rollout status deployment "$deployment" > /dev/null 2>&1
+          do
+            sleep 1
+          done
+        done
+        echo "All deployments are now ready!"
+
+    - name: Workaround - wait for the AWS load balancer to be ready
+      timeout-minutes: 15
+      run: |
         echo "Waiting for the AWS Load Balancer to be ready..."
         load_balancer_external_hostname=""
         while [ -z "$load_balancer_external_hostname" ];

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -74,13 +74,26 @@ jobs:
     - name: Workaround - wait for all the k8s resources to be ready
       timeout-minutes: 15
       run: |
-        echo "Waiting for pods to be ready..."
-        while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+        echo "Waiting for jobs to be ready..."
+        while ! kubectl -n posthog wait --for=condition=Complete jobs --all --timeout 10s > /dev/null 2>&1
         do
-          echo "  pods are not yet ready"
+          sleep 1
         done
-        echo "All pods are now ready!"
+        echo "All jobs are now ready!"
 
+        echo "Waiting for all deployments to be ready..."
+        for deployment in $(kubectl -n posthog get deployments --no-headers -o custom-columns=NAME:.metadata.name)
+        do
+          while ! kubectl -n posthog rollout status deployment "$deployment" > /dev/null 2>&1
+          do
+            sleep 1
+          done
+        done
+        echo "All deployments are now ready!"
+
+    - name: Workaround - wait for the DO load balancer to be ready
+      timeout-minutes: 15
+      run: |
         echo "Waiting for the DigitalOcean Load Balancer to be ready..."
         load_balancer_external_hostname=""
         while [ -z "$load_balancer_external_hostname" ];

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -108,13 +108,26 @@ jobs:
     - name: Workaround - wait for all the k8s resources to be ready
       timeout-minutes: 15
       run: |
-        echo "Waiting for pods to be ready..."
-        while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+        echo "Waiting for jobs to be ready..."
+        while ! kubectl -n posthog wait --for=condition=Complete jobs --all --timeout 10s > /dev/null 2>&1
         do
-          echo "  pods are not yet ready"
+          sleep 1
         done
-        echo "All pods are now ready!"
+        echo "All jobs are now ready!"
 
+        echo "Waiting for all deployments to be ready..."
+        for deployment in $(kubectl -n posthog get deployments --no-headers -o custom-columns=NAME:.metadata.name)
+        do
+          while ! kubectl -n posthog rollout status deployment "$deployment" > /dev/null 2>&1
+          do
+            sleep 1
+          done
+        done
+        echo "All deployments are now ready!"
+
+    - name: Workaround - wait for the GCP load balancer to be ready
+      timeout-minutes: 15
+      run: |
         echo "Waiting for the GCP Load Balancer to be ready..."
         load_balancer_external_ip=""
         while [ -z "$load_balancer_external_ip" ];

--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: (Upgrade) Install our helm chart from main branch
         if: matrix.test == 'upgrade'
         run: |
-          helm upgrade --install -f ci/values/k3s.yaml --timeout 10m --create-namespace --namespace posthog posthog ./main/charts/posthog --wait --wait-for-jobs --debug
+          helm upgrade --install -f ci/values/k3s.yaml --timeout 20m --create-namespace --namespace posthog posthog ./main/charts/posthog --wait --wait-for-jobs --debug
 
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install our helm chart
         run: |
-          helm upgrade --debug --install -f ci/values/k3s.yaml --timeout 10m --create-namespace --namespace posthog posthog ./charts/posthog --wait --wait-for-jobs --debug
+          helm upgrade --debug --install -f ci/values/k3s.yaml --timeout 20m --create-namespace --namespace posthog posthog ./charts/posthog --wait --wait-for-jobs --debug
 
       #
       # Wait for all k8s resources to be ready.
@@ -100,14 +100,23 @@ jobs:
       #
       - name: Workaround - wait for all the k8s resources to be ready
         timeout-minutes: 15
-
         run: |
-          echo "Waiting for pods to be ready..."
-          while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+          echo "Waiting for jobs to be ready..."
+          while ! kubectl -n posthog wait --for=condition=Complete jobs --all --timeout 10s > /dev/null 2>&1
           do
-            echo "  pods are not yet ready"
+            sleep 1
           done
-          echo "All pods are now ready!"
+          echo "All jobs are now ready!"
+
+          echo "Waiting for all deployments to be ready..."
+          for deployment in $(kubectl -n posthog get deployments --no-headers -o custom-columns=NAME:.metadata.name)
+          do
+            while ! kubectl -n posthog rollout status deployment "$deployment" > /dev/null 2>&1
+            do
+              sleep 1
+            done
+          done
+          echo "All deployments are now ready!"
 
       - name: Wait until all the resources are fully deployed in k8s
         uses: jupyterhub/action-k8s-await-workloads@main

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -1,0 +1,51 @@
+{{/* Common initContainers-wait-for-migrations definition */}}
+{{- define "_snippet-initContainers-wait-for-migrations" }}
+- name: wait-for-migrations
+  image: {{ include "posthog.image.fullPath" . }}
+  command:
+    - /bin/sh
+    - -c
+    - >
+        until (python manage.py migrate --check);
+        do
+            echo "Waiting for database migrations to be completed"; sleep 1;
+        done
+  env:
+
+  # PostgreSQL configuration
+  - name: POSTHOG_POSTGRES_HOST
+    value: {{ template "posthog.pgbouncer.host" . }}
+  - name: POSTHOG_POSTGRES_PORT
+    value: {{ include "posthog.pgbouncer.port" . | quote }}
+  - name: POSTHOG_DB_NAME
+    value: {{ default "posthog" .Values.postgresql.postgresqlDatabase | quote }}
+  - name: POSTHOG_DB_USER
+    value: {{ default "posthog" .Values.postgresql.postgresqlUsername | quote }}
+  - name: POSTHOG_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+      {{- if .Values.postgresql.existingSecret }}
+        name: {{ .Values.postgresql.existingSecret }}
+      {{- else }}
+        name: {{ template "posthog.postgresql.secret" . }}
+      {{- end }}
+        key: {{ template "posthog.postgresql.secretKey" . }}
+
+  # Redis configuration
+  - name: POSTHOG_REDIS_HOST
+    value: {{ template "posthog.redis.host" . }}
+  - name: POSTHOG_REDIS_PORT
+    value: {{ include "posthog.redis.port" . | quote }}
+  {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
+  - name: POSTHOG_REDIS_PASSWORD
+    value: {{ .Values.redis.password | quote }}
+  {{- end }}
+
+  # Django specific settings
+  - name: SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "posthog.fullname" . }}
+        key: posthog-secret
+
+{{- end }}

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -1,0 +1,41 @@
+{{/* Common initContainers-wait-for-service-dependencies definition */}}
+{{- define "_snippet-initContainers-wait-for-service-dependencies" }}
+- name: wait-for-service-dependencies
+  image: busybox:1.34
+  command:
+    - /bin/sh
+    - -c
+    - >
+        {{ if .Values.clickhouse.enabled }}
+        until (nc -vz "{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 8123);
+        do
+            echo "waiting for ClickHouse"; sleep 1;
+        done
+        {{ end }}
+
+        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.pgbouncer.port" . }});
+        do
+            echo "waiting for PgBouncer"; sleep 1;
+        done
+
+        {{ if .Values.postgresql.enabled }}
+        until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.postgresql.port" . }});
+        do
+            echo "waiting for PostgreSQL"; sleep 1;
+        done
+        {{ end }}
+
+        {{ if .Values.redis.enabled }}
+        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.redis.port" . }});
+        do
+            echo "waiting for Redis"; sleep 1;
+        done
+        {{ end }}
+
+        {{ if .Values.kafka.enabled }}
+        until (nc -vz "{{ include "posthog.kafka.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 9092);
+        do
+            echo "waiting for Kafka"; sleep 1;
+        done
+        {{ end }}
+{{- end }}

--- a/charts/posthog/templates/_snippet-metadata-annotations-common.tpl
+++ b/charts/posthog/templates/_snippet-metadata-annotations-common.tpl
@@ -1,0 +1,7 @@
+{{/*
+    Common metadata.annotations definition.
+*/}}
+{{- define "_snippet-metadata-annotations-common" }}
+"meta.helm.sh/release-name": {{ .Release.Name | quote }}
+"meta.helm.sh/release-namespace": {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/posthog/templates/_snippet-metadata-labels-common.tpl
+++ b/charts/posthog/templates/_snippet-metadata-labels-common.tpl
@@ -1,0 +1,13 @@
+{{/*
+    Common metadata.labels definition.
+
+    For more info see:
+      - https://helm.sh/docs/chart_best_practices/labels/#standard-labels
+      - https://kubernetes.io/docs/concepts/overview/_print/#labels
+*/}}
+{{- define "_snippet-metadata-labels-common" }}
+"app.kubernetes.io/name": {{ include "posthog.fullname" . | quote }}
+"app.kubernetes.io/instance": {{ .Release.Name | quote }}
+"app.kubernetes.io/managed-by": {{ .Release.Service | quote }}
+"helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
+{{- end }}

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -4,8 +4,11 @@ kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "99"
+    # Install this last as we need 'cert-manager's CDRs API
+    # to be installed first.
+    #
+    # ref: https://github.com/PostHog/charts-clickhouse/issues/168
+    "helm.sh/hook": post-install,post-upgrade
 spec:
   acme:
     # Email address used for ACME registration

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -3,17 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-events
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep"
-    "helm.sh/hook-weight": "1"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -211,4 +202,7 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -3,11 +3,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-events
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/charts/posthog/templates/events-service.yaml
+++ b/charts/posthog/templates/events-service.yaml
@@ -3,19 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-events
-  annotations:
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -2,13 +2,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
- name: {{ template "posthog.fullname" . }}
- labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
- annotations:
+  name: {{ template "posthog.fullname" . }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
     {{- if (eq (include "ingress.type" .) "nginx") }}
     kubernetes.io/ingress.class: "nginx"
     {{- end }}

--- a/charts/posthog/templates/kafka-service.yaml
+++ b/charts/posthog/templates/kafka-service.yaml
@@ -3,23 +3,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-kafka
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 {{- if .Values.kafka.service.labels }}
 {{ toYaml .Values.kafka.service.labels | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.kafka.service.type }}
   ports:
-  - port: {{ default "9092" .Values.kafka.port }} 
-    targetPort: {{ default "9092" .Values.kafka.port }} 
+  - port: {{ default "9092" .Values.kafka.port }}
+    targetPort: {{ default "9092" .Values.kafka.port }}
     protocol: TCP
-    name: kafka 
+    name: kafka
   selector:
     app: {{ template "posthog.fullname" . }}
     release: {{ .Release.Name }}
-    role: kafka 
-{{- end }} 
+    role: kafka
+{{- end }}

--- a/charts/posthog/templates/metrics-deployment.yaml
+++ b/charts/posthog/templates/metrics-deployment.yaml
@@ -3,11 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-metrics
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -38,7 +34,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-metrics
-        args: 
+        args:
           - "--statsd.listen-udp=:9125"
           - "--web.listen-address=:9102"
         image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -74,4 +70,4 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }} 
+{{- end }}

--- a/charts/posthog/templates/metrics-prometheus.yaml
+++ b/charts/posthog/templates/metrics-prometheus.yaml
@@ -6,11 +6,7 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/posthog/templates/metrics-service.yaml
+++ b/charts/posthog/templates/metrics-service.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-metrics
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 {{- if .Values.metrics.service.labels }}
 {{ toYaml .Values.metrics.service.labels | indent 4 }}
 {{- end }}
@@ -26,4 +22,4 @@ spec:
     app: {{ template "posthog.fullname" . }}
     release: {{ .Release.Name }}
     role: metrics
-{{- end }} 
+{{- end }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -2,20 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-migrate"
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
-    "helm.sh/hook-weight": "0"
+  name: {{ printf "%s-migrate-%s" .Release.Name (now | date "2006-01-02-15-04-05") }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   template:
     metadata:
-      name: "{{ .Release.Name }}-migrate"
+      name: {{ printf "%s-migrate-%s" .Release.Name (now | date "2006-01-02-15-04-05") }}
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
@@ -149,4 +142,6 @@ spec:
           value: {{ template "posthog.helmInstallInfo" . }}
         resources:
 {{ toYaml .Values.hooks.migrate.resources | indent 10 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -3,11 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -3,11 +3,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/charts/posthog/templates/pgbouncer-service.yaml
+++ b/charts/posthog/templates/pgbouncer-service.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   type: "ClusterIP"
   ports:

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -3,17 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-plugins
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep"
-    "helm.sh/hook-weight": "1"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -150,4 +141,7 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -3,11 +3,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-plugins
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/charts/posthog/templates/secrets.yaml
+++ b/charts/posthog/templates/secrets.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "posthog.fullname" . }}
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 type: Opaque
 data:
   {{- if $previous }}

--- a/charts/posthog/templates/serviceaccount.yaml
+++ b/charts/posthog/templates/serviceaccount.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "posthog.serviceAccountName" . }}
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -3,17 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-web
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep"
-    "helm.sh/hook-weight": "1"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -233,4 +224,7 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -2,12 +2,7 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "posthog.fullname" . }}-web
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/charts/posthog/templates/web-service.yaml
+++ b/charts/posthog/templates/web-service.yaml
@@ -3,19 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-web
-  annotations:
-   {{- range $key, $value := .Values.service.annotations }}
-     {{ $key }}: {{ $value | quote }}
-   {{- end }}
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -3,17 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-worker
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep"
-    "helm.sh/hook-weight": "1"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -186,4 +177,7 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -3,11 +3,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-worker
-  labels:
-    app: {{ template "posthog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/charts/posthog/tests/ingress.yaml
+++ b/charts/posthog/tests/ingress.yaml
@@ -48,6 +48,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -68,6 +70,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -84,6 +88,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: gce
             kubernetes.io/ingress.global-static-ip-name: posthog
             networking.gke.io/managed-certificates: RELEASE-NAME-gke-cert
@@ -102,6 +108,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: gce
             kubernetes.io/ingress.global-static-ip-name: ip_custom_name
             networking.gke.io/managed-certificates: RELEASE-NAME-gke-cert
@@ -116,6 +124,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -130,6 +140,8 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -146,5 +158,7 @@ tests:
       - equal:
           path: metadata.annotations
           value:
+            meta.helm.sh/release-name: RELEASE-NAME
+            meta.helm.sh/release-namespace: NAMESPACE
             key1: value1
             key2: value2

--- a/charts/posthog/tests/kafka-service.yaml
+++ b/charts/posthog/tests/kafka-service.yaml
@@ -26,28 +26,6 @@ tests:
       - isKind:
           of: Service
 
-  - it: should have the correct metadata values
-    set:
-      kafka.service.enabled: true
-    asserts:
-      - hasDocuments:
-          count: 1
-      - matchRegex:
-          path: metadata.name
-          pattern: -kafka$
-      - equal:
-          path: metadata.labels.app
-          value: RELEASE-NAME-posthog
-      - matchRegex:
-          path: metadata.labels.chart
-          pattern: ^posthog-
-      - equal:
-          path: metadata.labels.release
-          value: RELEASE-NAME
-      - equal:
-          path: metadata.labels.heritage
-          value: Helm
-
   - it: should have the correct optional metadata values
     set:
       kafka.service.enabled: true

--- a/charts/posthog/tests/migrate-job.yaml
+++ b/charts/posthog/tests/migrate-job.yaml
@@ -1,4 +1,4 @@
-suite: PostHog events deployment definition
+suite: PostHog migrate job definition
 templates:
   - templates/migrate.job.yaml
   - templates/secrets.yaml

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -14,10 +14,6 @@ redis:
   password: ""
 
 # Use small PVC in CI
-# TODO: remove clickhouseOperator after update CI pass
-clickhouseOperator:
-  storage: 1Gi
-
 clickhouse:
   persistence:
     size: 1Gi


### PR DESCRIPTION
## Description
1️⃣ Remove all the (possible) Helm annotations.
2️⃣ Add new `initContainer` definition to all the PostHog Deployments.
3️⃣ Group and cleanup `metadata.labels`.

## Why

1️⃣ There isn't a reason to have those hooks and they are breaking our chart in different ways (e.g. breaking a clean run of install + uninstall as due to those hooks we break some dependencies before removal, run updates without downtime, etc...). We are keeping the bare minimum annotations we need (for now 1).

2️⃣ Now that we don't enforce anymore a deployment order via Helm, let's introduce an `initContainer` definition to avoid Deployment pods crashing and restarting till all the external dependencies are not ready.

3️⃣ I took the opportunity to cleanup and standardise a bit this part.  

Release notes are available here https://github.com/PostHog/posthog.com/pull/2795

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
1. CI is ✅ (except for the upgrade test as we need to perform some manual steps before running the upgrade)
1. CI for e2e test is also ✅ (I've triggered [DO](https://github.com/PostHog/charts-clickhouse/runs/4883398969?check_suite_focus=true), [GCP](https://github.com/PostHog/charts-clickhouse/runs/4883394313?check_suite_focus=true) and [AWS](https://github.com/PostHog/charts-clickhouse/runs/4883385445?check_suite_focus=true) tests manually) 
2. I've manually tested the upgrade path locally: Helm install from `main` -> manual upgrade steps -> Helm install from this branch -> ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works