### PR TITLE
Deprecate `clickhouseOperator.useNodeSelector`

### DIFF
--- a/charts/posthog/templates/_snippet-error-on-removed-values.tpl
+++ b/charts/posthog/templates/_snippet-error-on-removed-values.tpl
@@ -20,6 +20,9 @@
 {{- if ne .Values.postgresql.postgresqlUsername "postgres" }}
     {{- required (printf (include "snippet.error-on-removed-values-template" .) "postgresql.postgresqlUsername has been removed" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
 {{- end -}}
+{{- if .Values.clickhouse.useNodeSelector }}
+    {{- required (printf (include "snippet.error-on-removed-values-template" .) "clickhouse.useNodeSelector has been removed." "please use the clickhouse.nodeSelector variable instead") nil -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -110,11 +110,6 @@ spec:
                   mountPath: /var/lib/clickhouse
               {{- end }}
 
-              {{- if .Values.clickhouse.useNodeSelector }}
-              nodeSelector:
-                clickhouse: true
-              {{- end }}
-
               {{- if .Values.clickhouse.resources }}
               resources: {{ toYaml .Values.clickhouse.resources | nindent 16 }}
               {{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -552,9 +552,6 @@ clickhouse:
   # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
   serviceType: NodePort
 
-  # -- If enabled, operator will prefer k8s nodes with tag `clickhouse:true`
-  useNodeSelector: false
-
   persistence:
     # -- Enable data persistence using PVC.
     enabled: true


### PR DESCRIPTION
## Description
With https://github.com/PostHog/charts-clickhouse/pull/212 we added a new `clickhouse.nodeSelector` chart variable to customize the `nodeSelector` definition of the ClickHouse installation.

This PR removes the now deprecated `clickhouseOperator.useNodeSelector` chart value. Looking at the how `altinity/clickhouse-operator` works, I doubt this value in our repo had ever worked as expected. 

In any case, to keep any eventual retro compatibility `clickhouseOperator.useNodeSelector: true` can be modified as:
```
clickhouse:
  nodeSelector:
    clickhouse: "true"
```

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
