### PR TITLE
clickhouse-operator config map: fix `listen_host`

### DIFF
--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -215,8 +215,6 @@ data:
     <yandex>
         <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
         <listen_host>::</listen_host>
-        <listen_host>0.0.0.0</listen_host>
-        <listen_try>1</listen_try>
     </yandex>
 
   01-clickhouse-02-logger.xml: |

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
@@ -188,8 +188,6 @@ the manifest should match the snapshot when using default values:
         <yandex>
             <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
             <listen_host>::</listen_host>
-            <listen_host>0.0.0.0</listen_host>
-            <listen_try>1</listen_try>
         </yandex>
       01-clickhouse-02-logger.xml: |
         <yandex>


### PR DESCRIPTION
## Description

I couldn't get the chart working locally with `kind`. Digging in, the
issue seemed to be that clickhouse failed to bind to 0.0.0.0.

This change makes it so we don't try to double-bind - :: already covers
0.0.0.0. As to why this only affected my setup - no clue, but the bug
seems pretty obvious.

Related docs link: https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-listen_host

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

I removed the lines, uninstalled and re-ran helm install. It now worked.

Note:
- this does _not_ restart the clickhouse pod
- configmap does not seem to get updated automatically when it changes. In essence this change only affects new installs
  - When I added a line to the file and ran `kubectl exec --stdin --tty chi-posthog-posthog-0-0-0 -n posthog -- cat /etc/clickhouse-server/config.d/01-clickhouse-01-listen.xml` the contents were the same. 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

cc @guidoiaquinti - would love some guidance on what level of testing do you think is appropriate here.