### PR TITLE
Allow passing custom clickhouse settings

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -12,7 +12,7 @@ spec:
       admin/quota: default
 
     profiles:
-      {{- merge dict .Values.clickhouse.defaultProfiles .Values.clickhouse.profiles | toYaml | nindent 6 }}
+      {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}
 
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -13,6 +13,9 @@ spec:
 
     profiles:
       default/allow_experimental_window_functions: "1"
+      {{- if .Values.clickhouse.profiles }}
+      {{- toYaml .Values.clickhouse.profiles | nindent 6 }}
+      {{- end }}
 
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -12,10 +12,7 @@ spec:
       admin/quota: default
 
     profiles:
-      default/allow_experimental_window_functions: "1"
-      {{- if .Values.clickhouse.profiles }}
-      {{- toYaml .Values.clickhouse.profiles | nindent 6 }}
-      {{- end }}
+      {{- merge dict .Values.clickhouse.defaultProfiles .Values.clickhouse.profiles | toYaml | nindent 6 }}
 
     clusters:
       - name: {{ .Values.clickhouse.database | quote }}

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -202,3 +202,38 @@ tests:
       - equal:
           path: spec.templates.volumeClaimTemplates[0].spec.storageClassName
           value: customStorageClass
+
+  - it: default profiles configuration should be correct
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.profiles
+          value:
+            default/allow_experimental_window_functions: "1"
+
+  - it: handles custom profiles configuration
+    set:
+      clickhouse.profiles.default/max_execution_time: "90"
+      clickhouse.profiles.default/max_memory_usage: "20000000000"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.profiles
+          value:
+            default/allow_experimental_window_functions: "1"
+            default/max_execution_time: "90"
+            default/max_memory_usage: "20000000000"
+
+
+  - it: handles custom profiles overriding defaults
+    set:
+      clickhouse.profiles.default/allow_experimental_window_functions: "0"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.profiles
+          value:
+            default/allow_experimental_window_functions: "0"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -8,7 +8,7 @@ image:
   sha:
   # -- Posthog image tag, e.g. release-1.31.1
   tag:
-  # -- Default image or tag, e.g. `:release-1.31.1` Do not overwrite!
+  # -- Default image or tag, e.g. `:release-1.31.1` Do not overwrite, use image.sha or image.tag instead.
   default: ":release-1.31.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -556,6 +556,11 @@ clickhouse:
     ##
     size: 20Gi
 
+  ## clickhouse.profiles -- (object) Clickhouse user profile configuration.
+  ## You can use this to override settings, for example `default/max_memory_usage: 40000000000`
+  ## For a full list of clickhouse settings, see https://clickhouse.com/docs/en/operations/settings/settings/
+  profiles:
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -8,7 +8,7 @@ image:
   sha:
   # -- Posthog image tag, e.g. release-1.31.1
   tag:
-  # -- Default image or tag, e.g. :release-1.31.1
+  # -- Default image or tag, e.g. `:release-1.31.1` Do not overwrite!
   default: ":release-1.31.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
@@ -556,10 +556,14 @@ clickhouse:
     ##
     size: 20Gi
 
-  ## clickhouse.profiles -- (object) Clickhouse user profile configuration.
+  ## -- Clickhouse user profile configuration.
   ## You can use this to override settings, for example `default/max_memory_usage: 40000000000`
   ## For a full list of clickhouse settings, see https://clickhouse.com/docs/en/operations/settings/settings/
-  profiles:
+  profiles: {}
+
+  ## -- Default user profile configuration for Clickhouse. Don't overwrite this!
+  defaultProfiles:
+    default/allow_experimental_window_functions: "1"
 
 ## Prometheus Exporter / Metrics
 ##

