### PR TITLE
dev(codespaces): add basic code spaces setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/ubuntu
+{
+	"name": "Ubuntu with kind",
+	"image": "mcr.microsoft.com/vscode/devcontainers/universal:1-linux",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-kubernetes-tools.vscode-kubernetes-tools",
+		"tomaciazek.ansible"
+	],
+
+	"forwardPorts": [8000, 4330],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/setup_container.sh"
+}

--- a/.devcontainer/setup_container.sh
+++ b/.devcontainer/setup_container.sh
@@ -1,0 +1,45 @@
+#/usr/bin/env bash
+
+set -e -o pipefail
+
+# Setup a cluster with kind + nginx ingress
+
+# Install kind so we can create a cluster as per
+# https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+chmod +x ./kind
+mkdir -p ~/.local/bin/
+mv ./kind ~/.local/bin/kind
+
+# We use a cluster config that adds ingress-ready=true to each node as per
+# https://kind.sigs.k8s.io/docs/user/ingress/#create-cluster
+# 
+# This should mean you can go to port http://localhost:8000 or
+# https://localhost:4430 to view the running posthog app once deployed to the
+# cluster, and once VSCode has forwarded the ports
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8000
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 4430
+    protocol: TCP
+EOF
+
+# Then provision the nginx controller, e.g.
+# https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx 
+# NOTE: I've pinned the version here
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/d8c9a6c238f714587da4d2ac2dcd0d3d39419ccf/deploy/static/provider/kind/deploy.yaml
+
+echo "printf 'Hello 🦔! To install PostHog into k8s run this:\n\n "helm upgrade --install posthog charts/posthog --set cloud=private"\n'" >> ~/.zshrc


### PR DESCRIPTION
This just uses the github codespaces "universal" image, which has things
like kubectl, helm etc. and then adds in kind and creates a cluster.

I'm using the universal image with the hope that this will be caches on
the codespaces nodes :fingerscrossed:

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
