### PR TITLE
Add 'enabled' flag for all services

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.events.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -210,3 +211,4 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+{{- end }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -20,8 +20,8 @@ spec:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
         role: events
-  {{- if not .Values.web.hpa.enabled }}
-  replicas: {{ .Values.web.replicacount }}
+  {{- if not .Values.events.hpa.enabled }}
+  replicas: {{ .Values.events.replicacount }}
   {{- end }}
   template:
     metadata:

--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.web.hpa.enabled -}}
+{{- if and .Values.events.enabled .Values.events.hpa.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-events
-  minReplicas: {{ .Values.web.hpa.minpods }}
-  maxReplicas: {{ .Values.web.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+  minReplicas: {{ .Values.events.hpa.minpods }}
+  maxReplicas: {{ .Values.events.hpa.maxpods }}
+  targetCPUUtilizationPercentage: {{ .Values.events.hpa.cputhreshold }}
 {{- end }}

--- a/charts/posthog/templates/events-service.yaml
+++ b/charts/posthog/templates/events-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.events.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,3 +37,4 @@ spec:
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migrate.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -152,3 +153,4 @@ spec:
           value: {{ template "posthog.helmInstallInfo" . }}
         resources:
 {{ toYaml .Values.hooks.migrate.resources | indent 10 }}
+{{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pgbouncer.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,3 +92,4 @@ spec:
     {{- if .Values.pgbouncer.extraVolumes }}
       volumes: {{- toYaml .Values.pgbouncer.extraVolumes | nindent 6 }}
     {{- end }}
+{{- end }}

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pgbouncer.hpa.enabled -}}
+{{- if and .Values.pgbouncer.enabled .Values.pgbouncer.hpa.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/posthog/templates/pgbouncer-service.yaml
+++ b/charts/posthog/templates/pgbouncer-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pgbouncer.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,12 +9,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  type: "ClusterIP" 
+  type: "ClusterIP"
   ports:
-  - port: 6543 
-    targetPort: 6543 
+  - port: 6543
+    targetPort: 6543
     protocol: TCP
     name: {{ template "posthog.fullname" . }}-pgbouncer
   selector:
     app: {{ template "posthog.fullname" . }}
-    role: pgbouncer 
+    role: pgbouncer
+{{- end }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.plugins.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -149,3 +150,4 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}
+{{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.plugins.hpa.enabled -}}
+{{- if and .Values.plugins.enabled .Values.plugins.hpa.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -232,3 +233,4 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+{{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.web.hpa.enabled -}}
+{{- if and .Values.web.enabled .Values.web.hpa.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/posthog/templates/web-service.yaml
+++ b/charts/posthog/templates/web-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,3 +37,4 @@ spec:
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,3 +186,4 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
+{{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.worker.hpa.enabled -}}
+{{- if and .Values.worker.enabled .Values.worker.hpa.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -1,0 +1,34 @@
+suite: PostHog events deployment definition
+templates:
+  - templates/events-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if events.enabled is set to false
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      events.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -1,0 +1,48 @@
+suite: PostHog events HPA definition
+templates:
+  - templates/events-hpa.yaml
+
+tests:
+  - it: should be empty if events.enabled and events.hpa.enabled are set to false
+    set:
+      events.enabled: false
+      events.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if events.enabled is true and events.hpa.enabled is set to false
+    set:
+      events.enabled: true
+      events.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if events.enabled and events.hpa.enabled are set to true
+    set:
+      events.enabled: true
+      events.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      events.enabled: true
+      events.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v1
+
+  - it: should be the correct kind
+    set:
+      events.enabled: true
+      events.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler

--- a/charts/posthog/tests/events-service.yaml
+++ b/charts/posthog/tests/events-service.yaml
@@ -1,0 +1,30 @@
+suite: PostHog events service definition
+templates:
+  - templates/events-service.yaml
+
+tests:
+  - it: should be empty if events.enabled is set to false
+    set:
+      events.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if events.enabled is set to true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/tests/migrate-job.yaml
+++ b/charts/posthog/tests/migrate-job.yaml
@@ -1,0 +1,34 @@
+suite: PostHog events deployment definition
+templates:
+  - templates/migrate.job.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if migrate.enabled is set to false
+    template: templates/migrate.job.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      migrate.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/migrate.job.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: batch/v1
+
+  - it: should be the correct kind
+    template: templates/migrate.job.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job

--- a/charts/posthog/tests/pgbouncer-deployment.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment.yaml
@@ -1,0 +1,34 @@
+suite: PostHog pgbouncer deployment definition
+templates:
+  - templates/pgbouncer-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if pgbouncer.enabled is set to false
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/posthog/tests/pgbouncer-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-hpa.yaml
@@ -1,0 +1,48 @@
+suite: PostHog pgbouncer HPA definition
+templates:
+  - templates/pgbouncer-hpa.yaml
+
+tests:
+  - it: should be empty if pgbouncer.enabled and pgbouncer.hpa.enabled are set to false
+    set:
+      pgbouncer.enabled: false
+      pgbouncer.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if pgbouncer.enabled is true and pgbouncer.hpa.enabled is set to false
+    set:
+      pgbouncer.enabled: true
+      pgbouncer.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if pgbouncer.enabled and pgbouncer.hpa.enabled are set to true
+    set:
+      pgbouncer.enabled: true
+      pgbouncer.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      pgbouncer.enabled: true
+      pgbouncer.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v1
+
+  - it: should be the correct kind
+    set:
+      pgbouncer.enabled: true
+      pgbouncer.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler

--- a/charts/posthog/tests/pgbouncer-service.yaml
+++ b/charts/posthog/tests/pgbouncer-service.yaml
@@ -1,0 +1,30 @@
+suite: PostHog pgbouncer service definition
+templates:
+  - templates/pgbouncer-service.yaml
+
+tests:
+  - it: should be empty if pgbouncer.enabled is set to false
+    set:
+      pgbouncer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if pgbouncer.enabled is set to true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/tests/plugins-deployment.yaml
+++ b/charts/posthog/tests/plugins-deployment.yaml
@@ -1,0 +1,34 @@
+suite: PostHog plugins deployment definition
+templates:
+  - templates/plugins-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if plugins.enabled is set to false
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      plugins.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -1,0 +1,48 @@
+suite: PostHog plugins HPA definition
+templates:
+  - templates/plugins-hpa.yaml
+
+tests:
+  - it: should be empty if plugins.enabled and plugins.hpa.enabled are set to false
+    set:
+      plugins.enabled: false
+      plugins.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if plugins.enabled is true and plugins.hpa.enabled is set to false
+    set:
+      plugins.enabled: true
+      plugins.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if plugins.enabled and plugins.hpa.enabled are set to true
+    set:
+      plugins.enabled: true
+      plugins.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      plugins.enabled: true
+      plugins.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v1
+
+  - it: should be the correct kind
+    set:
+      plugins.enabled: true
+      plugins.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -1,0 +1,34 @@
+suite: PostHog web deployment definition
+templates:
+  - templates/web-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if web.enabled is set to false
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      web.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -1,0 +1,48 @@
+suite: PostHog web HPA definition
+templates:
+  - templates/web-hpa.yaml
+
+tests:
+  - it: should be empty if web.enabled and web.hpa.enabled are set to false
+    set:
+      web.enabled: false
+      web.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if web.enabled is true and web.hpa.enabled is set to false
+    set:
+      web.enabled: true
+      web.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if web.enabled and web.hpa.enabled are set to true
+    set:
+      web.enabled: true
+      web.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      web.enabled: true
+      web.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v1
+
+  - it: should be the correct kind
+    set:
+      web.enabled: true
+      web.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler

--- a/charts/posthog/tests/web-service.yaml
+++ b/charts/posthog/tests/web-service.yaml
@@ -1,0 +1,30 @@
+suite: PostHog web service definition
+templates:
+  - templates/web-service.yaml
+
+tests:
+  - it: should be empty if web.enabled is set to false
+    set:
+      web.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if web.enabled is set to true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/tests/worker-deployment.yaml
+++ b/charts/posthog/tests/worker-deployment.yaml
@@ -1,0 +1,34 @@
+suite: PostHog worker deployment definition
+templates:
+  - templates/worker-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if worker.enabled is set to false
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      worker.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -1,0 +1,48 @@
+suite: PostHog worker HPA definition
+templates:
+  - templates/worker-hpa.yaml
+
+tests:
+  - it: should be empty if worker.enabled and worker.hpa.enabled are set to false
+    set:
+      worker.enabled: false
+      worker.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if worker.enabled is true and worker.hpa.enabled is set to false
+    set:
+      worker.enabled: true
+      worker.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if worker.enabled and worker.hpa.enabled are set to true
+    set:
+      worker.enabled: true
+      worker.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      worker.enabled: true
+      worker.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v1
+
+  - it: should be the correct kind
+    set:
+      worker.enabled: true
+      worker.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -39,6 +39,8 @@ env:
 
 # -- PgBouncer setup
 pgbouncer:
+   # -- Whether to install PGBouncer or not
+  enabled: true
   hpa:
     # -- Boolean to create a HorizontalPodAutoscaler for pgbouncer
     # -- This experimental and set up based on cpu utilization
@@ -59,7 +61,30 @@ pgbouncer:
   # -- Additional volumes to be added to the pgbouncer deployment
   extraVolumes: []
 
+migrate:
+  # -- Whether to install the PostHog migrate job or not
+  enabled: true
+
+events:
+  # -- Whether to install the PostHog events stack or not
+  enabled: true
+  # -- events horizontal pod autoscaler settings
+  hpa:
+    # -- Boolean to create a HorizontalPodAutoscaler for events stack
+    # -- This experimental
+    enabled: false
+    # -- CPU threshold percent for the events stack
+    cputhreshold: 60
+    # -- Min pods for the events stack
+    minpods: 1
+    # -- Max pods for the events stack
+    maxpods: 10
+  # -- Amount of events pods to run. Ignored if hpa is used
+  replicacount: 1
+
 web:
+  # -- Whether to install the PostHog web stack or not
+  enabled: true
   # -- Web horizontal pod autoscaler settings
   hpa:
     # -- Boolean to create a HorizontalPodAutoscaler for web
@@ -137,6 +162,8 @@ web:
   # podLabels: []
 
 worker:
+   # -- Whether to install the PostHog worker stack or not
+  enabled: true
   hpa:
     # -- Boolean to create a HorizontalPodAutoscaler for worker
     # -- This experimental
@@ -167,6 +194,8 @@ worker:
 
 # How many plugin server instances to run
 plugins:
+   # -- Whether to install the PostHog plugin stack or not
+  enabled: true
   ingestion:
     # -- Whether to enable plugin-server based ingestion
     enabled: true


### PR DESCRIPTION
## Description
This PR introduces few new Helm values to make the installation of all components optional:

- `pgbouncer.enabled`
- `migrate.enabled`
- `events.enabled`
- `web.enabled`
- `worker.enabled`
- `plugins.enabled`

all the above defaults are `true` so this change is technically a no-op. I've also took the opportunity to add:
 
- `events.hpa.enabled`
- `events.hpa.cputhreshold`
- `events.hpa.minpods`
- `events.hpa.maxpods`
- `events.hpa.replicacount`

to be able to control the HPA of the events deployment. 

This PR will be useful for test suite only verifying a single component (e.g. why should I install PostgreSQL if my test suite is targeting ClickHouse?)  

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
