### PR TITLE
[DigitalOcean 1 click] Use secure settings by default

### DIFF
--- a/do_1_click_values.yaml
+++ b/do_1_click_values.yaml
@@ -4,6 +4,5 @@ deploymentType: "DigitalOcean 1-click"
 ingress:
   nginx:
     enabled: true
-    redirectToTLS: false
-web:
-  secureCookies: false
+cert-manager:
+  enabled: true

--- a/do_1_click_values.yaml
+++ b/do_1_click_values.yaml
@@ -5,6 +5,5 @@ ingress:
   nginx:
     enabled: true
     redirectToTLS: false
-  letsencrypt: false
 web:
   secureCookies: false


### PR DESCRIPTION
## Description
Align _DigitalOcean 1 click setup_ to the _manual DO setup_.

The DO 1 click-setup is currently a two step process as described in our [docs](https://posthog.com/docs/self-host/deploy/digital-ocean). This is due to a limitation in DO marketplace API as it is not yet possible to provide parameters to DigitalOcean, so we need a post-install step to enable TLS.

This PR aligns `values.yaml` files between the two setups, after this change the only diff will be `ingress.hostname: <your-hostname>` missing (but that's expected as we can't use custom params in the 1 click install).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
