### PR TITLE
Fix template defaults for ClickHouse

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -18,7 +18,7 @@ spec:
       - name: {{ .Values.clickhouse.database | quote }}
         templates:
           podTemplate: pod-template
-          serviceTemplate: service-template
+          clusterServiceTemplate: service-template
           {{- if and (.Values.clickhouse.persistence.enabled) (not .Values.clickhouse.persistence.existingClaim) }}
           dataVolumeClaimTemplate: data-volumeclaim-template
           {{- end }}

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -12,9 +12,9 @@ the manifest should match the snapshot when using default values:
             shardsCount: 1
           name: posthog
           templates:
+            clusterServiceTemplate: service-template
             dataVolumeClaimTemplate: data-volumeclaim-template
             podTemplate: pod-template
-            serviceTemplate: service-template
         files:
           events.proto: |
             syntax = "proto3";

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -46,7 +46,7 @@ tests:
           path: spec.configuration.clusters[0].templates
           value:
             podTemplate: pod-template
-            serviceTemplate: service-template
+            clusterServiceTemplate: service-template
 
   - it: spec.configuration.cluster[0].templates volumeClaimTemplate should not exist if persistence is enabled and clickhouse.persistence.existingClaim is set
     set:
@@ -59,7 +59,7 @@ tests:
           path: spec.configuration.clusters[0].templates
           value:
             podTemplate: pod-template
-            serviceTemplate: service-template
+            clusterServiceTemplate: service-template
 
   - it: spec.configuration.cluster[0].templates volumeClaimTemplate should exist if persistence is enabled
     set:
@@ -71,7 +71,7 @@ tests:
           path: spec.configuration.clusters[0].templates
           value:
             podTemplate: pod-template
-            serviceTemplate: service-template
+            clusterServiceTemplate: service-template
             dataVolumeClaimTemplate: data-volumeclaim-template
 
 


### PR DESCRIPTION
## Description
With https://github.com/PostHog/charts-clickhouse/pull/224 we moved the `ClickHouseInstallation` defaults to be cluster specific but we introduced an unexpected regression (due to the `clusterServiceTemplate` -> `serviceTemplate` difference) that we are now fixing. 

Instead of using the custom settings we specify in `service-template` we were instead using the defaults.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
