### PR TITLE
cert-manager: use custom DNS

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -315,6 +315,26 @@ cert-manager:
   # -- Whether to install cert-manager CRDs.
   installCRDs: true
 
+  #
+  # [Workaround] - do not use the local DNS for the 'cert-manager' pods since it would return local IPs
+  # and break self checks.
+  #
+  # For more info see:
+  #   - https://github.com/jetstack/cert-manager/issues/1292
+  #   - https://github.com/jetstack/cert-manager/issues/3238
+  #   - https://github.com/jetstack/cert-manager/issues/4286
+  #   - https://github.com/compumike/hairpin-proxy
+  #
+  # This has some side effects, like 'cert-manager' pods not being able to resolve cluster-local names,
+  # but so far this has not caused issues (and we don't expect it to do so).
+  #
+  podDnsPolicy: None
+  podDnsConfig:
+    nameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+      - 208.67.222.222
+
 ingress:
   # -- Enable ingress controller resource
   enabled: true


### PR DESCRIPTION
## Description
By default, do not use the local DNS for the 'cert-manager' pods. See code comments for more info.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing

I've also verified the new defined DNS are used (note the `1.1.1.1:53` in the output)
```
E1213 14:12:39.046081       1 sync.go:186] cert-manager/controller/challenges "msg"="propagation check failed" "error"="failed to perform self check GET request 'http://test-guido.posthog.cc/.well-known/acme-challenge/5QeEvG03joqddbegPsw2M36gISBCY3tGWA2kKPkB5Is': Get \"http://test-guido.posthog.cc/.well-known/acme-challenge/5QeEvG03joqddbegPsw2M36gISBCY3tGWA2kKPkB5Is\": dial tcp: lookup test-guido.posthog.cc on 1.1.1.1:53: no such host" "dnsName"="test-guido.posthog.cc" "resource_kind"="Challenge" "resource_name"="nginx-letsencrypt-posthog-bhdgg-785202495-1807317267" "resource_namespace"="posthog" "resource_version"="v1" "type"="HTTP-01"
``` 

## Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
