### PR TITLE
feat(static-assets): allow specifying djangos `STATIC_URL`

### DIFF
--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -69,6 +69,8 @@ spec:
         {{- include "snippet.redis-env" . | indent 8 }}
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}
+        - name: STATIC_URL
+          value: {{ default "/static/" .Values.web.staticUrl | quote }}
         - name: DEPLOYMENT
           value: {{ template "posthog.deploymentEnv" . }}
         - name: SENTRY_DSN

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -27,7 +27,7 @@ env:
 
 # -- PgBouncer setup
 pgbouncer:
-   # -- Whether to install PGBouncer or not
+  # -- Whether to install PGBouncer or not
   enabled: true
   hpa:
     # -- Boolean to create a HorizontalPodAutoscaler for pgbouncer
@@ -95,6 +95,8 @@ web:
     # requests:
     #   cpu: 300m
     #   memory: 300Mi
+  # -- Location from which application static assets (js, css, etc.) should be served
+  staticUrl: "/static/"
   # -- Env variables for web container
   env:
     # -- Set google oauth 2 key. Requires posthog ee license.
@@ -143,7 +145,7 @@ web:
     timeoutSeconds: 2
 
 worker:
-   # -- Whether to install the PostHog worker stack or not
+  # -- Whether to install the PostHog worker stack or not
   enabled: true
   hpa:
     # -- Boolean to create a HorizontalPodAutoscaler for worker
@@ -175,7 +177,7 @@ worker:
 
 # How many plugin server instances to run
 plugins:
-   # -- Whether to install the PostHog plugin stack or not
+  # -- Whether to install the PostHog plugin stack or not
   enabled: true
   ingestion:
     # -- Whether to enable plugin-server based ingestion
@@ -534,7 +536,6 @@ clickhouse:
   ## @section Persistence parameters
   ##
   persistence:
-
     ## @param persistence.enabled Enable data persistence
     ##
     enabled: true


### PR DESCRIPTION
To take advantage of e.g. a CDN we want to be able to specify an
external url from which clients should retrieve static assets.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
