### PR TITLE
initContainer/wait-for-migrations: add ClickHouse env variables

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -34,6 +34,29 @@
   # Redis env variables
   {{- include "snippet.redis-env" . | indent 2 }}
 
+  {{- if .Values.clickhouse.enabled }}
+  - name: CLICKHOUSE_DATABASE
+    value: {{ .Values.clickhouse.database | quote }}
+  - name: CLICKHOUSE_HOST
+    {{- if .Values.clickhouse.host }}
+    value: {{ .Values.clickhouse.host | quote }}
+    {{- else }}
+    value: {{ template "posthog.clickhouse.fullname" . }}
+    {{- end }}
+  - name: CLICKHOUSE_USER
+    value: {{ .Values.clickhouse.user | quote }}
+  - name: CLICKHOUSE_PASSWORD
+    value: {{ .Values.clickhouse.password | quote }}
+  - name: CLICKHOUSE_REPLICATION
+    value: {{ .Values.clickhouse.replication | quote }}
+  - name: CLICKHOUSE_SECURE
+    value: {{ .Values.clickhouse.secure | quote }}
+  - name: CLICKHOUSE_VERIFY
+    value: {{ .Values.clickhouse.verify | quote }}
+  - name: CLICKHOUSE_ASYNC
+    value: {{ .Values.clickhouse.async| quote }}
+  {{- end }}
+
   # Django specific settings
   - name: SECRET_KEY
     valueFrom:

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -34,7 +34,7 @@
   # Redis env variables
   {{- include "snippet.redis-env" . | indent 2 }}
 
-  {{- if .Values.clickhouse.enabled }}
+  # ClickHouse env variables
   - name: CLICKHOUSE_DATABASE
     value: {{ .Values.clickhouse.database | quote }}
   - name: CLICKHOUSE_HOST
@@ -55,7 +55,6 @@
     value: {{ .Values.clickhouse.verify | quote }}
   - name: CLICKHOUSE_ASYNC
     value: {{ .Values.clickhouse.async| quote }}
-  {{- end }}
 
   # Django specific settings
   - name: SECRET_KEY


### PR DESCRIPTION
## Description
The upcoming PostHog release added some checks related to the ClickHouse version in use. In order for `python manage.py migrate --check` to return successfully we also need to expose ClickHouse env variables. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
Run Helm install with `image.tag: latest` using `main` ❌ 
Run Helm install with `image.tag: latest` using this branch ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
