### PR TITLE
Fix typo in `charts/posthog/Chart.lock` :facepalm:

### DIFF
--- a/charts/posthog/Chart.lock
+++ b/charts/posthog/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: prometheus-statsd-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 0.3.1
-digest: sha256:ccab4418b09d515e2c094b43d4932e3eb0ecbeaf5359e2e211de2e15a9947d83
-generated: "2021-12-10T16:01:43.582712+01:00"
+digest: sha256:e442ce20b1f51d79395e08abe6c968ac3e3d1cd66e5ef13296aee85b5fd06c61
+generated: "2021-12-21T12:26:31.673037+01:00"

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -41,7 +41,7 @@ dependencies:
   - name: kafka
     version: 12.6.0
     repository: https://charts.bitnami.com/bitnami
-    condition: kafka.enable
+    condition: kafka.enabled
   - name: ingress-nginx
     version: 4.0.13
     repository: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
## Description
This typo has been introduced via #1 and it's present since the beginning of this repo. Everywhere in the codebase we use `kafka.enabled` while in the logic to include it or not we used `kafka.enable`. This mean we are always installing Kafka also when passing the `kafka.enabled` override.

I've discovered this bug while working on more integration tests I'll probably push after the holiday break.  

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is passing + local testing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
