### PR TITLE
Improvements to the "Test chart" suite

### DIFF
--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: (Upgrade) Install our helm chart from main branch
         if: matrix.test == 'upgrade'
         run: |
-          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./main/charts/posthog
+          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./main/charts/posthog --wait --wait-for-jobs
 
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install our helm chart
         run: |
-          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./charts/posthog
+          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./charts/posthog --wait --wait-for-jobs
 
       # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads
       - name: Await all deployments to start

--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -17,12 +17,7 @@ jobs:
         # We run this job multiple times with different parameterization
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
-        #
-        # k3s-version: https://github.com/rancher/k3s/tags
-        # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: v1.22
-            test: install
           - k3s-channel: v1.21
             test: install
           - k3s-channel: v1.20
@@ -30,8 +25,8 @@ jobs:
           - k3s-channel: v1.19
             test: install
 
-          # We run two upgrade tests where we first install an already released
-          # Helm chart version and then upgrades to the version we are now
+          # We run an upgrade test where we first install an already released
+          # Helm chart version and then upgrade to the version we are now
           # testing. We test upgrading from the latest main version.
           #
           # It can be very useful to see the "Helm diff" step's output from the
@@ -48,10 +43,9 @@ jobs:
       # ref: https://github.com/jupyterhub/action-k3s-helm/
       - uses: jupyterhub/action-k3s-helm@v1
         with:
-          k3s-channel: v1.19
+          k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false
           traefik-enabled: false
-          docker-enabled: true
 
       - uses: actions/checkout@v2
         if: matrix.test == 'upgrade'
@@ -62,7 +56,7 @@ jobs:
       - name: (Upgrade) Install our helm chart from main branch
         if: matrix.test == 'upgrade'
         run: |
-          helm upgrade --install posthog main/charts/posthog --timeout 20m -f ci/values.yaml --debug
+          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./main/charts/posthog
 
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
@@ -72,7 +66,7 @@ jobs:
       - name: "(Upgrade) Helm diff ${{ matrix.upgrade-from }} chart with local chart"
         if: matrix.test == 'upgrade'
         run: |
-          helm diff upgrade --install posthog charts/posthog -f ci/values.yaml --debug
+          helm diff upgrade --install -f ci/values.yaml --namespace posthog posthog ./charts/posthog
 
       - name: "(Upgrade) Await chart install"
         if: matrix.test == 'upgrade'
@@ -83,7 +77,7 @@ jobs:
 
       - name: Install our helm chart
         run: |
-          helm upgrade --install posthog charts/posthog --timeout 20m -f ci/values.yaml
+          helm upgrade --install -f ci/values.yaml --timeout 10m --create-namespace --namespace posthog posthog ./charts/posthog
 
       # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads
       - name: Await all deployments to start
@@ -92,16 +86,16 @@ jobs:
           timeout: 900
           max-restarts: 15
 
-      - name: Setup for ingestion test
+      - name: Setup PostHog for the ingestion test
+        run: ./ci/setup_ingestion_test.sh
+
+      - name: Fetch PostHog endpoints to use for the ingestion test
         run: |
-          export WEB_POD=$(kubectl get pods -l role=web -o jsonpath="{.items[].metadata.name}")
-          kubectl exec $WEB_POD -- python manage.py setup_dev --no-data
+          POSTHOG_API_ADDRESS=$(kubectl get svc -n posthog posthog-web -o jsonpath="{.spec.clusterIP}")
+          POSTHOG_EVENTS_ADDRESS=$(kubectl get svc -n posthog posthog-events -o jsonpath="{.spec.clusterIP}")
 