--- a/ci/kubetest/test_clickhouse_custom_settings_profile.py
+++ b/ci/kubetest/test_clickhouse_custom_settings_profile.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+
+from utils import cleanup_k8s, install_chart, kubectl_exec, wait_for_pods_to_be_ready
+
+VALUES_YAML = """
+cloud: local
+
+clickhouse:
+  profiles:
+    default/max_execution_time: 90
+    default/max_memory_usage: 20000000000
+
+#
+# For the purpose of this test, let's disable everything else
+#
+
+# PostHog
+web:
+  enabled: false
+migrate:
+  enabled: false
+events:
+  enabled: false
+worker:
+  enabled: false
+plugins:
+  enabled: false
+
+# Services
+postgresql:
+  enabled: false
+redis:
+  enabled: false
+kafka:
+  enabled: false
+ingress:
+  enabled: false
+pgbouncer:
+  enabled: false
+"""
+
+
+@pytest.fixture
+def setup(kube):
+    cleanup_k8s()
+    install_chart(VALUES_YAML)
+    wait_for_pods_to_be_ready(kube)
+
+
+def test_custom_clickhouse_settings_profile(setup, kube):
+    command = f"clickhouse-client -q \"SELECT name, value FROM system.settings WHERE name IN ('max_execution_time', 'max_memory_usage') ORDER BY name FORMAT JSON\""
+    result = kubectl_exec("chi-posthog-posthog-0-0-0", command)
+    settings = json.loads(result)["data"]
+
+    assert settings == [
+        {"name": "max_execution_time", "value": "90"},
+        {"name": "max_memory_usage", "value": "20000000000"},
+    ]

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 from kubernetes import client
 
-from utils import NAMESPACE, cleanup_k8s, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
+from utils import NAMESPACE, cleanup_k8s, exec_subprocess, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger()
@@ -24,11 +24,7 @@ helm upgrade \
 
 def create_custom_pvc():
     log.debug("🔄 Creating a custom Persistent Volume Claim...")
-    cmd = "kubectl apply -n {namespace} -f clickhouse_existing_claim.yaml".format(namespace=NAMESPACE)
-    cmd_run = subprocess.run(cmd, shell=True)
-    cmd_return_code = cmd_run.returncode
-    if cmd_return_code:
-        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    exec_subprocess("kubectl apply -n {namespace} -f clickhouse_existing_claim.yaml".format(namespace=NAMESPACE))
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -1,10 +1,16 @@
 import logging
-import subprocess
 
 import pytest
 from kubernetes import client
 
-from utils import NAMESPACE, cleanup_k8s, exec_subprocess, get_clickhouse_statefulset_spec, helm_install, wait_for_pods_to_be_ready
+from utils import (
+    NAMESPACE,
+    cleanup_k8s,
+    exec_subprocess,
+    get_clickhouse_statefulset_spec,
+    helm_install,
+    wait_for_pods_to_be_ready,
+)
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger()
@@ -24,7 +30,8 @@ helm upgrade \
 
 def create_custom_pvc():
     log.debug("🔄 Creating a custom Persistent Volume Claim...")
-    exec_subprocess("kubectl apply -n {namespace} -f clickhouse_existing_claim.yaml".format(namespace=NAMESPACE))
+    exec_subprocess(f"kubectl create namespace {NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -")
+    exec_subprocess(f"kubectl apply -n {NAMESPACE} -f clickhouse_existing_claim.yaml")
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -119,27 +119,21 @@ def test_if_posthog_deployments_are_healthy(kube):
 def create_namespace_if_not_exists(name="posthog"):
     log.debug("🔄 Creating namespace {} (if not exists)...".format(name))
     cmd = "kubectl create namespace {} --dry-run=client -o yaml | kubectl apply -f -".format(name)
-    cmd_run = subprocess.run(cmd, shell=True)
-    cmd_return_code = cmd_run.returncode
-    if cmd_return_code:
-        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    _exec_subprocess(cmd)
     log.debug("✅ Done!")
 
 
 def install_custom_resources(filename, namespace="posthog"):
     log.debug("🔄 Setting up custom resources for this test...")
     cmd = "kubectl apply -n {namespace} -f {filename}".format(namespace=namespace, filename=filename)
-    cmd_run = subprocess.run(cmd, shell=True)
-    cmd_return_code = cmd_run.returncode
-    if cmd_return_code:
-        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    _exec_subprocess(cmd)
     log.debug("✅ Done!")
 
 
-def _exec_subprocess(cmd, fail_on_nonzero_exit=True):
+def _exec_subprocess(cmd):
     cmd_run = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     cmd_return_code = cmd_run.returncode
