### PR TITLE
Add celery worker cpu request

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -169,7 +169,8 @@ worker:
   replicacount: 1
   # -- Resource limits for workers
   resources:
-    {}
+    requests:
+      cpu: 3000m
     # limits:
     #   cpu: 300m
     #   memory: 500Mi


### PR DESCRIPTION
## Description

**Friendly reminder that I'm way out of my depth with Helm charts.**

Essentially, as part of the special migrations work, I'd like to bump Celery specs a bit.

There are 2 ways to do this:

- Set min replicas to 2
- Bump CPU request

Here I'm going with a CPU request bump as Celery will run _n_ worker processes where _n == n cores_. Our default deployments seem to be giving us 2 cores, and adding an extra one ensures Celery can have the same throughput while we hijack a worker for special migrations.

I guess this is a breaking change? Maybe the replicas approach is better?

Just sparking discussion here. I'd rather have a sensible default than write on the release notes that people should bump celery replicas on upgrades.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

It hasn't

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
