### PR TITLE
Add 'clickhouse.nodeSelector' variable

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -125,6 +125,9 @@ spec:
                   mountPath: /var/lib/clickhouse
               resources:
 {{ toYaml .Values.clickhouse.resources | indent 16 }}
+              {{- if .Values.clickhouse.nodeSelector }}
+              nodeSelector: {{- .Values.clickhouse.nodeSelector | toYaml | nindent 16 }}
+              {{- end }}
               {{- if .Values.clickhouseOperator.useNodeSelector }}
               nodeSelector:
                 clickhouse: true

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -1,0 +1,89 @@
+the manifest should match the snapshot when using default values:
+  1: |
+    apiVersion: clickhouse.altinity.com/v1
+    kind: ClickHouseInstallation
+    metadata:
+      name: posthog
+    spec:
+      configuration:
+        clusters:
+        - layout:
+            replicasCount: 1
+            shardsCount: 1
+          name: posthog
+          templates:
+            podTemplate: pod-template-with-volumes
+        files:
+          events.proto: |
+            syntax = "proto3";
+            message Event {
+              string uuid = 1;
+              string event = 2;
+              string properties = 3;
+              string timestamp = 4;
+              uint64 team_id = 5;
+              string distinct_id = 6;
+              string created_at = 7;
+              string elements_chain = 8;
+            }
+        profiles:
+          default/allow_experimental_window_functions: "1"
+        settings:
+          format_schema_path: /etc/clickhouse-server/config.d/
+        users:
+          admin/networks/ip: 0.0.0.0/0
+          admin/password: a1f31e03-c88e-4ca6-a2df-ad49183d15d9
+          admin/profile: default
+          admin/quota: default
+        zookeeper:
+          nodes:
+          - host: RELEASE-NAME-posthog-zookeeper
+            port: 2181
+      defaults:
+        templates:
+          dataVolumeClaimTemplate: data-volumeclaim-template
+          serviceTemplate: chi-service-template
+      templates:
+        podTemplates:
+        - name: pod-template-with-volumes
+          spec:
+            containers:
+            - command:
+              - /bin/bash
+              - -c
+              - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
+              image: yandex/clickhouse-server:21.6.5
+              name: clickhouse
+              ports:
+              - containerPort: 8123
+                name: http
+              - containerPort: 9000
+                name: client
+              - containerPort: 9009
+                name: interserver
+              resources: {}
+              volumeMounts:
+              - mountPath: /var/lib/clickhouse
+                name: data-volumeclaim-template
+            securityContext:
+              fsGroup: 101
+              runAsGroup: 101
+              runAsUser: 101
+        serviceTemplates:
+        - generateName: clickhouse-RELEASE-NAME
+          name: chi-service-template
+          spec:
+            ports:
+            - name: http
+              port: 8123
+            - name: tcp
+              port: 9000
+            type: NodePort
+        volumeClaimTemplates:
+        - name: data-volumeclaim-template
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -1,0 +1,42 @@
+suite: ClickHouse service account definition
+templates:
+  - templates/clickhouse_instance.yaml
+
+tests:
+  - it: should be empty if clickhouseOperator.enabled is set to false
+    set:
+      clickhouseOperator.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: the manifest should match the snapshot when using default values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchSnapshot: {}
+
+  - it: nodeSelector override via 'clickhouse.nodeSelector' works
+    set:
+      clickhouse.nodeSelector:
+        diskType: ssd
+        nodeType: fast
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.containers[0].nodeSelector
+          value:
+            diskType: ssd
+            nodeType: fast
+
+  - it: nodeSelector override via 'clickhouseOperator.useNodeSelector' works
+    set:
+      clickhouseOperator.useNodeSelector: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.containers[0].nodeSelector
+          value:
+            clickhouse: true

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -1,4 +1,4 @@
-suite: ClickHouse service account definition
+suite: ClickHouse instance
 templates:
   - templates/clickhouse_instance.yaml
 
@@ -11,10 +11,30 @@ tests:
           count: 0
 
   - it: the manifest should match the snapshot when using default values
+    set:
+      clickhouseOperator.enabled: true
     asserts:
       - hasDocuments:
           count: 1
       - matchSnapshot: {}
+
+  - it: should have the correct apiVersion
+    set:
+      clickhouseOperator.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: clickhouse.altinity.com/v1
+
+  - it: should be the correct kind
+    set:
+      clickhouseOperator.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClickHouseInstallation
 
   - it: nodeSelector override via 'clickhouse.nodeSelector' works
     set:


### PR DESCRIPTION
## Description
Add a new chart variable `clickhouse.nodeSelector` to customize the `nodeSelector` definition of the ClickHouse installation. Fixes https://github.com/PostHog/charts-clickhouse/issues/210.

Optional: we should deprecate `clickhouseOperator.useNodeSelector`, any user currently using it should simply use:
```
clickhouse.nodeSelector:
  clickhouse: true
```

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
