### PR TITLE
Changes to `.github/ISSUE_TEMPLATE` config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,33 +1,33 @@
 ---
-name: Bug report
-about: Something not working as expected? Let us look into it
+name: "\U0001F41B Bug report"
+about: Create a report to help us repair something that is currently broken
 labels: bug
 ---
 
 ## Bug description
-
-*Please describe.*
-
-*If helm install or upgrade failed include your `values.yaml` (without sensitive data) and output from `kubectl describe nodes`.*
+<!-- Use this section to clearly and concisely describe the bug. -->
 
 ## Expected behavior
+<!-- Tell us what you thought would happen. -->
 
-
+## Actual behavior
+<!-- Tell us what actually happens. -->
 
 ## How to reproduce
-
+<!-- Use this section to describe the steps that a user would take to experience this bug. -->
 1.
 2.
 3.
 
 ## Environment
+<!--
+Tell us a little about your environment.
+Please include information about how you installed or updated
+-->
 
-- [ ] Deployment platform (gcp/aws/...): _please provide_
+- [ ] Deployment platform (AWS/Azure/DigitalOcean/GCP/...): _please provide_
 - [ ] Chart version/commit: _please provide_
 - [ ] Posthog version: _please provide_
 
 ## Additional context
-
-
-
-#### *Thank you* for your bug report – we love squashing them!
+<!-- Add any relevant additional information here, if any -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: "\U0001F914 All other questions, including if you're not sure what to do."
+    url: https://posthog.com/slack
+    about: Search on our community Slack group for similar questions or ask for help there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,3 +10,6 @@ labels: enhancement, feature
 
 ### Alternative options
 <!-- Use this section to describe alternative options and why you've decided on the proposed feature above. -->
+
+## Additional context
+<!-- Add additional information here, if any -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,24 +1,12 @@
 ---
-name: Feature request
-about: Suggest a feature
+name: "\U0001F680 Feature request"
+about: Suggest a new feature or change
 labels: enhancement, feature
 
 ---
 
-## Is your feature request related to a problem?
+### Proposed change
+<!-- Use this section to describe the feature you'd like to be added. -->
 
-*Please describe.*
-
-## Describe the solution you'd like
-
-
-
-## Describe alternatives you've considered
-
-
-
-## Additional context
-
-
-
-#### *Thank you* for your feature request – we love each and every one!
+### Alternative options
+<!-- Use this section to describe alternative options and why you've decided on the proposed feature above. -->


### PR DESCRIPTION
Mimic what I found [here](https://github.com/jupyterhub/action-k8s-await-workloads/issues/new/choose) as I really like the format! 