### PR TITLE
CI - Fix helm-diff

### DIFF
--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -1,7 +1,4 @@
-# This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
-#
-name: Test chart
+name: e2e - k3s
 
 on:
   workflow_dispatch:
@@ -69,7 +66,7 @@ jobs:
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
         run: |
-          helm plugin install https://github.com/databus23/helm-diff
+          helm plugin install https://github.com/databus23/helm-diff --version 3.1.3
 
       - name: "(Upgrade) Helm diff ${{ matrix.upgrade-from }} chart with local chart"
         if: matrix.test == 'upgrade'
@@ -78,10 +75,11 @@ jobs:
 
       - name: "(Upgrade) Await chart install"
         if: matrix.test == 'upgrade'
-        uses: jupyterhub/action-k8s-await-workloads@v1
+        uses: jupyterhub/action-k8s-await-workloads@main
         with:
-          timeout: 900
-          max-restarts: 15
+          namespace: "posthog"
+          timeout: 300
+          max-restarts: 10
 
       - name: Install our helm chart
         run: |


### PR DESCRIPTION
## Description
The `helm-diff` plugin we use in CI is broken since ~15h due to a regression introduced upstream. Let's pin to the latest stable version 3.1.3 till it doesn't get fixed.

See upstream issues:
- https://github.com/databus23/helm-diff/issues/322
- https://github.com/databus23/helm-diff/issues/324

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