-          echo "POSTHOG_WEB_HOSTNAME=$(kubectl get svc posthog-web -o jsonpath="{.spec.clusterIP}")" >> $GITHUB_ENV
-          echo "POSTHOG_EVENTS_HOSTNAME=$(kubectl get svc posthog-events -o jsonpath="{.spec.clusterIP}")" >> $GITHUB_ENV
-
-          # Sleep until web service is ready to respond
-          sleep 20
+          echo "POSTHOG_API_ENDPOINT=http://${POSTHOG_API_ADDRESS}:8000" | tee -a "$GITHUB_ENV"
+          echo "POSTHOG_EVENT_ENDPOINT=http://${POSTHOG_EVENTS_ADDRESS}:8000" | tee -a "$GITHUB_ENV"
 
       # GitHub Action reference: https://github.com/k6io/action
       - name: Run ingestion test using k6

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.19.0-0 < 1.22.0-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">=1.19.0-0 < 1.22.0-0"
+kubeVersion: ">= 1.19.0-0 < 1.22.0-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [PostHog](https://posthog.com/) deployment on a [Kuberne
 See deployment instructions on [posthog.com/docs/self-host](https://posthog.com/docs/self-host).
 
 ## Prerequisites
-- Kubernetes 1.19+
+- Kubernetes >=1.19.0 < 1.22.0
 - Helm 3+
 
 ## Development

--- a/ci/k6-ingestion-test.js
+++ b/ci/k6-ingestion-test.js
@@ -3,15 +3,14 @@ import {check, sleep, fail} from 'k6'
 import { Gauge } from 'k6/metrics'
 import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
 
-const POSTHOG_ENDPOINT = __ENV.POSTHOG_ENDPOINT
-const POSTHOG_API_ENDPOINT = __ENV.POSTHOG_API_ENDPOINT || POSTHOG_ENDPOINT
-const POSTHOG_EVENT_ENDPOINT = __ENV.POSTHOG_EVENT_ENDPOINT || POSTHOG_ENDPOINT
+const POSTHOG_API_ENDPOINT = __ENV.POSTHOG_API_ENDPOINT
+const POSTHOG_EVENT_ENDPOINT = __ENV.POSTHOG_EVENT_ENDPOINT
 
 const captureURL = new URL(`${POSTHOG_EVENT_ENDPOINT}/e/`);
 const apiURL = new URL(`${POSTHOG_API_ENDPOINT}/api/insight/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`);
 
 if (POSTHOG_EVENT_ENDPOINT == null && POSTHOG_API_ENDPOINT == null) {
-  fail("Please specify env variable POSTHOG_ENDPOINT or POSTHOG_EVENT_ENDPOINT and POSTHOG_API_ENDPOINT")
+  fail("Please specify env variables POSTHOG_EVENT_ENDPOINT and POSTHOG_API_ENDPOINT")
 }
 
 let eventsIngested = new Gauge('events_ingested')

--- a/ci/k6-ingestion-test.js
+++ b/ci/k6-ingestion-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http'
 import {check, sleep, fail} from 'k6'
 import { Gauge } from 'k6/metrics'
-import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
+import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js'
 
 const POSTHOG_API_ENDPOINT = __ENV.POSTHOG_API_ENDPOINT
 const POSTHOG_EVENT_ENDPOINT = __ENV.POSTHOG_EVENT_ENDPOINT

--- a/ci/k6-ingestion-test.js
+++ b/ci/k6-ingestion-test.js
@@ -6,11 +6,11 @@ import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
 const POSTHOG_API_ENDPOINT = __ENV.POSTHOG_API_ENDPOINT
 const POSTHOG_EVENT_ENDPOINT = __ENV.POSTHOG_EVENT_ENDPOINT
 
-const captureURL = new URL(`${POSTHOG_EVENT_ENDPOINT}/e/`);
-const apiURL = new URL(`${POSTHOG_API_ENDPOINT}/api/insight/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`);
+const captureURL = new URL(`${POSTHOG_EVENT_ENDPOINT}/e/`)
+const apiURL = new URL(`${POSTHOG_API_ENDPOINT}/api/insight/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`)
 
-if (POSTHOG_EVENT_ENDPOINT == null && POSTHOG_API_ENDPOINT == null) {
-  fail("Please specify env variables POSTHOG_EVENT_ENDPOINT and POSTHOG_API_ENDPOINT")
+if (!POSTHOG_API_ENDPOINT || !POSTHOG_EVENT_ENDPOINT) {
+  fail("Please specify env variables POSTHOG_API_ENDPOINT and POSTHOG_API_ENDPOINT")
 }
 
 let eventsIngested = new Gauge('events_ingested')

--- a/ci/k6-ingestion-test.js
+++ b/ci/k6-ingestion-test.js
@@ -1,6 +1,18 @@
 import http from 'k6/http'
-import {check, group, sleep} from 'k6'
+import {check, sleep, fail} from 'k6'
 import { Gauge } from 'k6/metrics'
+import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
+
+const POSTHOG_ENDPOINT = __ENV.POSTHOG_ENDPOINT
+const POSTHOG_API_ENDPOINT = __ENV.POSTHOG_API_ENDPOINT || POSTHOG_ENDPOINT
+const POSTHOG_EVENT_ENDPOINT = __ENV.POSTHOG_EVENT_ENDPOINT || POSTHOG_ENDPOINT
+
+const captureURL = new URL(`${POSTHOG_EVENT_ENDPOINT}/e/`);
+const apiURL = new URL(`${POSTHOG_API_ENDPOINT}/api/insight/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`);
+
+if (POSTHOG_EVENT_ENDPOINT == null && POSTHOG_API_ENDPOINT == null) {
+  fail("Please specify env variable POSTHOG_ENDPOINT or POSTHOG_EVENT_ENDPOINT and POSTHOG_API_ENDPOINT")
+}
 
 let eventsIngested = new Gauge('events_ingested')
 
@@ -28,19 +40,18 @@ export let options = {
 }
 
 export function captureEvents() {
-  const res = http.post(`http://${__ENV.POSTHOG_EVENTS_HOSTNAME}:8000/e/`, JSON.stringify({
+  const res = http.post(captureURL.toString(), JSON.stringify({
     api_key: 'e2e_token_1239',
     event: 'k6s_custom_event',
     distinct_id: __VU
   }));
 
   check(res, { 'status 200': (r) => r.status === 200 })
-
   sleep(0.1)
 }
 
 export function checkIngestion() {
-  const res = http.get(`http://${__ENV.POSTHOG_WEB_HOSTNAME}:8000/api/insight/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`, {
+  const res = http.get(apiURL.toString(), {
     headers: {
       Authorization: `Bearer e2e_demo_api_key`
     }
@@ -58,6 +69,5 @@ export function checkIngestion() {
   })
 
   eventsIngested.add(count)
-
   sleep(0.5)
 }

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -2,9 +2,6 @@
 #
 # This script setup PostHog in DEV mode to do ingestion testing
 #
-sleep 20
 
 WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadata.name}")
 kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data
-
-sleep 20

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+#
+# This script setup PostHog in DEV mode to do ingestion testing
+#
+sleep 20
+
+WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadata.name}")
+kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data
+
+sleep 20

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -3,5 +3,7 @@
 # This script setup PostHog in DEV mode to do ingestion testing
 #
 
+sleep 10 # TODO: remove this. It was added as the command below often errors with 'unable to upgrade connection: container not found ("posthog-web")'
+
 WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadata.name}")
 kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -1,8 +1,5 @@
 cloud: k3s
 
-image:
-  tag: latest
-
 ingress:
   type: nginx
   hostname: test.yourcloud.net
@@ -12,15 +9,7 @@ ingress:
     enabled: false
 
 clickhouseOperator:
-  enabled: true
-  namespace: default
   storage: 2Gi
-
-plugins:
-  replicacount: 1
-
-worker:
-  replicacount: 1
 
 redis:
   usePassword: false

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -1,15 +1,16 @@
 cloud: k3s
 
 ingress:
-  type: nginx
-  hostname: test.yourcloud.net
-  path: /*
-  letsencrypt: false
   nginx:
-    enabled: false
+    enabled: true
+    redirectToTLS: false
+  letsencrypt: false
+
+web:
+  secureCookies: false
 
 clickhouseOperator:
-  storage: 2Gi
+  storage: 1Gi
 
 redis:
   usePassword: false
@@ -17,6 +18,3 @@ redis:
   master:
     persistence:
       size: 1Gi
-
-web:
-  secureCookies: false


### PR DESCRIPTION
## Description
This PR makes a couple of changes to the `Test chart` suite and a macro change in our helm chart K8s version compatibility:

1. the most important is that we weren't actually testing this chart against multiple k8s versions. I've now removed 1.22 from the tests as it's currently failing (the ClickHouse operator is using a deprecated API)

1. the test now creates and uses the `posthog` namespace (like we suggest in our docs)
 
1. the k6 ingestion test is now more configurable as we can now have separate endpoints for the capture and API stack. This will be useful when we'll do ingestion testing also on other platforms (e.g. DigitalOcean) when we'll hit a load balancer and not a service ClusterIP.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
