### PR TITLE
K8s: move supported version to >=1.20 <= 1.23

### DIFF
--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -21,13 +21,13 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
+          - k3s-channel: v1.23
+            test: install
           - k3s-channel: v1.22
             test: install
           - k3s-channel: v1.21
             test: install
           - k3s-channel: v1.20
-            test: install
-          - k3s-channel: v1.19
             test: install
 
           # We run an upgrade test where we first install an already released
@@ -36,7 +36,7 @@ jobs:
           #
           # It can be very useful to see the "Helm diff" step's output from the
           # latest dev version.
-          - k3s-channel: v1.19
+          - k3s-channel: v1.21
             test: upgrade
 
     steps:

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">= 1.19-0 <= 1.22-0"
+kubeVersion: ">= 1.20-0 <= 1.23-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [PostHog](https://posthog.com/) deployment on a [Kuberne
 See deployment instructions on [posthog.com/docs/self-host](https://posthog.com/docs/self-host).
 
 ## Prerequisites
-- Kubernetes >=1.19 <= 1.22
+- Kubernetes >=1.20 <= 1.23
 - Helm 3+
 
 ## Development


### PR DESCRIPTION
## Description
* drop support for k8s version 1.19 as it is end of life since 2021-10-28
* add support for k8s version 1.23 [announced on Dec 7th](https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/)

~~Note: CI for 1.23 is still failing as there isn't yet k3s support available.~~

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
