### PR TITLE
Remove reference to 'CLICKHOUSE_INITIAL_MIGRATIONS'

### DIFF
--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -110,10 +110,6 @@ spec:
               name: {{ template "posthog.fullname" . }}
             {{- end }}
               key: smtp-password
-        {{- if .Release.IsInstall }}
-        - name: CLICKHOUSE_INITIAL_MIGRATIONS
-          value: '1'
-        {{- end }}
         - name: PRIMARY_DB
           value: clickhouse
         - name: CLICKHOUSE_DATABASE


### PR DESCRIPTION
## Description
Remove reference to the deprecated `CLICKHOUSE_INITIAL_MIGRATIONS` env variable. 

## How did you test this code?
I didn't find any reference to `CLICKHOUSE_INITIAL_MIGRATIONS` in our codebase (see also https://github.com/PostHog/posthog/pull/7960)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
