### PR TITLE
CI - add timeout to TLS cert step

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -71,7 +71,7 @@ jobs:
           --name ${{ steps.vars.outputs.k8s_cluster_name }} \
           --region=us-east-1 \
           --zones="us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
-          --instance-types="t3a.small" \
+          --instance-types="t3a.medium" \
           --tags="provisioned_by=github_action" \
           --version 1.21 \
           --nodes 3

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -71,7 +71,7 @@ jobs:
           --name ${{ steps.vars.outputs.k8s_cluster_name }} \
           --region=us-east-1 \
           --zones="us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
-          --instance-types="t3.medium" \
+          --instance-types="t3a.small" \
           --tags="provisioned_by=github_action" \
           --version 1.21 \
           --nodes 3

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -122,6 +122,7 @@ jobs:
 
     - name: Wait for the Let's Encrypt certificate to be issued and deployed
       id: tls_certificate_creation
+      timeout-minutes: 60
       run: |
         echo "Wait for the Let's Encrypt certificate to be issued and deployed..."
         while ! kubectl wait --for=condition=Ready --timeout=60s certificaterequest --all -n posthog > /dev/null 2>&1

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -53,7 +53,7 @@ jobs:
           --region us-central1 \
           --cluster-version 1.21 \
           --labels="provisioned_by=github_action" \
-          --machine-type e2-medium \
+          --machine-type e2-small \
           --num-nodes 2
 
         # note: num-nodes will be created in each zone, such that if you specify
@@ -138,6 +138,7 @@ jobs:
 
     - name: Wait for the Google-managed TLS certificate to be issued and deployed
       id: tls_certificate_creation
+      timeout-minutes: 60
       run: |
         echo "Wait for the Google-managed TLS certificate to be issued and deployed..."
         certificate_status=""
@@ -158,9 +159,8 @@ jobs:
 
     #
     # TODO: the GCE Ingress is not picking up health check from readiness probe definition and it's using '/'
-    # instead. We need to fix this issue before being able to enable the k6 ingestion test.
-    #
-    # see: https://stackoverflow.com/questions/44584270/
+    # instead. We need to fix this issue before being able to enable the k6 ingestion test
+    # See WIP at https://github.com/PostHog/charts-clickhouse/pull/209
     #
     # - name: Run ingestion test using k6
     #   uses: k6io/action@v0.2.0
@@ -178,7 +178,7 @@ jobs:
     #
     - name: Fetch the associated NEG (Network Endpoint Groups)
       id: fetch_neg
-      if: ${{ always() && steps.helm_install.outcome == 'success' }}
+      if: ${{ always() }}
       shell: bash
       run: |
         #
@@ -209,7 +209,7 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }}
 
     - name: Delete the associated NEG (Network Endpoint Groups)
-      if: ${{ always() && steps.helm_install.outcome == 'success' && steps.fetch_neg.outcome == 'success' }}
+      if: ${{ always() && steps.fetch_neg.outcome == 'success' }}
       shell: bash
       run: |
         delete_neg() {


### PR DESCRIPTION
## Description
1. as requested by @tiina303 [here](https://github.com/PostHog/charts-clickhouse/pull/229#discussion_r770596929) let's always run the `Fetch the associated NEG` step.
2. add a timeout for the TLS cert step
3. use smaller nodes, cheaper is better

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