-    if cmd_return_code and fail_on_nonzero_exit:
+    if cmd_return_code:
         pytest.fail(
             f"""
         ❌ Error while running '{cmd}'.

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import tempfile
 import time
 
 import pytest
@@ -23,12 +24,38 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
 
 def helm_install(HELM_INSTALL_CMD):
     log.debug("🔄 Deploying PostHog...")
-    cmd = HELM_INSTALL_CMD
-    cmd_run = subprocess.run(cmd, shell=True)
-    cmd_return_code = cmd_run.returncode
-    if cmd_return_code:
-        pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+    _exec_subprocess(HELM_INSTALL_CMD)
     log.debug("✅ Done!")
+
+
+def install_chart(values_yaml):
+    log.debug("🔄 Deploying PostHog...")
+    with tempfile.NamedTemporaryFile(mode="w") as values_file:
+        values_file.write(values_yaml)
+        values_file.flush()
+
+        _exec_subprocess(
+            f"""
+            helm upgrade \
+                --install \
+                -f {values_file.name} \
+                --timeout 30m \
+                --create-namespace \
+                --namespace posthog \
+                posthog ../../charts/posthog \
+                --wait-for-jobs \
+                --wait
+        """
+        )
+    log.debug("✅ Done!")
+
+
+def kubectl_exec(pod, command):
+    log.debug(f"🔄 Executing command '{command}' in pod {pod}")
+    cmd_run = _exec_subprocess(f"kubectl exec {pod} --namespace {NAMESPACE} -- {command}")
+    log.debug("✅ Done!")
+
+    return cmd_run.stdout
 
 
 def wait_for_pods_to_be_ready(kube):
@@ -107,3 +134,19 @@ def install_custom_resources(filename, namespace="posthog"):
     if cmd_return_code:
         pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
     log.debug("✅ Done!")
+
+
+def _exec_subprocess(cmd, fail_on_nonzero_exit=True):
+    cmd_run = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    cmd_return_code = cmd_run.returncode
+    if cmd_return_code and fail_on_nonzero_exit:
+        pytest.fail(
+            f"""
+        ❌ Error while running '{cmd}'.
+        Return code: {cmd_return_code}
+
+        STDOUT: {cmd_run.stdout}
+        STDERR: {cmd_run.stderr}
+        """
+        )
+    return cmd_run

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -24,7 +24,7 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
 
 def helm_install(HELM_INSTALL_CMD):
     log.debug("🔄 Deploying PostHog...")
-    _exec_subprocess(HELM_INSTALL_CMD)
+    exec_subprocess(HELM_INSTALL_CMD)
     log.debug("✅ Done!")
 
 
@@ -34,7 +34,7 @@ def install_chart(values_yaml):
         values_file.write(values_yaml)
         values_file.flush()
 
-        _exec_subprocess(
+        exec_subprocess(
             f"""
             helm upgrade \
                 --install \
@@ -52,7 +52,7 @@ def install_chart(values_yaml):
 
 def kubectl_exec(pod, command):
     log.debug(f"🔄 Executing command '{command}' in pod {pod}")
-    cmd_run = _exec_subprocess(f"kubectl exec {pod} --namespace {NAMESPACE} -- {command}")
+    cmd_run = exec_subprocess(f"kubectl exec {pod} --namespace {NAMESPACE} -- {command}")
     log.debug("✅ Done!")
 
     return cmd_run.stdout
@@ -119,18 +119,18 @@ def test_if_posthog_deployments_are_healthy(kube):
 def create_namespace_if_not_exists(name="posthog"):
     log.debug("🔄 Creating namespace {} (if not exists)...".format(name))
     cmd = "kubectl create namespace {} --dry-run=client -o yaml | kubectl apply -f -".format(name)
-    _exec_subprocess(cmd)
+    exec_subprocess(cmd)
     log.debug("✅ Done!")
 
 
 def install_custom_resources(filename, namespace="posthog"):
     log.debug("🔄 Setting up custom resources for this test...")
     cmd = "kubectl apply -n {namespace} -f {filename}".format(namespace=namespace, filename=filename)
-    _exec_subprocess(cmd)
+    exec_subprocess(cmd)
     log.debug("✅ Done!")
 
 
-def _exec_subprocess(cmd):
+def exec_subprocess(cmd):
     cmd_run = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     cmd_return_code = cmd_run.returncode
     if cmd_return_code:


### PR DESCRIPTION
## Description

This PR fixes https://github.com/PostHog/charts-clickhouse/issues/249 by making clickhouse settings configurable.

Companion documentation PR: https://github.com/PostHog/posthog.com/pull/2833

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

See tests. I also tested manually. One edge case I ran into was when passing invalid settings, clickhouse doesn't automatically update. If then killed, the pod won't start up again until the issue is fixed.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
