### PR TITLE
Fix web-hpa config

### DIFF
--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -2,6 +2,7 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
+  name: {{ template "posthog.fullname" . }}-web
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   scaleTargetRef:


### PR DESCRIPTION
## Description
With https://github.com/PostHog/charts-clickhouse/pull/179 we've removed by mistake the `name` metadata field in the web hpa template. This can causes errors on upgrade if HPA is enabled (thank you @legion2 for [the report](https://github.com/PostHog/charts-clickhouse/pull/179#discussion_r789451655)).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
