### PR TITLE
Add support for `DEMO` env var

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -16,6 +16,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | cloud | string | `nil` | Required: Cloud service being deployed on. Either `gcp` or `aws` or `do` for DigitalOcean |
 | sentryDSN | string | `nil` | Sentry endpoint to send errors to |
+| demo | bool | `nil` | Whether this is a demo instance of PostHog |
 | clickhouseOperator.enabled | bool | `true` | Whether to install clickhouse. If false, `clickhouse.host` must be set |
 | clickhouseOperator.namespace | string | `nil` | Which namespace to install clickhouse operator to (defaults to namespace chart is installed to) |
 | clickhouseOperator.storage | string | `"20Gi"` | How much storage space to preallocate for clickhouse |

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -77,6 +77,8 @@ spec:
           value: {{ template "posthog.site.url" . }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
+        - name: DEMO
+          value: {{ .Values.demo | quote }}
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: DISABLE_SECURE_SSL_REDIRECT

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -62,6 +62,8 @@ spec:
           value: {{ template "posthog.site.url" . }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
+        - name: DEMO
+          value: {{ .Values.demo | quote }}
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -80,6 +80,8 @@ spec:
           value: {{ .Values.sentryDSN | quote }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
+        - name: DEMO
+          value: {{ .Values.demo | quote }}
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -77,6 +77,8 @@ spec:
           value: {{ template "posthog.site.url" . }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
+        - name: DEMO
+          value: {{ .Values.demo | quote }}
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: DISABLE_SECURE_SSL_REDIRECT

--- a/charts/posthog/templates/workers-deployment.yaml
+++ b/charts/posthog/templates/workers-deployment.yaml
@@ -80,6 +80,8 @@ spec:
           value: {{ template "posthog.site.url" . }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
+        - name: DEMO
+          value: {{ .Values.demo | quote }}
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: SECRET_KEY

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -17,6 +17,8 @@ image:
 cloud:
 # -- Sentry endpoint to send errors to
 sentryDSN:
+# -- Whether this is a demo instance of PostHog
+demo:
 
 clickhouseOperator:
   # -- Whether to install clickhouse. If false, `clickhouse.host` must be set


### PR DESCRIPTION
## Description

Adding support for https://github.com/PostHog/posthog/pull/7824.

I'm really inexperienced with Kubernetes though, so: is putting the YAML below in the deployment's `values.yaml` the right way of enabling this PR's env var `DEMO` and switching the Docker image tag from the release to `latest`?

```yaml
demo: true
image:
  tag: latest
```

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Not tested yet, have to set up Kubernetes locally.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
