### PR TITLE
Fix redis url bug

### DIFF
--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -89,16 +89,16 @@ spec:
           value: {{ template "posthog.pgbouncer.url" . }}
         - name: USING_PGBOUNCER
           value: 'true'
-          {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
-        - name: POSTHOG_REDIS_PASSWORD
-          value: {{ .Values.redis.password | quote }}
-        - name: REDIS_URL
-          value: "redis://:$(POSTHOG_REDIS_PASSWORD)@{{- template "posthog.redis.host" . -}}:{{-  template "posthog.redis.port" . -}}"
-        {{- end }}
         - name: POSTHOG_REDIS_HOST
           value: {{ template "posthog.redis.host" . }}
         - name: POSTHOG_REDIS_PORT
           value: {{ include "posthog.redis.port" . | quote }}
+          {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
+        - name: POSTHOG_REDIS_PASSWORD
+          value: {{ .Values.redis.password | quote }}
+        - name: REDIS_URL
+          value: "redis://:$(POSTHOG_REDIS_PASSWORD)@$(POSTHOG_REDIS_HOST):$(POSTHOG_REDIS_PORT)"
+        {{- end }}
         {{- if .Values.statsd.enabled }}
         - name: STATSD_HOST
           value: {{ template "posthog.statsd.host" . }}

--- a/charts/posthog/tests/redis.yaml
+++ b/charts/posthog/tests/redis.yaml
@@ -1,0 +1,63 @@
+suite: Redis
+templates:
+  - templates/plugins-deployment.yaml
+  - templates/secrets.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+
+tests:
+  - it: should have correct envs setup with default setup
+    template: templates/plugins-deployment.yaml
+    set:
+      cloud: "other"
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            {"name": "REDIS_URL", "value": "redis://:$(POSTHOG_REDIS_PASSWORD)@$(POSTHOG_REDIS_HOST):$(POSTHOG_REDIS_PORT)"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_HOST", "value": "my-release-posthog-redis-master"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_PORT", "value": "6379"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_PASSWORD", "value": null}
+  - it: should have correct envs setup with external redis
+    template: templates/plugins-deployment.yaml
+    set:
+      cloud: "other"
+      redis.enabled: false
+      redis.host: my-redis-host
+      redis.port: 12345
+      redis.password: my-redis-pass
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            {"name": "REDIS_URL", "value": "redis://:$(POSTHOG_REDIS_PASSWORD)@$(POSTHOG_REDIS_HOST):$(POSTHOG_REDIS_PORT)"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_HOST", "value": "my-redis-host"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_PORT", "value": "12345"}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+             {"name": "POSTHOG_REDIS_PASSWORD", "value": "my-redis-pass"}
+
+


### PR DESCRIPTION

## Description

Closes https://github.com/PostHog/charts-clickhouse/issues/194

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
```
helm template -f customer.values.yaml posthog ~/Posthog/charts-clickhouse/charts/posthog | grep "REDIS_URL" -A2
        - name: REDIS_URL
          value: "redis://:$(POSTHOG_REDIS_PASSWORD)@$(POSTHOG_REDIS_HOST):$(POSTHOG_REDIS_PORT)"
        - name: CLICKHOUSE_DATABASE
```

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
