### PR TITLE
enable TLS connection from pgbouncer to hosted PG

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Set postgres password b64
 Set postgres URL
 */}}
 {{- define "posthog.postgresql.url" -}}
-    postgres://{{- .Values.postgresql.postgresqlUsername -}}:{{- template "posthog.postgresql.password" . -}}@{{- template "posthog.postgresql.host" .  -}}:{{- template "posthog.postgresql.port" . -}}/{{- .Values.postgresql.postgresqlDatabase }}
+    postgres://{{- .Values.postgresql.postgresqlUsername -}}:{{- template "posthog.postgresql.password" . -}}@{{- template "posthog.postgresql.host" .  -}}:{{- template "posthog.postgresql.port" . -}}/{{- .Values.postgresql.postgresqlDatabase -}}
 {{- end -}}
 
 {{/*

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -68,6 +68,8 @@ spec:
           value: "1000"
         - name: POOL_MODE
           value: "transaction"
+        - name: SERVER_TLS_SSLMODE 
+          value: {{ .Values.postgresql.sslmode }}
 {{- if .Values.pgbouncer.env }}
 {{ toYaml .Values.pgbouncer.env | indent 8 }}
 {{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -344,6 +344,8 @@ ingress:
 postgresql:
   # -- Install postgres server on kubernetes (see below)
   enabled: true
+  # -- sslmode for connection - defaults to prefer
+  sslmode: prefer
   # -- Name override for postgresql app
   nameOverride: posthog-postgresql
   # -- Postgresql database name


### PR DESCRIPTION
## Description
This is required if you use hosted PostgreSQL like RDS
