### PR TITLE
e2e - DigitalOcean 1-click (install)

### DIFF
--- a/.github/workflows/test-install-digital-ocean.yaml
+++ b/.github/workflows/test-install-digital-ocean.yaml
@@ -26,6 +26,7 @@ jobs:
         doctl k8s clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --region fra1 \
+          --version 1.21.5-do.0 \
           --tag="provisioned_by:github_action" \
           --size s-2vcpu-2gb \
           --count 3 \

--- a/.github/workflows/test-install-digital-ocean.yaml
+++ b/.github/workflows/test-install-digital-ocean.yaml
@@ -1,0 +1,82 @@
+name: e2e - DigitalOcean 1-click (install)
+
+on: [push, pull_request]
+
+jobs:
+  do-install:
+    runs-on: ubuntu-latest
+    if: github.repository == 'PostHog/charts-clickhouse'
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+    - name: Declare variables that we can share across steps
+      id: vars
+      run: |
+        echo "::set-output name=k8s_cluster_name::helm-e2e-testing-do-1-click-$(git rev-parse --short HEAD)"
+
+    - name: Deploy a new k8s cluster
+      run: |
+        doctl k8s clusters create \
+          ${{ steps.vars.outputs.k8s_cluster_name }} \
+          --region fra1 \
+          --tag="provisioned_by:github_action" \
+          --size s-2vcpu-2gb \
+          --count 3 \
+          --wait \
+          --1-clicks \
+          posthog
+
+    # Wait for the DigitalOcean marketplace to complete the installation
+    #
+    # Despite the --wait flag used in the command above
+    # there is no guarantee the PostHog app will be deployed
+    # when the command returns. With this workaround we wait
+    # until the Kubernetes keyspace is created.
+    #
+    # ref: https://github.com/digitalocean/doctl/issues/1063
+    #
+    # Why can't we directly use the 'action-k8s-await-workloads' step below?
+    # Because it's not working for this use case
+    #
+    # ref: https://github.com/jupyterhub/action-k8s-await-workloads/issues/38
+    #
+    - name: Workaround - wait until the 'posthog' pods are ready
+      timeout-minutes: 15
+      run: |
+        echo "Waiting for pods to be ready..."
+        while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+        do
+          echo "  sleeping 10 seconds"
+          sleep 10
+        done
+        echo "All pods are now ready!"
+
+    - name: Wait until all the resources are fully deployed in k8s
+      uses: jupyterhub/action-k8s-await-workloads@main
+      with:
+        namespace: "posthog"
+        timeout: 300
+        max-restarts: 10
+
+    # TODO
+    # - setup ingestion test
+    # - run ingestion test
+    # - run k8s spec test
+
+    - name: Emit k8s namespace report
+      uses: jupyterhub/action-k8s-namespace-report@v1
+      if: always()
+      with:
+        namespace: "posthog"
+
+    - name: Delete the k8s cluster and all associated resources (LB, volumes, ...)
+      if: always()
+      run: |
+        doctl k8s cluster delete --dangerous --force ${{ steps.vars.outputs.k8s_cluster_name }}

--- a/.github/workflows/test-install-digital-ocean.yaml
+++ b/.github/workflows/test-install-digital-ocean.yaml
@@ -1,6 +1,6 @@
 name: e2e - DigitalOcean 1-click (install)
 
-on: [push, pull_request]
+on: push
 
 jobs:
   do-install:

--- a/.github/workflows/test-install-digital-ocean.yaml
+++ b/.github/workflows/test-install-digital-ocean.yaml
@@ -29,7 +29,7 @@ jobs:
           --version 1.21.5-do.0 \
           --tag="provisioned_by:github_action" \
           --size s-2vcpu-2gb \
-          --count 3 \
+          --count 2 \
           --wait \
           --1-clicks \
           posthog


### PR DESCRIPTION
## Description
Add a new test to verify the DigitalOcean 1-click install. This workflow creates a new K8S cluster in DigitalOcean for each push this repo, waits until resources are ready to then reprovision it when the test is completed. 

I've opted for this solution instead of using a single cluster where to install/update/uninstall (as requested in https://github.com/PostHog/charts-clickhouse/issues/183) as there's no way atm to run a clean PostHog uninstall. Starting from scratch all the times is a bit more deterministic (from a cost perspective I don't think this should be an issue, the cluster costs $45/month and the test suite runs in ~ 10 min post cluster creation -> 45 / 43800 * 10 = ~ $0.01 per test).

This e2e test is not fully complete as we should also make sure:

1. all the expected k8s resources are in the state we expect (goal is to have a test suite using something like `vapor-ware/kubetest`)
2. ingestion test runs successfully (we have those but we need to adjust them a bit in order to do ingestion & checks via the LB -> see https://github.com/PostHog/charts-clickhouse/pull/189)
3. TLS setup is working (step 2 of "securing DO installation" guide. I need to figure out the domain management part yet)

I’m going to take ☝️ as separate PRs as they are pretty big and not exactly part of this task (they will be also shared across the other e2e tests).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
See CI

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works