### PR TITLE
Fix - GCE L7 LB not picking up a custom readinessProbe URL

### DIFF
--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -155,16 +155,10 @@ jobs:
         echo "POSTHOG_API_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
         echo "POSTHOG_EVENT_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
 
-    #
-    # TODO: the GCE Ingress is not picking up health check from readiness probe definition and it's using '/'
-    # instead. We need to fix this issue before being able to enable the k6 ingestion test.
-    #
-    # see: https://stackoverflow.com/questions/44584270/
-    #
-    # - name: Run ingestion test using k6
-    #   uses: k6io/action@v0.2.0
-    #   with:
-    #     filename: ci/k6-ingestion-test.js
+    - name: Run ingestion test using k6
+      uses: k6io/action@v0.2.0
+      with:
+        filename: ci/k6-ingestion-test.js
 
     - name: Delete the k8s cluster and all the associated resources
       if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}

--- a/charts/posthog/templates/beat-deployment.yaml
+++ b/charts/posthog/templates/beat-deployment.yaml
@@ -63,7 +63,8 @@ spec:
           - |
             ./bin/docker-worker-beat
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -71,7 +71,8 @@ spec:
             ./bin/docker-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -74,7 +74,8 @@ spec:
           - |
             ./bin/plugin-server --no-restart-loop
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -71,7 +71,8 @@ spec:
             ./bin/docker-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/resource-policy": "keep" 
+    "helm.sh/resource-policy": "keep"
     "helm.sh/hook-weight": "1"
 spec:
   selector:
@@ -74,7 +74,8 @@ spec:
           - |
             ./bin/docker-worker-celery
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+          - name: http
+            containerPort: {{ .Values.service.internalPort }}
         env:
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}


### PR DESCRIPTION
## Description
This is a fix for a GCP specific issue. The GCE L7 LB is not picking up the custom `readinessProbe` configurations if a port is not specified in the deployment configuration. 

For more info see:
- https://stackoverflow.com/questions/44584270/how-to-get-a-custom-healthcheck-path-in-a-gce-l7-balancer-serving-a-kubernetes-i
- https://groups.google.com/g/kubernetes-users/c/lhVfyfCwEyo/m/b187gC84CwAJ   
- https://github.com/kubernetes/ingress-gce/blob/master/docs/faq/gce.md#can-i-configure-gce-health-checks-through-the-ingress
- https://github.com/kubernetes/ingress-gce/issues/241#issuecomment-384749607

In this PR we modify the deployment configuration to specify the port and we also re-enable k6 ingestion testing for the GCP e2e test (previously disabled due to this issue)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
