### PR TITLE
Add ability to expose ClickHouse externally (some clients require this)

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -139,6 +139,15 @@ spec:
             - name: tcp
               port: 9000
           type: {{ .Values.clickhouseOperator.serviceType }}
+        metadata:
+          annotations:
+            # For more details on Internal Load Balancer check
+            # https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+            cloud.google.com/load-balancer-type: {{ if .Values.clickhouse.exposedExternally "External" "Internal" }}
+            service.beta.kubernetes.io/aws-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
+            service.beta.kubernetes.io/azure-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
+            service.beta.kubernetes.io/openstack-internal-load-balancer: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
+            service.beta.kubernetes.io/cce-load-balancer-internal-vpc: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
     {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
     volumeClaimTemplates:
       - name: data-volumeclaim-template

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -143,11 +143,11 @@ spec:
           annotations:
             # For more details on Internal Load Balancer check
             # https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-            cloud.google.com/load-balancer-type: {{ if .Values.clickhouse.exposedExternally "External" "Internal" }}
-            service.beta.kubernetes.io/aws-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
-            service.beta.kubernetes.io/azure-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
-            service.beta.kubernetes.io/openstack-internal-load-balancer: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
-            service.beta.kubernetes.io/cce-load-balancer-internal-vpc: {{ if .Values.clickhouse.exposedExternally "false" "true" }}
+            cloud.google.com/load-balancer-type: {{ if .Values.clickhouse.exposedExternally }} "External" {{ else }} "Internal" {{ end }} 
+            service.beta.kubernetes.io/aws-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally }} "false" {{ else }} "true" {{ end }} 
+            service.beta.kubernetes.io/azure-load-balancer-internal: {{ if .Values.clickhouse.exposedExternally }} "false" {{ else }} "true" {{ end }}
+            service.beta.kubernetes.io/openstack-internal-load-balancer: {{ if .Values.clickhouse.exposedExternally }} "false" {{ else }} "true"{{ end }}
+            service.beta.kubernetes.io/cce-load-balancer-internal-vpc: {{ if .Values.clickhouse.exposedExternally }} "false" {{ else }} "true" {{ end }}
     {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
     volumeClaimTemplates:
       - name: data-volumeclaim-template

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -453,6 +453,8 @@ clickhouse:
   # -- Set if not installing clickhouse operator
   host:
   # :TODO:
+  # -- Set exposedExternally to true if you want to be able to reach CH from outside the cluster 
+  exposedExternally: false
   replication: false
   secure: false
   verify: false


### PR DESCRIPTION
## Description
A customer is requesting that we bring back external access to ClickHouse on their cluster. This allows us to flip a switch to enable that.

