### PR TITLE
e2e - Google Cloud Platform (install)

### DIFF
--- a/.github/workflows/test-digitalocean-1-click-install.yaml
+++ b/.github/workflows/test-digitalocean-1-click-install.yaml
@@ -106,7 +106,7 @@
 #       with:
 #         filename: ci/k6-ingestion-test.js
 
-#     - name: Delete the k8s cluster and all associated resources (LB, volumes, ...)
+#     - name: Delete the k8s cluster and all the associated resources
 #       if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
 #       run: |
 #         doctl k8s cluster delete --dangerous --force ${{ steps.vars.outputs.k8s_cluster_name }}

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -7,7 +7,7 @@
 #
 name: e2e - DigitalOcean (install)
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   do-install:
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Install doctl
+    - name: Install doctl to manage 'posthog.cc' DNS
       uses: digitalocean/action-doctl@v2
       with:
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -81,8 +81,8 @@ jobs:
         load_balancer_external_ip=""
         while [ -z "$load_balancer_external_ip" ];
         do
+          echo "  sleeping 10 seconds" && sleep 10
           load_balancer_external_ip=$(kubectl get ingress -n posthog posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-          [ -z "$load_balancer_external_ip" ] && echo "  sleeping 10 seconds" && sleep 10
         done
         echo "The DigitalOcean Load Balancer is now ready!"
 
@@ -108,6 +108,7 @@ jobs:
           --record-data "$load_balancer_external_ip"
 
     - name: Wait for the Let's Encrypt certificate to be issued and deployed
+      id: tls_certificate_creation
       run: |
         echo "Wait for the Let's Encrypt certificate to be issued and deployed..."
         while ! kubectl wait --for=condition=Ready --timeout=60s certificaterequest --all -n posthog > /dev/null 2>&1
@@ -129,13 +130,19 @@ jobs:
       with:
         filename: ci/k6-ingestion-test.js
 
-    - name: Delete the k8s cluster and all associated resources (LB, volumes, ...)
+    - name: Delete the k8s cluster and all the associated resources
       if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
       run: |
-        doctl k8s cluster delete --dangerous --force ${{ steps.vars.outputs.k8s_cluster_name }}
+        doctl k8s cluster delete \
+          --dangerous \
+          --force \
+          ${{ steps.vars.outputs.k8s_cluster_name }}
 
     - name: Delete the DNS record
       if: ${{ always() && steps.dns_creation.outcome == 'success' }}
       run: |
         DNS_RECORD_ID=$(doctl compute domain records list posthog.cc --no-header --format ID,Name | grep ${{ steps.vars.outputs.dns_record }} | awk '{print $1}')
-        doctl compute domain records delete --force posthog.cc "$DNS_RECORD_ID"
+        doctl compute domain records delete \
+          posthog.cc \
+          --force \
+          "$DNS_RECORD_ID"

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -155,10 +155,6 @@ jobs:
     #
     # see: https://stackoverflow.com/questions/44584270/
     #
-    - name: Run ingestion test using k6
-      run: |
-        sleep 30
-
     # - name: Run ingestion test using k6
     #   uses: k6io/action@v0.2.0
     #   with:

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -7,7 +7,7 @@
 #
 name: e2e - Google Cloud Platform (install)
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   gcp-install:
@@ -25,7 +25,7 @@ jobs:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
 
-    - name: Install doctl
+    - name: Install doctl to manage 'posthog.cc' DNS
       uses: digitalocean/action-doctl@v2
       with:
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
         gcloud container clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --project ${{ secrets.GCP_PROJECT_ID }} \
-          --region europe-west4 \
+          --region us-central1 \
           --cluster-version 1.21 \
           --labels="provisioned_by=github_action" \
           --machine-type e2-medium \
@@ -169,7 +169,7 @@ jobs:
       run: |
         gcloud container clusters delete \
           --project ${{ secrets.GCP_PROJECT_ID }} \
-          --region europe-west4 \
+          --region us-central1 \
           --quiet \
           ${{ steps.vars.outputs.k8s_cluster_name }}
 

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -1,0 +1,200 @@
+#
+# This is an e2e test to deploy PostHog on Google Cloud Platform using Helm.
+#
+# TODO:
+# - run k8s spec test
+# - run action only when necessary
+#
+name: e2e - Google Cloud Platform (install)
+
+on: push
+
+jobs:
+  gcp-install:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'PostHog/charts-clickhouse'
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up GCP Cloud SDK
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
+
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+    - name: Declare variables that we can share across steps
+      id: vars
+      run: |
+        TEST_NAME="helm-test-e2e-gcp-install-$(git rev-parse --short HEAD)"
+        echo "::set-output name=k8s_cluster_name::${TEST_NAME}"
+        echo "::set-output name=dns_record::${TEST_NAME}"
+        echo "::set-output name=fqdn_record::${TEST_NAME}.posthog.cc"
+
+    - name: Deploy a new k8s cluster
+      id: k8s_cluster_creation
+      run: |
+        gcloud container clusters create \
+          ${{ steps.vars.outputs.k8s_cluster_name }} \
+          --project ${{ secrets.GCP_PROJECT_ID }} \
+          --region europe-west4 \
+          --cluster-version 1.21 \
+          --labels="provisioned_by=github_action" \
+          --machine-type e2-medium \
+          --num-nodes 2
+
+        # note: num-nodes will be created in each zone, such that if you specify
+        # --num-nodes=4 and choose two locations 8 nodes will be created.
+
+    - name: Create new GCP global static IP address
+      id: static_ip_creation
+      # note: we need to create the IP address first in order
+      # to get the load balancer successfully provisioned
+      run: |
+        gcloud compute addresses create \
+          --project ${{ secrets.GCP_PROJECT_ID }} \
+          --global \
+          ${{ steps.vars.outputs.dns_record }}
+
+    - name: Create the DNS record
+      id: dns_creation
+      run: |
+        # Get the global static IP address
+        global_static_ip=$(gcloud compute addresses list --project ${{ secrets.GCP_PROJECT_ID }} --global --filter=name:${{ steps.vars.outputs.dns_record }} --format="value(ADDRESS)")
+
+        # Create the DNS record
+        doctl compute domain records create \
+          posthog.cc \
+          --record-type A \
+          --record-ttl 60 \
+          --record-name "${{ steps.vars.outputs.dns_record }}" \
+          --record-data "$global_static_ip"
+
+    - name: Install PostHog using the Helm chart
+      run: |
+        helm upgrade --install \
+          -f ci/values/google_cloud_platform.yaml \
+          --set "ingress.hostname=${{ steps.vars.outputs.fqdn_record }}" \
+          --set "ingress.gcp.ip_name=${{ steps.vars.outputs.dns_record }}" \
+          --timeout 20m \
+          --create-namespace \
+          --namespace posthog \
+          posthog ./charts/posthog \
+          --wait-for-jobs \
+          --wait
+
+    #
+    # Wait for all k8s resources to be ready.
+    #
+    # Despite the --wait flag used in the command above
+    # there is no guarantee that all the resources will be deployed
+    # when the command returns.
+    #
+    #
+    # Why can't we directly use the 'action-k8s-await-workloads' step below?
+    # Because it's not working for this use case
+    #
+    # ref: https://github.com/jupyterhub/action-k8s-await-workloads/issues/38
+    #
+    - name: Workaround - wait for all the k8s resources to be ready
+      timeout-minutes: 15
+      run: |
+        echo "Waiting for pods to be ready..."
+        while ! kubectl wait --for=condition=Ready pods --timeout=60s --all -n posthog > /dev/null 2>&1
+        do
+          echo "  pods are not yet ready"
+        done
+        echo "All pods are now ready!"
+
+        echo "Waiting for the GCP Load Balancer to be ready..."
+        load_balancer_external_ip=""
+        while [ -z "$load_balancer_external_ip" ];
+        do
+          echo "  sleeping 10 seconds" && sleep 10
+          load_balancer_external_ip=$(kubectl get ingress -n posthog posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+        done
+        echo "The GCP Load Balancer is now ready!"
+
+    - name: Wait until all the resources are fully deployed in k8s
+      uses: jupyterhub/action-k8s-await-workloads@main
+      with:
+        namespace: "posthog"
+        timeout: 300
+        max-restarts: 10
+
+    - name: Wait for the Google-managed TLS certificate to be issued and deployed
+      id: tls_certificate_creation
+      run: |
+        echo "Wait for the Google-managed TLS certificate to be issued and deployed..."
+        certificate_status=""
+        while [ "$certificate_status" != "Active"  ];
+        do
+          echo "  sleeping 10 seconds" && sleep 10
+          certificate_status=$(kubectl get managedcertificate -n posthog posthog-gke-cert -o jsonpath="{.status.certificateStatus}")
+        done
+        echo "The certificate has been issued and it has been deployed!"
+
+    - name: Setup PostHog for the ingestion test
+      run: ./ci/setup_ingestion_test.sh
+
+    - name: Set PostHog endpoints to use for the ingestion test
+      run: |
+        echo "POSTHOG_API_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+        echo "POSTHOG_EVENT_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+
+    #
+    # TODO: the GCE Ingress is not picking up health check from readiness probe definition and it's using '/'
+    # instead. We need to fix this issue before being able to enable the k6 ingestion test.
+    #
+    # see: https://stackoverflow.com/questions/44584270/
+    #
+    # - name: Run ingestion test using k6
+    #   uses: k6io/action@v0.2.0
+    #   with:
+    #     filename: ci/k6-ingestion-test.js
+
+    - name: Delete the k8s cluster and all the associated resources
+      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
+      run: |
+        gcloud container clusters delete \
+          --project ${{ secrets.GCP_PROJECT_ID }} \
+          --region europe-west4 \
+          --quiet \
+          ${{ steps.vars.outputs.k8s_cluster_name }}
+
+    - name: Delete the global static IP address
+      if: ${{ always() && steps.static_ip_creation.outcome == 'success' }}
+      run: |
+        gcloud compute addresses delete \
+          --project ${{ secrets.GCP_PROJECT_ID }} \
+          --global \
+          --quiet \
+          ${{ steps.vars.outputs.dns_record }}
+
+    - name: Delete the DNS record
+      if: ${{ always() && steps.dns_creation.outcome == 'success' }}
+      run: |
+        DNS_RECORD_ID=$(doctl compute domain records list posthog.cc --no-header --format ID,Name | grep ${{ steps.vars.outputs.dns_record }} | awk '{print $1}')
+        doctl compute domain records delete \
+          posthog.cc \
+          --force \
+          "$DNS_RECORD_ID"
+
+    - name: Delete the Google-managed TLS certificate
+      if: ${{ always() }}
+      run: |
+        TLS_CERTIFICATE_NAME=$(gcloud compute ssl-certificates list --project ${{ secrets.GCP_PROJECT_ID }} --global --filter=${{ steps.vars.outputs.dns_record }} --format="value(NAME)")
+        if [ -n "$TLS_CERTIFICATE_NAME" ];
+        then
+          gcloud compute ssl-certificates delete \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --quiet \
+            "$TLS_CERTIFICATE_NAME"
+        fi

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -155,6 +155,10 @@ jobs:
     #
     # see: https://stackoverflow.com/questions/44584270/
     #
+    - name: Run ingestion test using k6
+      run: |
+        sleep 30
+
     # - name: Run ingestion test using k6
     #   uses: k6io/action@v0.2.0
     #   with:

--- a/ci/k6-ingestion-test.js
+++ b/ci/k6-ingestion-test.js
@@ -17,8 +17,8 @@ let eventsIngested = new Gauge('events_ingested')
 
 export let options = {
   thresholds: {
-    http_req_failed: ['rate<0.01'],   // http errors should be less than 1%
-    http_req_duration: ['p(95)<500'], // 95% of requests should be below 500ms
+    http_req_failed: ['rate < 0.01'],   // http errors should be less than 1%
+    http_req_duration: ['p(90) < 1000'], // 90% of requests should be below 1s
     events_ingested: ['value > 0', 'value > 100']
   },
   scenarios: {

--- a/ci/values/google_cloud_platform.yaml
+++ b/ci/values/google_cloud_platform.yaml
@@ -1,0 +1,3 @@
+cloud: "gcp"
+ingress:
+  hostname: <your-hostname>


### PR DESCRIPTION
## Description
Similar to https://github.com/PostHog/charts-clickhouse/pull/196 this PR brings an e2e test to deploy PostHog via Helm on Google Cloud Platform (as requested in #183).

It includes certificate signing using Google-managed SSL certificates (see [here](https://crt.sh/?q=posthog.cc) for the certificate transparency log entries).

Due to a bug in the [GCE ingress](https://stackoverflow.com/questions/44584270/how-to-get-a-custom-healthcheck-path-in-a-gce-l7-balancer-serving-a-kubernetes-i) that I still need to work around, I'm temporary disabling the k6 test as the test will fail otherwise.

I'm inclined to merge this anyway as it is and then revisit the k6 test once the e2e tests for the other platforms are also shipped.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
