### PR TITLE
Add clickhouse.volumePermissions.enabled: true

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -113,7 +113,7 @@ spec:
               args:
                 - -ec
                 - |
-                  chown -R "{{ .Values.clickhouseOperator.securityContext.runAsUser }}:{{ .Values.clickhouseOperator.securityContext.runAsGroup }}" "/var/lib/clickhouse"
+                  chown -R "{{ .Values.clickhouse.securityContext.runAsUser }}:{{ .Values.clickhouse.securityContext.runAsGroup }}" "/var/lib/clickhouse"
               securityContext:
                 runAsUser: 0
               resources:

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -103,6 +103,30 @@ spec:
           {{- if .Values.clickhouse.securityContext.enabled }}
           securityContext: {{- omit .Values.clickhouse.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.clickhouse.volumePermissions.enabled }}
+          initContainers:
+            - name: volume-permissions
+              image: docker.io/bitnami/minideb:buster
+              imagePullPolicy: "Always"
+              command:
+                - /bin/bash
+              args:
+                - -ec
+                - |
+                  chown -R "{{ .Values.clickhouseOperator.securityContext.runAsUser }}:{{ .Values.clickhouseOperator.securityContext.runAsGroup }}" "/var/lib/clickhouse"
+              securityContext:
+                runAsUser: 0
+              resources:
+                limits: {}
+                requests: {}
+              volumeMounts:
+              {{- if (eq (include "clickhouse.externalVolume" .) "false" ) }}
+                - name: data-volumeclaim-template
+              {{- else }}
+                - name: clickhouse-storage
+              {{- end }}
+                  mountPath: /var/lib/clickhouse
+          {{- end }}
           containers:
             - name: clickhouse
               # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH


### PR DESCRIPTION
## Description
Make configuration consistent with all bitnami helm charts.

For example Redis' volumePermissions.enabled: https://github.com/bitnami/charts/blob/master/bitnami/redis/README.md#init-container-parameters

This is needed in the case you bump into permission issues when mounting a PVC.
I couldn't get Posthog working on IBM Cloud without setting volumePermissions.enabled on all the stateful services.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
