### PR TITLE
Make StorageClass installation optional in AWS/GCP

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -243,17 +243,6 @@ Set clickhouse fullname
 {{- end -}}
 
 {{/*
-Set clickhouse external volume
-*/}}
-{{- define "clickhouse.externalVolume" -}}
-{{- if ne (.Values.clickhouse.persistentVolumeClaim | toString) "<nil>" -}}
-  true
-{{- else -}}
-  false
-{{- end -}}
-{{- end -}}
-
-{{/*
 Set statsd host
 */}}
 {{- define "posthog.statsd.host" -}}

--- a/charts/posthog/templates/clickhouse-operator/clusterrole.yaml
+++ b/charts/posthog/templates/clickhouse-operator/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Template Parameters:
 #
 # NAMESPACE=posthog
@@ -12,7 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: clickhouse-operator-posthog
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
 rules:
 - apiGroups:
     - ""

--- a/charts/posthog/templates/clickhouse-operator/clusterrolebinding.yaml
+++ b/charts/posthog/templates/clickhouse-operator/clusterrolebinding.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: clickhouse-operator-posthog
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13,6 +13,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: clickhouse-operator
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
 
 {{- end }}

--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Template Parameters:
 #
 # NAME=etc-clickhouse-operator-files
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: etc-clickhouse-operator-files
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 data:
@@ -190,7 +190,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: etc-clickhouse-operator-confd-files
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 data:
@@ -207,7 +207,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: etc-clickhouse-operator-configd-files
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 data:
@@ -266,7 +266,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: etc-clickhouse-operator-templatesd-files
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 data:
@@ -367,7 +367,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: etc-clickhouse-operator-usersd-files
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 data:

--- a/charts/posthog/templates/clickhouse-operator/deployment.yaml
+++ b/charts/posthog/templates/clickhouse-operator/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Template Parameters:
 #
 # NAMESPACE=posthog
@@ -12,7 +12,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: clickhouse-operator
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 spec:

--- a/charts/posthog/templates/clickhouse-operator/service.yaml
+++ b/charts/posthog/templates/clickhouse-operator/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Template Parameters:
 #
 # NAMESPACE=posthog
@@ -13,7 +13,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: clickhouse-operator-metrics
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
     app: clickhouse-operator
 spec:

--- a/charts/posthog/templates/clickhouse-operator/serviceaccount.yaml
+++ b/charts/posthog/templates/clickhouse-operator/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
 # Template Parameters:
 #
 # COMMENT=
@@ -10,6 +10,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: clickhouse-operator
-  namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
 
 {{- end }}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -1,63 +1,34 @@
