### PR TITLE
Update kafka default partitions number per topic

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -452,6 +452,8 @@ kafka:
   logRetentionBytes: _15_000_000_000
   # -- The minimum age of a log file to be eligible for deletion due to age
   logRetentionHours: 24
+  # -- The default number of partitions per topic	
+  numPartitions: 12
   zookeeper:
     # -- Install zookeeper on kubernetes
     enabled: false


### PR DESCRIPTION
## Description

Partitions per kafka topic is currently set to the default of 1. This makes scaling horizontally services like the plugin servers a problem, as additional servers will sit and do nothing since one plugin server is already handling the only partition available. 


## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