-{{- if .Values.clickhouseOperator.enabled }}
-{{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
-{{ if (eq (.Values.cloud | toString) "gcp" )}}
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gce-resizable
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-standard
-  fstype: ext4
-  replication-type: none
-reclaimPolicy: Retain
-#volumeBindingMode: Immediate
-allowVolumeExpansion: true
-{{- else if (eq (.Values.cloud | toString) "aws") }}
-#
-# AWS resizable disk example
-#
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gp2-resizable
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-reclaimPolicy: Retain
-#volumeBindingMode: Immediate
-allowVolumeExpansion: true
-{{ end }}
-{{- end }}
----
+{{- if .Values.clickhouse.enabled }}
 apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseInstallation"
 metadata:
   name: "posthog"
 spec:
-  defaults:
-    templates:
-      {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
-      dataVolumeClaimTemplate: data-volumeclaim-template
-      {{- end }}
-      serviceTemplate: chi-service-template
   configuration:
     users:
       admin/password: {{ .Values.clickhouse.password }}
       admin/networks/ip: "0.0.0.0/0"
       admin/profile: default
       admin/quota: default
+
     profiles:
       default/allow_experimental_window_functions: "1"
+
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}
         templates:
-          podTemplate: pod-template-with-volumes
+          podTemplate: pod-template
+          serviceTemplate: service-template
+          {{- if and (.Values.clickhouse.persistence.enabled) (not .Values.clickhouse.persistence.existingClaim) }}
+          dataVolumeClaimTemplate: data-volumeclaim-template
+          {{- end }}
         layout:
           shardsCount: 1
           replicasCount: 1
+
     settings:
       format_schema_path: /etc/clickhouse-server/config.d/
+
     files:
       events.proto: |
         syntax = "proto3";
@@ -71,6 +42,7 @@ spec:
           string created_at = 7;
           string elements_chain = 8;
         }
+
     zookeeper:
       nodes:
       {{- if .Values.clickhouse.externalZookeeper }}
@@ -79,27 +51,34 @@ spec:
         - host: {{ template "posthog.zookeeper.host" . }}
           port: {{ template "posthog.zookeeper.port" . }}
       {{- end }}
+
   templates:
     podTemplates:
-      - name: pod-template-with-volumes
+      - name: pod-template
         spec:
           {{- if .Values.clickhouse.affinity }}
-          affinity:
-{{ toYaml .Values.clickhouse.affinity | indent 12 }}
+          affinity: {{ toYaml .Values.clickhouse.affinity | nindent 12 }}
           {{- end }}
           {{- if .Values.clickhouse.tolerations }}
-          tolerations:
-{{ toYaml .Values.clickhouse.tolerations | indent 12 }}
+          tolerations: {{ toYaml .Values.clickhouse.tolerations | nindent 12 }}
           {{- end }}
           {{- if .Values.clickhouse.nodeSelector }}
           nodeSelector: {{ toYaml .Values.clickhouse.nodeSelector | nindent 12 }}
           {{- end }}
-          {{- if (eq (include "clickhouse.externalVolume" .) "true" ) }}
+
+          {{- if .Values.clickhouse.persistence.enabled }}
           volumes:
-            - name: clickhouse-storage
+          {{- if .Values.clickhouse.persistence.existingClaim }}
+            - name: existing-volumeclaim
               persistentVolumeClaim:
-                claimName: {{ .Values.clickhouse.persistentVolumeClaim }}
+                claimName: {{ .Values.clickhouse.persistence.existingClaim }}
+          {{- else }}
+            - name: data-volumeclaim-template
+              persistentVolumeClaim:
+                claimName: data-volumeclaim-template
           {{- end }}
+          {{- end }}
+
           {{- if .Values.clickhouse.securityContext.enabled }}
           securityContext: {{- omit .Values.clickhouse.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
@@ -112,6 +91,7 @@ spec:
                 - /bin/bash
                 - -c
                 - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
+
               ports:
                 - name: http
                   containerPort: 8123
@@ -119,21 +99,28 @@ spec:
                   containerPort: 9000
                 - name: interserver
                   containerPort: 9009
+
+              {{- if .Values.clickhouse.persistence.enabled }}
               volumeMounts:
-              {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
-                - name: data-volumeclaim-template
+              {{- if .Values.clickhouse.persistence.existingClaim }}
+                - name: existing-volumeclaim
               {{- else }}
-                - name: clickhouse-storage
+                - name: data-volumeclaim-template
               {{- end }}
                   mountPath: /var/lib/clickhouse
-              resources:
-{{ toYaml .Values.clickhouse.resources | indent 16 }}
-              {{- if .Values.clickhouseOperator.useNodeSelector }}
+              {{- end }}
+
+              {{- if .Values.clickhouse.useNodeSelector }}
               nodeSelector:
                 clickhouse: true
               {{- end }}
+
+              {{- if .Values.clickhouse.resources }}
+              resources: {{ toYaml .Values.clickhouse.resources | nindent 16 }}
+              {{- end }}
+
     serviceTemplates:
-      - name: chi-service-template
+      - name: service-template
         generateName: {{ template "posthog.clickhouse.fullname" . }}
         spec:
           ports:
@@ -141,20 +128,20 @@ spec:
               port: 8123
             - name: tcp
               port: 9000
-          type: {{ .Values.clickhouseOperator.serviceType }}
-    {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
+          type: {{ .Values.clickhouse.serviceType }}
+
+    {{- if and (.Values.clickhouse.persistence.enabled) (not .Values.clickhouse.persistence.existingClaim) }}
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:
-          {{- if (eq (.Values.cloud | toString) "gcp" )}}
-          storageClassName: gce-resizable
-          {{- else if (eq (.Values.cloud | toString) "aws") }}
-          storageClassName: gp2-resizable
+          {{- if .Values.clickhouse.persistence.storageClass }}
+          storageClassName: {{ .Values.clickhouse.persistence.storageClass }}
           {{- end }}
           accessModes:
             - ReadWriteOnce
           resources:
             requests:
-              storage: {{ .Values.clickhouseOperator.storage | quote }}
+              storage: {{ .Values.clickhouse.persistence.size | quote }}
     {{- end }}
+
 {{- end }}

--- a/charts/posthog/templates/storage_class.yaml
+++ b/charts/posthog/templates/storage_class.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.installCustomStorageClass }}
+{{ if (eq (.Values.cloud | toString) "gcp" )}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gce-resizable
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  fstype: ext4
+  replication-type: none
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+{{- else if (eq (.Values.cloud | toString) "aws") }}
+#
+# AWS resizable disk example
+#
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp2-resizable
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+{{ end }}
+{{- end }}

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -12,7 +12,9 @@ the manifest should match the snapshot when using default values:
             shardsCount: 1
           name: posthog
           templates:
-            podTemplate: pod-template-with-volumes
+            dataVolumeClaimTemplate: data-volumeclaim-template
+            podTemplate: pod-template
+            serviceTemplate: service-template
         files:
           events.proto: |
             syntax = "proto3";
@@ -39,13 +41,9 @@ the manifest should match the snapshot when using default values:
           nodes:
           - host: RELEASE-NAME-posthog-zookeeper
             port: 2181
-      defaults:
-        templates:
-          dataVolumeClaimTemplate: data-volumeclaim-template
-          serviceTemplate: chi-service-template
       templates:
         podTemplates:
-        - name: pod-template-with-volumes
+        - name: pod-template
           spec:
             containers:
             - command:
@@ -61,7 +59,6 @@ the manifest should match the snapshot when using default values:
                 name: client
               - containerPort: 9009
                 name: interserver
-              resources: {}
               volumeMounts:
               - mountPath: /var/lib/clickhouse
                 name: data-volumeclaim-template
@@ -69,9 +66,13 @@ the manifest should match the snapshot when using default values:
               fsGroup: 101
               runAsGroup: 101
               runAsUser: 101
+            volumes:
+            - name: data-volumeclaim-template
+              persistentVolumeClaim:
+                claimName: data-volumeclaim-template
         serviceTemplates:
         - generateName: clickhouse-RELEASE-NAME
-          name: chi-service-template
+          name: service-template
           spec:
             ports:
             - name: http

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -3,16 +3,16 @@ templates:
   - templates/clickhouse_instance.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: the manifest should match the snapshot when using default values
     set:
-      clickhouseOperator.enabled: true
+      clickhouse.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -20,7 +20,7 @@ tests:
 
   - it: should have the correct apiVersion
     set:
-      clickhouseOperator.enabled: true
+      clickhouse.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -29,12 +29,123 @@ tests:
 
   - it: should be the correct kind
     set:
-      clickhouseOperator.enabled: true
+      clickhouse.enabled: true
     asserts:
       - hasDocuments:
           count: 1
       - isKind:
           of: ClickHouseInstallation
+
+  - it: spec.configuration.cluster[0].templates volumeClaimTemplate should not exist if persistence is disabled
+    set:
+      clickhouse.persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.clusters[0].templates
+          value:
+            podTemplate: pod-template
+            serviceTemplate: service-template
+
+  - it: spec.configuration.cluster[0].templates volumeClaimTemplate should not exist if persistence is enabled and clickhouse.persistence.existingClaim is set
+    set:
+      clickhouse.persistence.enabled: false
+      clickhouse.persistence.existingClaim: pvc-claim
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.clusters[0].templates
+          value:
+            podTemplate: pod-template
+            serviceTemplate: service-template
+
+  - it: spec.configuration.cluster[0].templates volumeClaimTemplate should exist if persistence is enabled
+    set:
+      clickhouse.persistence.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.clusters[0].templates
+          value:
+            podTemplate: pod-template
+            serviceTemplate: service-template
+            dataVolumeClaimTemplate: data-volumeclaim-template
+
+
+  - it: pod-template spec.volumes should not exist if persistence is disabled
+    set:
+      clickhouse.persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.volumes
+          value: null
+
+  - it: pod-template spec.volumes should have 'data-volumeclaim-template' if persistence is enabled
+    set:
+      clickhouse.persistence.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.volumes
+          value:
+            - name: data-volumeclaim-template
+              persistentVolumeClaim:
+                claimName: data-volumeclaim-template
+
+  - it: pod-template spec.volumes should have 'existing-volumeclaim' if clickhouse.persistence.existingClaim is set
+    set:
+      clickhouse.persistence.enabled: true
+      clickhouse.persistence.existingClaim: pvc-claim
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.volumes
+          value:
+            - name: existing-volumeclaim
+              persistentVolumeClaim:
+                claimName: pvc-claim
+
+  - it: pod-template spec.containers[0].volumeMounts should not exist if persistence is disabled
+    set:
+      clickhouse.persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.containers[0].volumeMounts
+          value: null
+
+  - it: pod-template spec.containers[0].volumeMounts should exist if persistence is enabled
+    set:
+      clickhouse.persistence.enabled: enabled
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.containers[0].volumeMounts
+          value:
+            - mountPath: /var/lib/clickhouse
+              name: data-volumeclaim-template
+
+  - it: pod-template spec.containers[0].volumeMounts should have 'existing-volumeclaim' if clickhouse.persistence.existingClaim is set
+    set:
+      clickhouse.persistence.enabled: enabled
+      clickhouse.persistence.existingClaim: pvc-claim
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].spec.containers[0].volumeMounts
+          value:
+            - mountPath: /var/lib/clickhouse
+              name: existing-volumeclaim
 
   - it: nodeSelector override via 'clickhouse.nodeSelector' works
     set:
@@ -49,3 +160,45 @@ tests:
           value:
             diskType: ssd
             nodeType: fast
+
+  - it: volumeClaimTemplates shouldn't exit if clickhouse.persistence.enabled is false
+    set:
+      clickhouse.persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.volumeClaimTemplates
+          value: null
+
+  - it: volumeClaimTemplates shouldn't exit if clickhouse.persistence.enabled is true and clickhouse.persistence.existingClaim is set
+    set:
+      clickhouse.persistence.enabled: false
+      clickhouse.persistence.existingClaim: pvc-claim
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.volumeClaimTemplates
+          value: null
+
+  - it: The storageClassName value should be null using the default values
+    set:
+      clickhouse.persistence.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.volumeClaimTemplates[0].spec.storageClassName
+          value: null
+
+  - it: The storageClassName override should work
+    set:
+      clickhouse.persistence.enabled: true
+      clickhouse.persistence.storageClass: customStorageClass
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.volumeClaimTemplates[0].spec.storageClassName
+          value: customStorageClass

--- a/charts/posthog/tests/clickhouse-operator/clusterrole.yaml
+++ b/charts/posthog/tests/clickhouse-operator/clusterrole.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/clusterrole.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 1
       - matchSnapshot: {}
 
-  - it: ClusterRole/clickhouse-operator-posthog metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ClusterRole/clickhouse-operator-posthog metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: "custom-namespace"
+      clickhouse.namespace: "custom-namespace"
     documentIndex: 0
     asserts:
       - hasDocuments:

--- a/charts/posthog/tests/clickhouse-operator/clusterrolebinding.yaml
+++ b/charts/posthog/tests/clickhouse-operator/clusterrolebinding.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/clusterrolebinding.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 1
       - matchSnapshot: {}
 
-  - it: ClusterRoleBinding/clickhouse-operator-posthog metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ClusterRoleBinding/clickhouse-operator-posthog metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: "custom-namespace"
+      clickhouse.namespace: "custom-namespace"
     documentIndex: 0
     asserts:
       - hasDocuments:
@@ -38,9 +38,9 @@ tests:
           path: metadata.namespace
           value: custom-namespace-from-release
 
-  - it: ClusterRoleBinding/clickhouse-operator-posthog subjects[0].namespace override via clickhouseOperator.namespace should work
+  - it: ClusterRoleBinding/clickhouse-operator-posthog subjects[0].namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: "custom-namespace"
+      clickhouse.namespace: "custom-namespace"
     documentIndex: 0
     asserts:
       - hasDocuments:

--- a/charts/posthog/tests/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/tests/clickhouse-operator/configmap.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/configmap.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 5
       - matchSnapshot: {}
 
-  - it: ConfigMap/etc-clickhouse-operator-files metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ConfigMap/etc-clickhouse-operator-files metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     documentIndex: 0
     asserts:
       - hasDocuments:
@@ -44,9 +44,9 @@ tests:
             namespace: custom-namespace-from-release
             labels: { app: clickhouse-operator }
 
-  - it: ConfigMap/etc-clickhouse-operator-confd-files metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ConfigMap/etc-clickhouse-operator-confd-files metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     documentIndex: 1
     asserts:
       - hasDocuments:
@@ -72,9 +72,9 @@ tests:
             namespace: custom-namespace-from-release
             labels: { app: clickhouse-operator }
 
-  - it: ConfigMap/etc-clickhouse-operator-configd-files metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ConfigMap/etc-clickhouse-operator-configd-files metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     documentIndex: 2
     asserts:
       - hasDocuments:
@@ -100,9 +100,9 @@ tests:
             namespace: custom-namespace-from-release
             labels: { app: clickhouse-operator }
 
-  - it: ConfigMap/etc-clickhouse-operator-templatesd-files metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ConfigMap/etc-clickhouse-operator-templatesd-files metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     documentIndex: 3
     asserts:
       - hasDocuments:
@@ -128,9 +128,9 @@ tests:
             namespace: custom-namespace-from-release
             labels: { app: clickhouse-operator }
 
-  - it: ConfigMap/etc-clickhouse-operator-usersd-files metadata.namespace override via clickhouseOperator.namespace should work
+  - it: ConfigMap/etc-clickhouse-operator-usersd-files metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     documentIndex: 4
     asserts:
       - hasDocuments:

--- a/charts/posthog/tests/clickhouse-operator/deployment.yaml
+++ b/charts/posthog/tests/clickhouse-operator/deployment.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/deployment.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 1
       - matchSnapshot: {}
 
-  - it: metadata.namespace override via clickhouseOperator.namespace should work
+  - it: metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/posthog/tests/clickhouse-operator/service.yaml
+++ b/charts/posthog/tests/clickhouse-operator/service.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/service.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 1
       - matchSnapshot: {}
 
-  - it: metadata.namespace override via clickhouseOperator.namespace should work
+  - it: metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/posthog/tests/clickhouse-operator/serviceaccount.yaml
+++ b/charts/posthog/tests/clickhouse-operator/serviceaccount.yaml
@@ -3,9 +3,9 @@ templates:
   - templates/clickhouse-operator/serviceaccount.yaml
 
 tests:
-  - it: should be empty if clickhouseOperator.enabled is set to false
+  - it: should be empty if clickhouse.enabled is set to false
     set:
-      clickhouseOperator.enabled: false
+      clickhouse.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -16,9 +16,9 @@ tests:
           count: 1
       - matchSnapshot: {}
 
-  - it: metadata.namespace override via clickhouseOperator.namespace should work
+  - it: metadata.namespace override via clickhouse.namespace should work
     set:
-      clickhouseOperator.namespace: custom-namespace
+      clickhouse.namespace: custom-namespace
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -18,18 +18,6 @@ cloud:
 # -- Sentry endpoint to send errors to
 sentryDSN:
 
-clickhouseOperator:
-  # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
-  enabled: true
-  # -- Which namespace to install clickhouse operator to (defaults to namespace chart is installed to)
-  namespace:
-  # -- How much storage space to preallocate for clickhouse
-  storage: 20Gi
-  # -- If enabled, operator will prefer k8s nodes with tag `clickhouse:true`
-  useNodeSelector: false
-  # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
-  serviceType: NodePort
-
 # -- Env vars to throw into every deployment (web, worker, and plugin server)
 env:
   - name: ASYNC_EVENT_PROPERTY_USAGE
@@ -471,8 +459,10 @@ zookeeper:
   replicaCount: 1
 
 clickhouse:
-  # -- Use clickhouse as primary database
+  # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
   enabled: true
+  # -- Which namespace to install clickhouse and the clickhouse-operator to (defaults to namespace chart is installed to)
+  namespace:
   # -- Clickhouse database
   database: posthog
   # -- Clickhouse user
@@ -491,8 +481,7 @@ clickhouse:
   # servers:
   # - host: posthog-posthog-zookeeper
   #   port: 2181
-  # -- Optional: Used to manually specify a persistent volume claim. When specified the cloud specific storage class will not be provisioned
-  persistentVolumeClaim:
+
   # -- Toleration labels for clickhouse pod assignment
   tolerations: []
   # -- Affinity settings for clickhouse pod
@@ -510,6 +499,37 @@ clickhouse:
     runAsUser: 101
     runAsGroup: 101
     fsGroup: 101
+
+  # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
+  serviceType: NodePort
+
+  # -- If enabled, operator will prefer k8s nodes with tag `clickhouse:true`
+  useNodeSelector: false
+
+  ## @section Persistence parameters
+  ##
+  persistence:
+
+    ## @param persistence.enabled Enable data persistence
+    ##
+    enabled: true
+
+    ## @param persistence.existingClaim A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound.
+    ##
+    existingClaim: ""
+
+    ## @param persistence.storageClass Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    storageClass: null
+
+    ## @param persistence.size PVC Storage Request for the data volume
+    ##
+    size: 20Gi
 
 ## Prometheus Exporter / Metrics
 ##
@@ -709,3 +729,6 @@ statsd:
     prometheus.io/scrape: "true"
     prometheus.io/path: /metrics
     prometheus.io/port: "9102"
+
+# Misc
+installCustomStorageClass: false

--- a/ci/kubetest/clickhouse_existing_claim.yaml
+++ b/ci/kubetest/clickhouse_existing_claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: custom-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/ci/kubetest/test_clickhouse_persistence_disabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_disabled.py
@@ -1,0 +1,30 @@
+import pytest
+
+from utils import cleanup_k8s, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
+
+HELM_INSTALL_CMD = """
+helm upgrade \
+    --install \
+    -f ../../ci/values/kubetest/test_clickhouse_persistence_disabled.yaml \
+    --timeout 30m \
+    --create-namespace \
+    --namespace posthog \
+    posthog ../../charts/posthog \
+    --wait-for-jobs \
+    --wait
+"""
+
+
+@pytest.fixture
+def setup(kube):
+    cleanup_k8s()
+    helm_install(HELM_INSTALL_CMD)
+    wait_for_pods_to_be_ready(kube)
+
+
+def test_volume_claim(setup, kube):
+    statefulset_spec = get_clickhouse_statefulset_spec(kube)
+
+    # Verify the spec.volumes configuration
+    volumes = statefulset_spec.template.spec.volumes
+    assert all(volume.config_map is not None for volume in volumes), "All the spec.volumes should be of type config_map"

--- a/ci/kubetest/test_clickhouse_persistence_enabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled.py
@@ -1,0 +1,44 @@
+import pytest
+from kubernetes import client
+
+from utils import cleanup_k8s, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
+
+HELM_INSTALL_CMD = """
+helm upgrade \
+    --install \
+    -f ../../ci/values/kubetest/test_clickhouse_persistence_enabled.yaml \
+    --timeout 30m \
+    --create-namespace \
+    --namespace posthog \
+    posthog ../../charts/posthog \
+    --wait-for-jobs \
+    --wait
+"""
+
+
+@pytest.fixture
+def setup(kube):
+    cleanup_k8s()
+    helm_install(HELM_INSTALL_CMD)
+    wait_for_pods_to_be_ready(kube)
+
+
+def test_volume_claim(setup, kube):
+    statefulset_spec = get_clickhouse_statefulset_spec(kube)
+
+    # Verify the spec.volumes configuration
+    volumes = statefulset_spec.template.spec.volumes
+    expected_volume = client.V1Volume(
+        name="data-volumeclaim-template",
+        persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+            claim_name="data-volumeclaim-template",
+        ),
+    )
+    assert expected_volume in volumes, "spec.volumes should include {}".format(expected_volume)
+
+    # Verify the spec.containers.[].volumeMounts
+    volume_mounts = statefulset_spec.template.spec.containers[0].volume_mounts
+    expected_volume_mount = client.V1VolumeMount(name="data-volumeclaim-template", mount_path="/var/lib/clickhouse")
+    assert expected_volume_mount in volume_mounts, "spec.containers.[].volumeMounts should include {}".format(
+        expected_volume_mount
+    )

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -1,0 +1,61 @@
+import logging
+import subprocess
+
+import pytest
+from kubernetes import client
+
+from utils import NAMESPACE, cleanup_k8s, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger()
+
+HELM_INSTALL_CMD = """
+helm upgrade \
+    --install \
+    -f ../../ci/values/kubetest/test_clickhouse_persistence_enabled_existing_claim.yaml \
+    --timeout 30m \
+    --create-namespace \
+    --namespace posthog \
+    posthog ../../charts/posthog \
+    --wait-for-jobs \
+    --wait
+"""
+
+
+def create_custom_pvc():
+    log.debug("🔄 Creating a custom Persistent Volume Claim...")
+    cmd = "kubectl apply -n {namespace} -f clickhouse_existing_claim.yaml".format(namespace=NAMESPACE)
+    cmd_run = subprocess.run(cmd, shell=True)
+    cmd_return_code = cmd_run.returncode
+    if cmd_return_code:
+        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    log.debug("✅ Done!")
+
+
+@pytest.fixture
+def setup(kube):
+    cleanup_k8s()
+    create_custom_pvc()
+    helm_install(HELM_INSTALL_CMD)
+    wait_for_pods_to_be_ready(kube)
+
+
+def test_volume_claim(setup, kube):
+    statefulset_spec = get_clickhouse_statefulset_spec(kube)
+
+    # Verify the spec.volumes configuration
+    volumes = statefulset_spec.template.spec.volumes
+    expected_volume = client.V1Volume(
+        name="existing-volumeclaim",
+        persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+            claim_name="custom-pvc",
+        ),
+    )
+    assert expected_volume in volumes, "spec.volumes should include {}".format(expected_volume)
+
+    # Verify the spec.containers.[].volumeMounts
+    volume_mounts = statefulset_spec.template.spec.containers[0].volume_mounts
+    expected_volume_mount = client.V1VolumeMount(name="existing-volumeclaim", mount_path="/var/lib/clickhouse")
+    assert expected_volume_mount in volume_mounts, "spec.containers.[].volumeMounts should include {}".format(
+        expected_volume_mount
+    )

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -1,0 +1,55 @@
+import logging
+import subprocess
+import time
+
+import pytest
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger()
+
+NAMESPACE = "posthog"
+
+
+def cleanup_k8s():
+    log.debug("🔄 Setting up the k8s cluster...")
+    cmd = "kubectl delete all --all -n {namespace}".format(namespace=NAMESPACE)
+    cmd_run = subprocess.run(cmd, shell=True)
+    cmd_return_code = cmd_run.returncode
+    if cmd_return_code:
+        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    log.debug("✅ Done!")
+
+
+def helm_install(HELM_INSTALL_CMD):
+    log.debug("🔄 Deploying PostHog...")
+    cmd = HELM_INSTALL_CMD
+    cmd_run = subprocess.run(cmd, shell=True)
+    cmd_return_code = cmd_run.returncode
+    if cmd_return_code:
+        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    log.debug("✅ Done!")
+
+
+def wait_for_pods_to_be_ready(kube):
+    log.debug("🔄 Waiting for all pods to be ready...")
+    time.sleep(30)
+    start = time.time()
+    timeout = 60
+    while time.time() < start + timeout:
+        pods = kube.get_pods(namespace="posthog")
+        for pod in pods.values():
+            if not pod.is_ready():
+                continue
+        break
+    else:
+        pytest.fail("❌ Timeout raised while waiting for pods to be ready")
+    log.debug("✅ Done!")
+
+
+def get_clickhouse_statefulset_spec(kube):
+    statefulsets = kube.get_statefulsets(
+        namespace="posthog",
+        labels={"clickhouse.altinity.com/namespace": "posthog"},
+    )
+    statefulset = next(iter(statefulsets.values()))
+    return statefulset.obj.spec

--- a/ci/values/amazon_web_services.yaml
+++ b/ci/values/amazon_web_services.yaml
@@ -7,8 +7,9 @@ cert-manager:
   enabled: true
 
 # Use small PVC in CI
-clickhouseOperator:
-  storage: 1Gi
+clickhouse:
+  persistence:
+    size: 1Gi
 
 kafka:
   persistence:

--- a/ci/values/digital_ocean.yaml
+++ b/ci/values/digital_ocean.yaml
@@ -7,8 +7,9 @@ cert-manager:
   enabled: true
 
 # Use small PVC in CI
-clickhouseOperator:
-  storage: 1Gi
+clickhouse:
+  persistence:
+    size: 1Gi
 kafka:
   persistence:
     size: 1Gi

--- a/ci/values/google_cloud_platform.yaml
+++ b/ci/values/google_cloud_platform.yaml
@@ -3,8 +3,9 @@ ingress:
   hostname: <your-hostname>
 
 # Use small PVC in CI
-clickhouseOperator:
-  storage: 1Gi
+clickhouse:
+  persistence:
+    size: 1Gi
 kafka:
   persistence:
     size: 1Gi

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -14,8 +14,13 @@ redis:
   password: ""
 
 # Use small PVC in CI
+# TODO: remove clickhouseOperator after update CI pass
 clickhouseOperator:
   storage: 1Gi
+
+clickhouse:
+  persistence:
+    size: 1Gi
 kafka:
   persistence:
     size: 1Gi

--- a/ci/values/kubetest/test_clickhouse_persistence_disabled.yaml
+++ b/ci/values/kubetest/test_clickhouse_persistence_disabled.yaml
@@ -1,0 +1,36 @@
+cloud: local
+
+clickhouse:
+  enabled: true
+  persistence:
+    enabled: false
+
+#
+# For the purpose of this test, let's disable everything else
+#
+
+# PostHog
+web:
+  enabled: false
+migrate:
+  enabled: false
+events:
+  enabled: false
+beat:
+  enabled: false
+worker:
+  enabled: false
+plugins:
+  enabled: false
+
+# Services
+postgresql:
+  enabled: false
+redis:
+  enabled: false
+kafka:
+  enabled: false
+ingress:
+  enabled: false
+pgbouncer:
+  enabled: false

--- a/ci/values/kubetest/test_clickhouse_persistence_enabled.yaml
+++ b/ci/values/kubetest/test_clickhouse_persistence_enabled.yaml
@@ -1,0 +1,37 @@
+cloud: local
+
+clickhouse:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 1Gi
+
+#
+# For the purpose of this test, let's disable everything else
+#
+
+# PostHog
+web:
+  enabled: false
+migrate:
+  enabled: false
+events:
+  enabled: false
+beat:
+  enabled: false
+worker:
+  enabled: false
+plugins:
+  enabled: false
+
+# Services
+postgresql:
+  enabled: false
+redis:
+  enabled: false
+kafka:
+  enabled: false
+ingress:
+  enabled: false
+pgbouncer:
+  enabled: false

--- a/ci/values/kubetest/test_clickhouse_persistence_enabled_existing_claim.yaml
+++ b/ci/values/kubetest/test_clickhouse_persistence_enabled_existing_claim.yaml
@@ -1,0 +1,37 @@
+cloud: local
+
+clickhouse:
+  enabled: true
+  persistence:
+    enabled: true
+    existingClaim: custom-pvc
+
+#
+# For the purpose of this test, let's disable everything else
+#
+
+# PostHog
+web:
+  enabled: false
+migrate:
+  enabled: false
+events:
+  enabled: false
+beat:
+  enabled: false
+worker:
+  enabled: false
+plugins:
+  enabled: false
+
+# Services
+postgresql:
+  enabled: false
+redis:
+  enabled: false
+kafka:
+  enabled: false
+ingress:
+  enabled: false
+pgbouncer:
+  enabled: false

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -50,23 +50,23 @@ kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/crds" 
 kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/templates/clickhouse-operator" --exclude-kind CustomResourceDefinition --template '{{.kind | lower}}.yaml'
 
 #
-# Add a {{- if .Values.clickhouseOperator.enabled }} and {{- end }} at the end of each non-crds resource.
+# Add a {{- if .Values.clickhouse.enabled }} and {{- end }} at the end of each non-crds resource.
 # Also replace 'namespace: posthog' and '#namespace: posthog' with
-# {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }} so we can keep customizing where the operator is installed
+# {{ .Values.clickhouse.namespace | default .Release.Namespace }} so we can keep customizing where the operator is installed
 #
 FILES="${CHART_PATH}/templates/clickhouse-operator/*"
 for f in $FILES
 do
     sed -i '' '1i\
-{{- if .Values.clickhouseOperator.enabled }}
+{{- if .Values.clickhouse.enabled }}
     ' "$f"
 
     sed -i '' '$a\
 {{- end }}
     ' "$f"
 
-    sed -i '' 's/#namespace: posthog$/namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}/g' "$f"
+    sed -i '' 's/#namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
-    sed -i '' 's/namespace: posthog$/namespace: {{ .Values.clickhouseOperator.namespace | default .Release.Namespace }}/g' "$f"
+    sed -i '' 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
 done


### PR DESCRIPTION
## Description
1️⃣  Till this PR we've been including additional `StorageClass` definition into our chart only when using AWS and GCP. As extensively already discussed, this should be considered an anti-pattern as storage class definitions are global resources that only administrator should be able to manage.

Our chart should simply rely on the cluster default storage class and/or give our users the ability to customise which `StorageClass` to use.

2️⃣ This PR renames the `clickhouseOperator` values to `clickhouse` as they were never used to configured the operator:

* `clickhouseOperator.enabled` -> `clickhouse.enabled`
* `clickhouseOperator.namespace` -> `clickhouse.namespace`
* `clickhouseOperator.storage` -> `clickhouse.persistence.size`
* `clickhouseOperator.useNodeSelector` -> `clickhouse.useNodeSelector`
* `clickhouseOperator.serviceType` -> `clickhouse.serviceType`

we also renamed `clickhouse.persistentVolumeClaim` to `clickhouse.persistence.existingClaim` to align the naming with the  bitnami charts.


Related issues:
* https://github.com/PostHog/charts-clickhouse/issues/174
* https://github.com/PostHog/charts-clickhouse/issues/214
* https://github.com/PostHog/charts-clickhouse/issues/215

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
- CI is ✅ 
- Verified that if a AWS/GCP user doesn't read the release note and runs an upgrade with the default `installCustomStorageClass: false` the custom `StorageClass` is removed but the underlying volumes don't get deleted. 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
