### PR TITLE
External clickhouse support

### DIFF
--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -43,3 +43,10 @@ jobs:
             --group ${{ matrix.group }} \
             --splitting-algorithm=least_duration \
             --group-by file
+
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      - name: Emit namespace report
+        uses: jupyterhub/action-k8s-namespace-report@v1
+        if: always()
+        with:
+          namespace: posthog

--- a/.github/workflows/test-unit-helm.yaml
+++ b/.github/workflows/test-unit-helm.yaml
@@ -22,4 +22,4 @@ jobs:
           helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.7
 
       - name: Run test suite
-        run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' charts/posthog
+        run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -39,7 +39,7 @@ In order to run the test suite, you need to install the `helm-unittest` plugin. 
 
 For more information about how it works and how to write test cases, please look at the upstream [documentation](https://github.com/quintush/helm-unittest/blob/master/README.md) or to the [tests already available in this repo](https://github.com/PostHog/charts-clickhouse/tree/main/charts/posthog/tests).
 
-To run the test suite you can execute: `helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' charts/posthog`
+To run the test suite you can execute: `helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog`
 
 #### Integration tests
 - [kubetest](https://github.com/PostHog/charts-clickhouse/tree/main/ci/kubetest): to verify if applying the rendered Helm templates against a Kubernetes target cluster gives us the stack we expect (example: are the disks encrypted? Can this pod communicate with this service?)

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -17,3 +17,19 @@
 - name: CLICKHOUSE_VERIFY
   value: {{ .Values.clickhouse.verify | quote }}
 {{- end }}
+
+
+{*
+   ------ CLICKHOUSE ------
+*}
+
+{{/*
+Return clickhouse fullname
+*/}}
+{{- define "posthog.clickhouse.fullname" -}}
+{{- if .Values.clickhouse.fullnameOverride -}}
+{{- .Values.clickhouse.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" "clickhouse" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -1,5 +1,7 @@
 {{/* Common ClickHouse ENV variables used by PostHog */}}
 {{- define "snippet.clickhouse-env" }}
+- name: CLICKHOUSE_CLUSTER
+  value: {{ .Values.clickhouse.cluster | quote }}
 - name: CLICKHOUSE_DATABASE
   value: {{ .Values.clickhouse.database | quote }}
 - name: CLICKHOUSE_HOST

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -19,7 +19,7 @@
 - name: CLICKHOUSE_HOST
   value: {{ required "externalClickhouse.host is required if not clickhouse.enabled" .Values.externalClickhouse.host | quote }}
 - name: CLICKHOUSE_CLUSTER
-  value: {{ .Values.externalClickhouse.cluster | quote }}
+  value: {{ required "externalClickhouse.cluster is required if not clickhouse.enabled" .Values.externalClickhouse.cluster | quote }}
 - name: CLICKHOUSE_DATABASE
   value: {{ .Values.externalClickhouse.database | quote }}
 - name: CLICKHOUSE_USER

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -5,11 +5,7 @@
 - name: CLICKHOUSE_DATABASE
   value: {{ .Values.clickhouse.database | quote }}
 - name: CLICKHOUSE_HOST
-  {{- if .Values.clickhouse.host }}
-  value: {{ .Values.clickhouse.host | quote }}
-  {{- else }}
   value: {{ template "posthog.clickhouse.fullname" . }}
-  {{- end }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.clickhouse.user | quote }}
 - name: CLICKHOUSE_PASSWORD

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -25,7 +25,7 @@
 - name: CLICKHOUSE_USER
   value: {{ required "externalClickhouse.user is required if not clickhouse.enabled" .Values.externalClickhouse.user | quote }}
 {{- if .Values.externalClickhouse.existingSecret }}
-- name: POSTHOG_REDIS_PASSWORD
+- name: CLICKHOUSE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "posthog.clickhouse.secretName" . }}
@@ -71,10 +71,10 @@ Return true if a secret object for ClickHouse should be created
 Return the ClickHouse secret name
 */}}
 {{- define "posthog.clickhouse.secretName" -}}
-{{- if .Values.externalRedis.existingSecret }}
-    {{- .Values.externalRedis.existingSecret | quote -}}
+{{- if .Values.externalClickhouse.existingSecret }}
+    {{- .Values.externalClickhouse.existingSecret | quote -}}
 {{- else -}}
-    {{- printf "%s-external" (include "posthog.redis.fullname" .) -}}
+    {{- printf "%s-external" (include "posthog.clickhouse.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -85,6 +85,6 @@ Return the ClickHouse secret key
 {{- if .Values.externalClickhouse.existingSecret }}
     {{- required "You need to provide existingSecretPasswordKey when an existingSecret is specified in externalClickhouse" .Values.externalClickhouse.existingSecretPasswordKey | quote }}
 {{- else -}}
-    {{- printf "redis-password" -}}
+    {{- printf "clickhouse-password" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -1,11 +1,12 @@
 {{/* Common ClickHouse ENV variables used by PostHog */}}
 {{- define "snippet.clickhouse-env" }}
+{{- if .Values.clickhouse.enabled -}}
+- name: CLICKHOUSE_HOST
+  value: {{ template "posthog.clickhouse.fullname" . }}
 - name: CLICKHOUSE_CLUSTER
   value: {{ .Values.clickhouse.cluster | quote }}
 - name: CLICKHOUSE_DATABASE
   value: {{ .Values.clickhouse.database | quote }}
-- name: CLICKHOUSE_HOST
-  value: {{ template "posthog.clickhouse.fullname" . }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.clickhouse.user | quote }}
 - name: CLICKHOUSE_PASSWORD
@@ -14,6 +15,22 @@
   value: {{ .Values.clickhouse.secure | quote }}
 - name: CLICKHOUSE_VERIFY
   value: {{ .Values.clickhouse.verify | quote }}
+{{- else -}}
+- name: CLICKHOUSE_HOST
+  value: {{ required "externalClickhouse.host is required if not clickhouse.enabled" .Values.externalClickhouse.host | quote }}
+- name: CLICKHOUSE_CLUSTER
+  value: {{ .Values.externalClickhouse.cluster | quote }}
+- name: CLICKHOUSE_DATABASE
+  value: {{ .Values.externalClickhouse.database | quote }}
+- name: CLICKHOUSE_USER
+  value: {{ required "externalClickhouse.user is required if not clickhouse.enabled" .Values.externalClickhouse.user | quote }}
+- name: CLICKHOUSE_PASSWORD
+  value: {{ .Values.externalClickhouse.password | quote }}
+- name: CLICKHOUSE_SECURE
+  value: {{ .Values.externalClickhouse.secure | quote }}
+- name: CLICKHOUSE_VERIFY
+  value: {{ .Values.externalClickhouse.verify | quote }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -249,21 +249,6 @@ Return whether Redis uses password authentication or not
 {{- end -}}
 {{- end -}}
 
-{*
-   ------ CLICKHOUSE ------
-*}
-
-{{/*
-Set clickhouse fullname
-*/}}
-{{- define "posthog.clickhouse.fullname" -}}
-{{- if .Values.clickhouse.fullnameOverride -}}
-{{- .Values.clickhouse.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" "clickhouse" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 Set statsd host
 */}}

--- a/charts/posthog/templates/_snippet-clickhouse-env.tpl
+++ b/charts/posthog/templates/_snippet-clickhouse-env.tpl
@@ -1,0 +1,19 @@
+{{/* Common ClickHouse ENV variables used by PostHog */}}
+{{- define "snippet.clickhouse-env" }}
+- name: CLICKHOUSE_DATABASE
+  value: {{ .Values.clickhouse.database | quote }}
+- name: CLICKHOUSE_HOST
+  {{- if .Values.clickhouse.host }}
+  value: {{ .Values.clickhouse.host | quote }}
+  {{- else }}
+  value: {{ template "posthog.clickhouse.fullname" . }}
+  {{- end }}
+- name: CLICKHOUSE_USER
+  value: {{ .Values.clickhouse.user | quote }}
+- name: CLICKHOUSE_PASSWORD
+  value: {{ .Values.clickhouse.password | quote }}
+- name: CLICKHOUSE_SECURE
+  value: {{ .Values.clickhouse.secure | quote }}
+- name: CLICKHOUSE_VERIFY
+  value: {{ .Values.clickhouse.verify | quote }}
+{{- end }}

--- a/charts/posthog/templates/_snippet-error-on-removed-values.tpl
+++ b/charts/posthog/templates/_snippet-error-on-removed-values.tpl
@@ -8,6 +8,8 @@
     {{- required (printf (include "snippet.error-on-removed-values-template" .) "clickhouseOperator values are no longer valid." "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-9xx") nil -}}
 {{- else if or .Values.redis.port .Values.redis.host .Values.redis.password }}
     {{- required (printf (include "snippet.error-on-removed-values-template" .) "redis.port, redis.host and redis.password are no longer valid." "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-11xx") nil -}}
+{{- else if .Values.clickhouse.host }}
+    {{- required (printf (include "snippet.error-on-removed-values-template" .) "clickhouse.host has been moved to externalClickhouse.host" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/posthog/templates/_snippet-error-on-removed-values.tpl
+++ b/charts/posthog/templates/_snippet-error-on-removed-values.tpl
@@ -10,6 +10,8 @@
     {{- required (printf (include "snippet.error-on-removed-values-template" .) "redis.port, redis.host and redis.password are no longer valid." "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-11xx") nil -}}
 {{- else if .Values.clickhouse.host }}
     {{- required (printf (include "snippet.error-on-removed-values-template" .) "clickhouse.host has been moved to externalClickhouse.host" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
+{{- else if .Values.clickhouse.replication }}
+    {{- required (printf (include "snippet.error-on-removed-values-template" .) "clickhouse.replication has been removed" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -35,26 +35,7 @@
   {{- include "snippet.redis-env" . | indent 2 }}
 
   # ClickHouse env variables
-  - name: CLICKHOUSE_DATABASE
-    value: {{ .Values.clickhouse.database | quote }}
-  - name: CLICKHOUSE_HOST
-    {{- if .Values.clickhouse.host }}
-    value: {{ .Values.clickhouse.host | quote }}
-    {{- else }}
-    value: {{ template "posthog.clickhouse.fullname" . }}
-    {{- end }}
-  - name: CLICKHOUSE_USER
-    value: {{ .Values.clickhouse.user | quote }}
-  - name: CLICKHOUSE_PASSWORD
-    value: {{ .Values.clickhouse.password | quote }}
-  - name: CLICKHOUSE_REPLICATION
-    value: {{ .Values.clickhouse.replication | quote }}
-  - name: CLICKHOUSE_SECURE
-    value: {{ .Values.clickhouse.secure | quote }}
-  - name: CLICKHOUSE_VERIFY
-    value: {{ .Values.clickhouse.verify | quote }}
-  - name: CLICKHOUSE_ASYNC
-    value: {{ .Values.clickhouse.async| quote }}
+  {{- include "snippet.clickhouse-env" . | indent 2 }}
 
   # Django specific settings
   - name: SECRET_KEY

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -35,7 +35,7 @@
   {{- include "snippet.redis-env" . | indent 2 }}
 
   # ClickHouse env variables
-  {{- include "snippet.clickhouse-env" . | indent 2 }}
+  {{- include "snippet.clickhouse-env" . | nindent 2 }}
 
   # Django specific settings
   - name: SECRET_KEY

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   configuration:
     users:
-      admin/password: {{ .Values.clickhouse.password }}
-      admin/networks/ip: "0.0.0.0/0"
-      admin/profile: default
-      admin/quota: default
+      {{ .Values.clickhouse.user }}/password: {{ .Values.clickhouse.password }}
+      {{ .Values.clickhouse.user }}/networks/ip: "0.0.0.0/0"
+      {{ .Values.clickhouse.user }}/profile: default
+      {{ .Values.clickhouse.user }}/quota: default
 
     profiles:
       {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -15,7 +15,7 @@ spec:
       {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}
 
     clusters:
-      - name: {{ .Values.clickhouse.database | quote }}
+      - name: {{ .Values.clickhouse.cluster | quote }}
         templates:
           podTemplate: pod-template
           clusterServiceTemplate: service-template

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -132,28 +132,12 @@ spec:
           value: {{ default "false" .Values.email.use_ssl | quote }}
         - name: DEFAULT_FROM_EMAIL
           value: {{ .Values.email.from_email | quote }}
-        {{- if .Values.clickhouse.enabled }}
         - name: PRIMARY_DB
           value: clickhouse
-        - name: CLICKHOUSE_DATABASE
-          value: {{ .Values.clickhouse.database | quote }}
-        - name: CLICKHOUSE_HOST
-          {{- if .Values.clickhouse.host }}
-          value: {{ .Values.clickhouse.host | quote }}
-          {{- else }}
-          value: {{ template "posthog.clickhouse.fullname" . }}
-          {{- end }}
-        - name: CLICKHOUSE_USER
-          value: {{ .Values.clickhouse.user | quote }}
-        - name: CLICKHOUSE_PASSWORD
-          value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_SECURE
-          value: {{ .Values.clickhouse.secure | quote }}
-        - name: CLICKHOUSE_VERIFY
+        {{- include "snippet.clickhouse-env" . | indent 8 }}
           value: {{ .Values.clickhouse.verify | quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- end }}
         {{- if .Values.kafka.enabled }}
         - name: KAFKA_URL
           value: {{ template "posthog.kafka.url" . }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -135,7 +135,6 @@ spec:
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
-          value: {{ .Values.clickhouse.verify | quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -134,7 +134,7 @@ spec:
           value: {{ .Values.email.from_email | quote }}
         - name: PRIMARY_DB
           value: clickhouse
-        {{- include "snippet.clickhouse-env" . | indent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
           value: {{ .Values.clickhouse.verify | quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -147,14 +147,10 @@ spec:
           value: {{ .Values.clickhouse.user | quote }}
         - name: CLICKHOUSE_PASSWORD
           value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_REPLICATION
-          value: {{ .Values.clickhouse.replication | quote }}
         - name: CLICKHOUSE_SECURE
           value: {{ .Values.clickhouse.secure | quote }}
         - name: CLICKHOUSE_VERIFY
           value: {{ .Values.clickhouse.verify | quote }}
-        - name: CLICKHOUSE_ASYNC
-          value: {{ .Values.clickhouse.async| quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- end }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -100,7 +100,7 @@ spec:
               key: smtp-password
         - name: PRIMARY_DB
           value: clickhouse
-        {{- include "snippet.clickhouse-env" . | indent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -100,22 +100,7 @@ spec:
               key: smtp-password
         - name: PRIMARY_DB
           value: clickhouse
-        - name: CLICKHOUSE_DATABASE
-          value: {{ .Values.clickhouse.database | quote }}
-        - name: CLICKHOUSE_HOST
-          {{- if .Values.clickhouse.host }}
-          value: {{ .Values.clickhouse.host | quote }}
-          {{- else }}
-          value: {{ template "posthog.clickhouse.fullname" . }}
-          {{- end }}
-        - name: CLICKHOUSE_USER
-          value: {{ .Values.clickhouse.user | quote }}
-        - name: CLICKHOUSE_PASSWORD
-          value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_SECURE
-          value: {{ .Values.clickhouse.secure | quote }}
-        - name: CLICKHOUSE_VERIFY
-          value: {{ .Values.clickhouse.verify | quote }}
+        {{- include "snippet.clickhouse-env" . | indent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -112,14 +112,10 @@ spec:
           value: {{ .Values.clickhouse.user | quote }}
         - name: CLICKHOUSE_PASSWORD
           value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_REPLICATION
-          value: {{ .Values.clickhouse.replication | quote }}
         - name: CLICKHOUSE_SECURE
           value: {{ .Values.clickhouse.secure | quote }}
         - name: CLICKHOUSE_VERIFY
           value: {{ .Values.clickhouse.verify | quote }}
-        - name: CLICKHOUSE_ASYNC
-          value: {{ .Values.clickhouse.async| quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -90,7 +90,7 @@ spec:
         - name: STATSD_PORT
           value: "9125"
         {{- end }}
-        {{- include "snippet.clickhouse-env" . | indent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -90,26 +90,9 @@ spec:
         - name: STATSD_PORT
           value: "9125"
         {{- end }}
-        {{- if .Values.clickhouse.enabled }}
-        - name: CLICKHOUSE_DATABASE
-          value: {{ .Values.clickhouse.database | quote }}
-        - name: CLICKHOUSE_HOST
-          {{- if .Values.clickhouse.host }}
-          value: {{ .Values.clickhouse.host | quote }}
-          {{- else }}
-          value: {{ template "posthog.clickhouse.fullname" . }}
-          {{- end }}
-        - name: CLICKHOUSE_USER
-          value: {{ .Values.clickhouse.user | quote }}
-        - name: CLICKHOUSE_PASSWORD
-          value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_SECURE
-          value: {{ .Values.clickhouse.secure | quote }}
-        - name: CLICKHOUSE_VERIFY
-          value: {{ .Values.clickhouse.verify | quote }}
+        {{- include "snippet.clickhouse-env" . | indent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- end }}
         {{- if .Values.kafka.enabled }}
         - name: KAFKA_ENABLED
           value: "true"

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -103,14 +103,10 @@ spec:
           value: {{ .Values.clickhouse.user | quote }}
         - name: CLICKHOUSE_PASSWORD
           value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_REPLICATION
-          value: {{ .Values.clickhouse.replication | quote }}
         - name: CLICKHOUSE_SECURE
           value: {{ .Values.clickhouse.secure | quote }}
         - name: CLICKHOUSE_VERIFY
           value: {{ .Values.clickhouse.verify | quote }}
-        - name: CLICKHOUSE_ASYNC
-          value: {{ .Values.clickhouse.async| quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- end }}

--- a/charts/posthog/templates/secrets-clickhouse-external.yaml
+++ b/charts/posthog/templates/secrets-clickhouse-external.yaml
@@ -1,0 +1,9 @@
+{{- if (include "posthog.clickhouse.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "posthog.clickhouse.secretName" . }}
+type: Opaque
+data:
+  {{ template "posthog.clickhouse.secretPasswordKey" . }}: {{ .Values.externalClickhouse.password | b64enc | quote }}
+{{- end }}

--- a/charts/posthog/templates/test-templates/clickhouse-env.yaml
+++ b/charts/posthog/templates/test-templates/clickhouse-env.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.testTemplates -}}
+{{- if .Values.testTemplates.clickhouseEnvTest -}}
+# Test template for only clickhouse env. Used in charts/posthog/tests/_clickhouse.yaml
+apiVersion: v1
+kind: ConfigMap
+data:
+{{- include "snippet.clickhouse-env" . | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -156,7 +156,7 @@ spec:
         {{- end }}
         - name: PRIMARY_DB
           value: clickhouse
-        {{- include "snippet.clickhouse-env" . | indent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -169,14 +169,10 @@ spec:
           value: {{ .Values.clickhouse.user | quote }}
         - name: CLICKHOUSE_PASSWORD
           value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_REPLICATION
-          value: {{ .Values.clickhouse.replication | quote }}
         - name: CLICKHOUSE_SECURE
           value: {{ .Values.clickhouse.secure | quote }}
         - name: CLICKHOUSE_VERIFY
           value: {{ .Values.clickhouse.verify | quote }}
-        - name: CLICKHOUSE_ASYNC
-          value: {{ .Values.clickhouse.async| quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- end }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -154,28 +154,11 @@ spec:
         - name: SAML_DISABLED
           value: '1'
         {{- end }}
-        {{- if .Values.clickhouse.enabled }}
         - name: PRIMARY_DB
           value: clickhouse
-        - name: CLICKHOUSE_DATABASE
-          value: {{ .Values.clickhouse.database | quote }}
-        - name: CLICKHOUSE_HOST
-          {{- if .Values.clickhouse.host }}
-          value: {{ .Values.clickhouse.host | quote }}
-          {{- else }}
-          value: {{ template "posthog.clickhouse.fullname" . }}
-          {{- end }}
-        - name: CLICKHOUSE_USER
-          value: {{ .Values.clickhouse.user | quote }}
-        - name: CLICKHOUSE_PASSWORD
-          value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_SECURE
-          value: {{ .Values.clickhouse.secure | quote }}
-        - name: CLICKHOUSE_VERIFY
-          value: {{ .Values.clickhouse.verify | quote }}
+        {{- include "snippet.clickhouse-env" . | indent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- end }}
         {{- if .Values.kafka.enabled }}
         - name: KAFKA_URL
           value: {{ template "posthog.kafka.url" . }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -130,7 +130,7 @@ spec:
           value: {{ .Values.email.from_email | quote }}
         - name: PRIMARY_DB
           value: clickhouse
-        {{- include "snippet.clickhouse-env" . | indent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -128,28 +128,11 @@ spec:
           value: {{ default "false" .Values.email.use_ssl | quote }}
         - name: DEFAULT_FROM_EMAIL
           value: {{ .Values.email.from_email | quote }}
-          {{- if .Values.clickhouse.enabled }}
         - name: PRIMARY_DB
           value: clickhouse
-        - name: CLICKHOUSE_DATABASE
-          value: {{ .Values.clickhouse.database | quote }}
-        - name: CLICKHOUSE_HOST
-          {{- if .Values.clickhouse.host }}
-          value: {{ .Values.clickhouse.host | quote }}
-          {{- else }}
-          value: {{ template "posthog.clickhouse.fullname" . }}
-          {{- end }}
-        - name: CLICKHOUSE_USER
-          value: {{ .Values.clickhouse.user | quote }}
-        - name: CLICKHOUSE_PASSWORD
-          value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_SECURE
-          value: {{ .Values.clickhouse.secure | quote }}
-        - name: CLICKHOUSE_VERIFY
-          value: {{ .Values.clickhouse.verify | quote }}
+        {{- include "snippet.clickhouse-env" . | indent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- end }}
         {{- if .Values.kafka.enabled }}
         - name: KAFKA_URL
           value: {{ template "posthog.kafka.url" . }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -143,14 +143,10 @@ spec:
           value: {{ .Values.clickhouse.user | quote }}
         - name: CLICKHOUSE_PASSWORD
           value: {{ .Values.clickhouse.password | quote }}
-        - name: CLICKHOUSE_REPLICATION
-          value: {{ .Values.clickhouse.replication | quote }}
         - name: CLICKHOUSE_SECURE
           value: {{ .Values.clickhouse.secure | quote }}
         - name: CLICKHOUSE_VERIFY
           value: {{ .Values.clickhouse.verify | quote }}
-        - name: CLICKHOUSE_ASYNC
-          value: {{ .Values.clickhouse.async| quote }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- end }}

--- a/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
@@ -72,11 +72,11 @@ should render with external clickhouse with secrets:
       value: posthog
     - name: CLICKHOUSE_USER
       value: adminuser
-    - name: POSTHOG_REDIS_PASSWORD
+    - name: CLICKHOUSE_PASSWORD
       valueFrom:
         secretKeyRef:
           key: clickhousePassword
-          name: RELEASE-NAME-posthog-redis-external
+          name: someExistingSecret
     - name: CLICKHOUSE_SECURE
       value: "false"
     - name: CLICKHOUSE_VERIFY

--- a/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
@@ -1,0 +1,83 @@
+should render with custom values:
+  1: |
+    - name: CLICKHOUSE_HOST
+      value: clickhouse-RELEASE-NAME
+    - name: CLICKHOUSE_CLUSTER
+      value: customCluster
+    - name: CLICKHOUSE_DATABASE
+      value: customDatabase
+    - name: CLICKHOUSE_USER
+      value: customUser
+    - name: CLICKHOUSE_PASSWORD
+      value: customPassword
+    - name: CLICKHOUSE_SECURE
+      value: "true"
+    - name: CLICKHOUSE_VERIFY
+      value: "true"
+should render with defaults:
+  1: |
+    - name: CLICKHOUSE_HOST
+      value: clickhouse-RELEASE-NAME
+    - name: CLICKHOUSE_CLUSTER
+      value: posthog
+    - name: CLICKHOUSE_DATABASE
+      value: posthog
+    - name: CLICKHOUSE_USER
+      value: admin
+    - name: CLICKHOUSE_PASSWORD
+      value: a1f31e03-c88e-4ca6-a2df-ad49183d15d9
+    - name: CLICKHOUSE_SECURE
+      value: "false"
+    - name: CLICKHOUSE_VERIFY
+      value: "false"
+should render with external clickhouse:
+  1: |
+    - name: CLICKHOUSE_HOST
+      value: foo.bar.net
+    - name: CLICKHOUSE_CLUSTER
+      value: posthog
+    - name: CLICKHOUSE_DATABASE
+      value: posthog
+    - name: CLICKHOUSE_USER
+      value: adminuser
+    - name: CLICKHOUSE_PASSWORD
+      value: hello
+    - name: CLICKHOUSE_SECURE
+      value: "false"
+    - name: CLICKHOUSE_VERIFY
+      value: "false"
+should render with external clickhouse with more custom settings:
+  1: |
+    - name: CLICKHOUSE_HOST
+      value: foo.bar.net
+    - name: CLICKHOUSE_CLUSTER
+      value: customCluster
+    - name: CLICKHOUSE_DATABASE
+      value: customDatabase
+    - name: CLICKHOUSE_USER
+      value: adminuser
+    - name: CLICKHOUSE_PASSWORD
+      value: hello
+    - name: CLICKHOUSE_SECURE
+      value: "true"
+    - name: CLICKHOUSE_VERIFY
+      value: "true"
+should render with external clickhouse with secrets:
+  1: |
+    - name: CLICKHOUSE_HOST
+      value: foo.bar.net
+    - name: CLICKHOUSE_CLUSTER
+      value: posthog
+    - name: CLICKHOUSE_DATABASE
+      value: posthog
+    - name: CLICKHOUSE_USER
+      value: adminuser
+    - name: POSTHOG_REDIS_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: clickhousePassword
+          name: RELEASE-NAME-posthog-redis-external
+    - name: CLICKHOUSE_SECURE
+      value: "false"
+    - name: CLICKHOUSE_VERIFY
+      value: "false"

--- a/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
@@ -35,7 +35,7 @@ should render with external clickhouse:
     - name: CLICKHOUSE_HOST
       value: foo.bar.net
     - name: CLICKHOUSE_CLUSTER
-      value: posthog
+      value: somecluster
     - name: CLICKHOUSE_DATABASE
       value: posthog
     - name: CLICKHOUSE_USER
@@ -67,7 +67,7 @@ should render with external clickhouse with secrets:
     - name: CLICKHOUSE_HOST
       value: foo.bar.net
     - name: CLICKHOUSE_CLUSTER
-      value: posthog
+      value: somecluster
     - name: CLICKHOUSE_DATABASE
       value: posthog
     - name: CLICKHOUSE_USER

--- a/charts/posthog/tests/_clickhouse.tpl.yaml
+++ b/charts/posthog/tests/_clickhouse.tpl.yaml
@@ -38,6 +38,7 @@ tests:
     set:
       testTemplates.clickhouseEnvTest: true
       clickhouse.enabled: false
+      externalClickhouse.cluster: somecluster
       externalClickhouse.host: foo.bar.net
       externalClickhouse.user: adminuser
       externalClickhouse.password: hello
@@ -64,6 +65,7 @@ tests:
     set:
       testTemplates.clickhouseEnvTest: true
       clickhouse.enabled: false
+      externalClickhouse.cluster: somecluster
       externalClickhouse.host: foo.bar.net
       externalClickhouse.user: adminuser
       externalClickhouse.existingSecret: someExistingSecret
@@ -76,6 +78,7 @@ tests:
     set:
       testTemplates.clickhouseEnvTest: true
       clickhouse.enabled: false
+      externalClickhouse.cluster: somecluster
       externalClickhouse.host: foo.bar.net
       externalClickhouse.user: adminuser
     asserts:

--- a/charts/posthog/tests/_clickhouse.tpl.yaml
+++ b/charts/posthog/tests/_clickhouse.tpl.yaml
@@ -1,0 +1,86 @@
+# Tests charts/posthog/templates/_clickhouse.tpl
+suite: _clickhouse.tpl template
+templates:
+  - templates/test-templates/clickhouse-env.yaml
+
+tests:
+  - it: should render with defaults
+    set:
+      testTemplates.clickhouseEnvTest: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchSnapshot:
+          path: data
+
+  - it: should render with custom values
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.cluster: customCluster
+      clickhouse.database: customDatabase
+      clickhouse.user: customUser
+      clickhouse.password: customPassword
+      clickhouse.secure: true
+      clickhouse.verify: true
+    asserts:
+      - matchSnapshot:
+          path: data
+
+  - it: should fail to render with only clickhouse disabled
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: externalClickhouse.host is required if not clickhouse.enabled
+
+  - it: should render with external clickhouse
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.enabled: false
+      externalClickhouse.host: foo.bar.net
+      externalClickhouse.user: adminuser
+      externalClickhouse.password: hello
+    asserts:
+      - matchSnapshot:
+          path: data
+
+  - it: should render with external clickhouse with more custom settings
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.enabled: false
+      externalClickhouse.host: foo.bar.net
+      externalClickhouse.user: adminuser
+      externalClickhouse.password: hello
+      externalClickhouse.cluster: customCluster
+      externalClickhouse.database: customDatabase
+      externalClickhouse.secure: true
+      externalClickhouse.verify: true
+    asserts:
+      - matchSnapshot:
+          path: data
+
+  - it: should render with external clickhouse with secrets
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.enabled: false
+      externalClickhouse.host: foo.bar.net
+      externalClickhouse.user: adminuser
+      externalClickhouse.existingSecret: someExistingSecret
+      externalClickhouse.existingSecretPasswordKey: clickhousePassword
+    asserts:
+      - matchSnapshot:
+          path: data
+
+  - it: should fail to render with external clickhouse but no auth
+    set:
+      testTemplates.clickhouseEnvTest: true
+      clickhouse.enabled: false
+      externalClickhouse.host: foo.bar.net
+      externalClickhouse.user: adminuser
+    asserts:
+      - failedTemplate:
+          errorMessage: externalClickhouse.password or externalClickhouse.existingSecret is required if using external clickhouse
+
+
+

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -237,3 +237,16 @@ tests:
           path: spec.configuration.profiles
           value:
             default/allow_experimental_window_functions: "0"
+
+  - it: handles custom users and passwords
+    set:
+      clickhouse.user: someuser
+      clickhouse.password: somepass
+    asserts:
+      - equal:
+          path: spec.configuration.users
+          value:
+            someuser/password: somepass
+            someuser/networks/ip: "0.0.0.0/0"
+            someuser/profile: default
+            someuser/quota: default

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -577,7 +577,7 @@ clickhouse:
 ##
 externalClickhouse:
   host:
-  cluster: posthog
+  cluster:
   database: posthog
   user:
   password:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -494,13 +494,10 @@ clickhouse:
   user: admin
   # -- Clickhouse password
   password: a1f31e03-c88e-4ca6-a2df-ad49183d15d9
-  # -- Set if not installing clickhouse operator
-  host:
-  # :TODO:
-  replication: false
+  # -- Whether to use TLS connection connecting to ClickHouse
   secure: false
+  # -- Whether to verify TLS certificate on connection to ClickHouse
   verify: false
-  async: false
   # externalZookeeper:
   # -- URL for zookeeper.
   # servers:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -564,6 +564,28 @@ clickhouse:
   defaultProfiles:
     default/allow_experimental_window_functions: "1"
 
+## External ClickHouse cluster;
+## @param existingClickhouse.host Host of the external cluster
+## @param existingClickhouse.cluster Name of the external cluster to run DDL queries on
+## @param existingClickhouse.database Database name for the external cluster
+## @param existingClickhouse.user User name for the external cluster to connect to the external cluster as
+## @param existingClickhouse.password Password for the cluster. Ignored if existingClickhouse.existingSecret is set
+## @param existingClickhouse.existingSecret Name of an existing Kubernetes secret object containing the password
+## @param existingClickhouse.existingSecretPasswordKey Name of the key pointing to the password in your Kubernetes secret
+## @param existingClickhouse.secure Whether to use TLS connection connecting to ClickHouse
+## @param existingClickhouse.verify Whether to verify TLS connection connecting to ClickHouse
+##
+externalClickhouse:
+  host:
+  cluster: posthog
+  database: posthog
+  user:
+  password:
+  existingSecret:
+  existingSecretPasswordKey:
+  secure: false
+  verify: false
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -564,26 +564,26 @@ clickhouse:
   defaultProfiles:
     default/allow_experimental_window_functions: "1"
 
-## External ClickHouse cluster;
-## @param existingClickhouse.host Host of the external cluster
-## @param existingClickhouse.cluster Name of the external cluster to run DDL queries on
-## @param existingClickhouse.database Database name for the external cluster
-## @param existingClickhouse.user User name for the external cluster to connect to the external cluster as
-## @param existingClickhouse.password Password for the cluster. Ignored if existingClickhouse.existingSecret is set
-## @param existingClickhouse.existingSecret Name of an existing Kubernetes secret object containing the password
-## @param existingClickhouse.existingSecretPasswordKey Name of the key pointing to the password in your Kubernetes secret
-## @param existingClickhouse.secure Whether to use TLS connection connecting to ClickHouse
-## @param existingClickhouse.verify Whether to verify TLS connection connecting to ClickHouse
+## External clickhouse configuration
 ##
 externalClickhouse:
+  # -- Host of the external cluster. This is required when clickhouse.enabled is false
   host:
+  # -- Name of the external cluster to run DDL queries on. This is required when clickhouse.enabled is false
   cluster:
+  # -- Database name for the external cluster
   database: posthog
+  # -- User name for the external cluster to connect to the external cluster as
   user:
+  # -- Password for the cluster. Ignored if existingClickhouse.existingSecret is set
   password:
+  # -- Name of an existing Kubernetes secret object containing the password
   existingSecret:
+  # -- Name of the key pointing to the password in your Kubernetes secret
   existingSecretPasswordKey:
+  # -- Whether to use TLS connection connecting to ClickHouse
   secure: false
+  # -- Whether to verify TLS connection connecting to ClickHouse
   verify: false
 
 ## Prometheus Exporter / Metrics

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -488,6 +488,8 @@ clickhouse:
   enabled: true
   # -- Which namespace to install clickhouse and the clickhouse-operator to (defaults to namespace chart is installed to)
   namespace:
+  # -- Clickhouse cluster
+  cluster: posthog
   # -- Clickhouse database
   database: posthog
   # -- Clickhouse user

--- a/ci/kubetest/custom_k8s_resources/clickhouse_external_secret.yaml
+++ b/ci/kubetest/custom_k8s_resources/clickhouse_external_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: clickhouse-existing-secret
+data:
+  clickhouse-password: a3ViZXRlc3Rwdw==

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -3,6 +3,7 @@ import pytest
 from utils import (
     NAMESPACE,
     VALUES_DISABLE_EVERYTHING,
+    cleanup_helm,
     cleanup_k8s,
     exec_subprocess,
     install_chart,
@@ -113,4 +114,5 @@ def verify_can_connect_to_clickhouse(kube):
 
 @pytest.fixture(autouse=True)
 def before_each_cleanup():
-    cleanup_k8s(["default", NAMESPACE, "clickhouse"])
+    cleanup_k8s([NAMESPACE, "clickhouse"])
+    cleanup_helm([NAMESPACE, "clickhouse"])

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -3,7 +3,7 @@ import pytest
 from utils import (
     NAMESPACE,
     VALUES_DISABLE_EVERYTHING,
-    cleanup_helm,
+    merge_yaml,
     cleanup_k8s,
     exec_subprocess,
     install_chart,
@@ -11,56 +11,76 @@ from utils import (
     wait_for_pods_to_be_ready,
 )
 
-VALUES_ACCESS_CLICKHOUSE = {
-    **VALUES_DISABLE_EVERYTHING,
-    "clickhouse": {"enabled": True},
-    "zookeeper": {"enabled": True},
-    "web": {"enabled": True},
-    "migrate": {"enabled": True},
-    "postgresql": {"enabled": True},
-    "redis": {"enabled": True},
-    "pgbouncer": {"enabled": True},
-}
+VALUES_ACCESS_CLICKHOUSE = merge_yaml(
+    VALUES_DISABLE_EVERYTHING,
+    """
+    clickhouse:
+      enabled: true
+    zookeeper:
+      enabled: true
+    web:
+      enabled: true
+    migrate:
+      enabled: true
+    postgresql:
+      enabled: true
+    redis:
+      enabled: true
+    pgbouncer:
+      enabled: true
+    """
+)
 
-VALUES_EXTERNAL_CLICKHOUSE = {
-    **VALUES_DISABLE_EVERYTHING,
-    "clickhouse": {
-        "enabled": True,
-        "cluster": "kubetest",
-        "database": "kubetest_db",
-        "user": "kubeuser",
-        "password": "kubetestpw",
-    },
-    "zookeeper": {"enabled": True},
-}
+VALUES_EXTERNAL_CLICKHOUSE = merge_yaml(
+    VALUES_DISABLE_EVERYTHING,
+    """
+    clickhouse:
+      enabled: true
+      cluster: kubetest
+      database: kubetest_db
+      user: kubeuser
+      password: kubetestpw
 
-VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = {
-    **VALUES_DISABLE_EVERYTHING,
-    "web": {"enabled": True},
-    "migrate": {"enabled": True},
-    "postgresql": {"enabled": True},
-    "redis": {"enabled": True},
-    "pgbouncer": {"enabled": True},
-    "externalClickhouse": {
-        "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
-        "cluster": "kubetest",
-        "database": "kubetest_db",
-        "user": "kubeuser",
-        "password": "kubetestpw",
-    },
-}
+    zookeeper:
+      enabled: true
+    """
+)
 
-VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = {
-    **VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD,
-    "externalClickhouse": {
-        "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
-        "cluster": "kubetest",
-        "database": "kubetest_db",
-        "user": "kubeuser",
-        "existingSecret": "clickhouse-existing-secret",
-        "existingSecretPasswordKey": "clickhouse-password",
-    },
-}
+VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = merge_yaml(
+    VALUES_DISABLE_EVERYTHING,
+    """
+    web:
+      enabled: true
+    migrate:
+      enabled: true
+    postgresql:
+      enabled: true
+    redis:
+      enabled: true
+    pgbouncer:
+      enabled: true
+
+    externalClickhouse:
+      host: "clickhouse-posthog.clickhouse.svc.cluster.local"
+      cluster: kubetest
+      database: kubetest_db
+      user: kubeuser
+      password: kubetestpw
+    """
+)
+
+VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = merge_yaml(
+    VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD,
+    """
+    externalClickhouse:
+      host: "clickhouse-posthog.clickhouse.svc.cluster.local"
+      cluster: kubetest
+      database: kubetest_db
+      user: kubeuser
+      existingSecret: clickhouse-existing-secret
+      existingSecretPasswordKey: clickhouse-password
+    """
+)
 
 
 def test_can_connect_from_web_pod(kube):

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -106,7 +106,7 @@ def verify_can_connect_to_clickhouse(kube):
         ]
     )
 
-    # This will exit 0 if clickhouse is not connectable
+    # This command will exit with an error code if clickhouse is not connectable
     exec_subprocess(command)
 
 

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -1,0 +1,116 @@
+import pytest
+
+from utils import (
+    NAMESPACE,
+    VALUES_DISABLE_EVERYTHING,
+    cleanup_k8s,
+    exec_subprocess,
+    install_chart,
+    install_custom_resources,
+    wait_for_pods_to_be_ready,
+)
+
+VALUES_ACCESS_CLICKHOUSE = {
+    **VALUES_DISABLE_EVERYTHING,
+    "clickhouse": {"enabled": True},
+    "zookeeper": {"enabled": True},
+    "web": {"enabled": True},
+    "migrate": {"enabled": True},
+    "postgresql": {"enabled": True},
+    "redis": {"enabled": True},
+    "pgbouncer": {"enabled": True},
+}
+
+VALUES_EXTERNAL_CLICKHOUSE = {
+    **VALUES_DISABLE_EVERYTHING,
+    "clickhouse": {
+        "enabled": True,
+        "cluster": "kubetest",
+        "database": "kubetest_db",
+        "user": "admin",  # :TODO: Chart lies about allowing to specify a non-admin user.
+        "password": "kubetestpw",
+    },
+    "zookeeper": {"enabled": True},
+}
+
+VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = {
+    **VALUES_DISABLE_EVERYTHING,
+    "web": {"enabled": True},
+    "migrate": {"enabled": True},
+    "postgresql": {"enabled": True},
+    "redis": {"enabled": True},
+    "pgbouncer": {"enabled": True},
+    "externalClickhouse": {
+        "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
+        "cluster": "kubetest",
+        "database": "kubetest_db",
+        "user": "admin",
+        "password": "kubetestpw",
+        # "existingSecret": "clickhouse-existing-secret",
+        # "existingSecretPasswordKey": "clickhouse-password"
+    },
+}
+
+VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = {
+    **VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD,
+    "externalClickhouse": {
+        "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
+        "cluster": "kubetest",
+        "database": "kubetest_db",
+        "user": "admin",
+        "existingSecret": "clickhouse-existing-secret",
+        "existingSecretPasswordKey": "clickhouse-password",
+    },
+}
+
+
+def test_can_connect_from_web_pod(kube):
+    install_chart(VALUES_ACCESS_CLICKHOUSE)
+    wait_for_pods_to_be_ready(kube)
+
+    verify_can_connect_to_clickhouse(kube)
+
+
+def test_can_connect_external_clickhouse_via_password(kube):
+    setup_external_clickhouse()
+    install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD)
+    wait_for_pods_to_be_ready(kube)
+
+    verify_can_connect_to_clickhouse(kube)
+
+
+def test_can_connect_external_clickhouse_via_secret(kube):
+    install_custom_resources("./custom_k8s_resources/clickhouse_external_secret.yaml")
+    setup_external_clickhouse()
+    install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET)
+    wait_for_pods_to_be_ready(kube)
+
+    verify_can_connect_to_clickhouse(kube)
+
+
+def setup_external_clickhouse():
+    # :TRICKY: We can't use a single docker image since posthog relies on clickhouse being installed in a cluster
+    install_chart(VALUES_EXTERNAL_CLICKHOUSE, namespace="clickhouse")
+
+
+def verify_can_connect_to_clickhouse(kube):
+    "Checks whether clickhouse is connectable from the web pod"
+    pods = kube.get_pods(namespace=NAMESPACE, labels={"role": "web"})
+    pod = list(pods.values())[0]
+
+    command = " ".join(
+        [
+            f"kubectl exec --stdin --tty {pod.name} -n posthog",
+            "--",
+            "python manage.py shell_plus -c",
+            "\"print('connection check success', sync_execute('select count() from events')[0][0])\"",
+        ]
+    )
+
+    # This will exit 0 if clickhouse is not connectable
+    exec_subprocess(command)
+
+
+@pytest.fixture(autouse=True)
+def before_each_cleanup():
+    cleanup_k8s(["default", NAMESPACE, "clickhouse"])

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -113,4 +113,3 @@ def verify_can_connect_to_clickhouse(kube):
 @pytest.fixture(autouse=True)
 def before_each_cleanup():
     cleanup_k8s([NAMESPACE, "clickhouse"])
-    cleanup_helm([NAMESPACE, "clickhouse"])

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -28,7 +28,7 @@ VALUES_EXTERNAL_CLICKHOUSE = {
         "enabled": True,
         "cluster": "kubetest",
         "database": "kubetest_db",
-        "user": "admin",  # :TODO: Chart lies about allowing to specify a non-admin user.
+        "user": "kubeuser",
         "password": "kubetestpw",
     },
     "zookeeper": {"enabled": True},
@@ -45,10 +45,8 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = {
         "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
         "cluster": "kubetest",
         "database": "kubetest_db",
-        "user": "admin",
+        "user": "kubeuser",
         "password": "kubetestpw",
-        # "existingSecret": "clickhouse-existing-secret",
-        # "existingSecretPasswordKey": "clickhouse-password"
     },
 }
 
@@ -58,7 +56,7 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = {
         "host": "clickhouse-posthog.clickhouse.svc.cluster.local",
         "cluster": "kubetest",
         "database": "kubetest_db",
-        "user": "admin",
+        "user": "kubeuser",
         "existingSecret": "clickhouse-existing-secret",
         "existingSecretPasswordKey": "clickhouse-password",
     },

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -3,11 +3,12 @@ import pytest
 from utils import (
     NAMESPACE,
     VALUES_DISABLE_EVERYTHING,
-    merge_yaml,
+    cleanup_helm,
     cleanup_k8s,
     exec_subprocess,
     install_chart,
     install_custom_resources,
+    merge_yaml,
     wait_for_pods_to_be_ready,
 )
 
@@ -28,7 +29,7 @@ VALUES_ACCESS_CLICKHOUSE = merge_yaml(
       enabled: true
     pgbouncer:
       enabled: true
-    """
+    """,
 )
 
 VALUES_EXTERNAL_CLICKHOUSE = merge_yaml(
@@ -43,7 +44,7 @@ VALUES_EXTERNAL_CLICKHOUSE = merge_yaml(
 
     zookeeper:
       enabled: true
-    """
+    """,
 )
 
 VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = merge_yaml(
@@ -66,7 +67,7 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = merge_yaml(
       database: kubetest_db
       user: kubeuser
       password: kubetestpw
-    """
+    """,
 )
 
 VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = merge_yaml(
@@ -79,7 +80,7 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = merge_yaml(
       user: kubeuser
       existingSecret: clickhouse-existing-secret
       existingSecretPasswordKey: clickhouse-password
-    """
+    """,
 )
 
 
@@ -133,3 +134,4 @@ def verify_can_connect_to_clickhouse(kube):
 @pytest.fixture(autouse=True)
 def before_each_cleanup():
     cleanup_k8s([NAMESPACE, "clickhouse"])
+    cleanup_helm([NAMESPACE, "clickhouse"])

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -9,30 +9,50 @@ import yaml
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger()
 
+YamlString = str
+
 NAMESPACE = "posthog"
 
-VALUES_DISABLE_EVERYTHING = {
-    "cloud": "local",
-    "web": {"enabled": False},
-    "migrate": {"enabled": False},
-    "events": {"enabled": False},
-    "worker": {"enabled": False},
-    "plugins": {"enabled": False},
-    "postgresql": {"enabled": False},
-    "redis": {"enabled": False},
-    "kafka": {"enabled": False},
-    "ingress": {"enabled": False},
-    "pgbouncer": {"enabled": False},
-    "clickhouse": {"enabled": False},
-    "zookeeper": {"enabled": False},
-}
+VALUES_DISABLE_EVERYTHING: YamlString = """
+cloud: "local"
+web:
+    enabled: false
+migrate:
+    enabled: false
+events:
+    enabled: false
+worker:
+    enabled: false
+plugins:
+    enabled: false
+postgresql:
+    enabled: false
+redis:
+    enabled: false
+kafka:
+    enabled: false
+ingress:
+    enabled: false
+pgbouncer:
+    enabled: false
+clickhouse:
+    enabled: false
+zookeeper:
+    enabled: false
+"""
+
+def merge_yaml(*yamls):
+    result = {}
+    for value in yamls:
+        result.update(yaml.safe_load(value))
+    return yaml.dump(result)
 
 
 def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
     exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
-    exec_subprocess("kubectl delete clusterrole clickhouse-operator-posthog --ignore-not-found")
     exec_subprocess("kubectl delete clusterrolebinding clickhouse-operator-posthog --ignore-not-found")
+    exec_subprocess("kubectl delete clusterrole clickhouse-operator-posthog --ignore-not-found")
     for namespace in namespaces:
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
     log.debug("✅ Done!")

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -176,6 +176,7 @@ def install_custom_resources(filename, namespace="posthog"):
 
 
 def exec_subprocess(cmd, ignore_errors=False):
+    print([cmd])
     cmd_run = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     cmd_return_code = cmd_run.returncode
     if cmd_return_code and not ignore_errors:

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -30,9 +30,9 @@ VALUES_DISABLE_EVERYTHING = {
 
 def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
+    exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
     for namespace in namespaces:
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
-    exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -51,10 +51,7 @@ def merge_yaml(*yamls):
 
 def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
-    # :TODO: Remove finalizers for chi!
-    # kubectl patch chi posthog --all -p '{"metadata":{"finalizers":null}}' --type=merge
 
-    # exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
     exec_subprocess("kubectl delete clusterrolebinding clickhouse-operator-posthog --ignore-not-found")
     exec_subprocess("kubectl delete clusterrole clickhouse-operator-posthog --ignore-not-found")
     for namespace in namespaces:

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -39,6 +39,13 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("✅ Done!")
 
 
+def cleanup_helm(namespaces=[NAMESPACE]):
+    log.debug("🔄 Making sure helm releases get removed...")
+    for namespace in namespaces:
+        exec_subprocess(f"helm uninstall posthog --namespace {namespace} || true")
+    log.debug("✅ Done!")
+
+
 def helm_install(HELM_INSTALL_CMD):
     log.debug("🔄 Deploying PostHog...")
     exec_subprocess(HELM_INSTALL_CMD)

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -32,7 +32,7 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
     for namespace in namespaces:
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
-    exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found")
+    exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
     log.debug("✅ Done!")
 
 
@@ -153,10 +153,10 @@ def install_custom_resources(filename, namespace="posthog"):
     log.debug("✅ Done!")
 
 
-def exec_subprocess(cmd):
+def exec_subprocess(cmd, ignore_errors=False):
     cmd_run = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     cmd_return_code = cmd_run.returncode
-    if cmd_return_code:
+    if cmd_return_code and not ignore_errors:
         pytest.fail(
             f"""
         ❌ Error while running '{cmd}'.

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -2,9 +2,9 @@ import logging
 import subprocess
 import tempfile
 import time
-import yaml
 
 import pytest
+import yaml
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger()
@@ -13,19 +13,18 @@ NAMESPACE = "posthog"
 
 VALUES_DISABLE_EVERYTHING = {
     "cloud": "local",
-
-    "web": { "enabled": False },
-    "migrate": { "enabled": False },
-    "events": { "enabled": False },
-    "worker": { "enabled": False },
-    "plugins": { "enabled": False },
-    "postgresql": { "enabled": False },
-    "redis": { "enabled": False },
-    "kafka": { "enabled": False },
-    "ingress": { "enabled": False },
-    "pgbouncer": { "enabled": False },
-    "clickhouse": { "enabled": False },
-    "zookeeper": { "enabled": False }
+    "web": {"enabled": False},
+    "migrate": {"enabled": False},
+    "events": {"enabled": False},
+    "worker": {"enabled": False},
+    "plugins": {"enabled": False},
+    "postgresql": {"enabled": False},
+    "redis": {"enabled": False},
+    "kafka": {"enabled": False},
+    "ingress": {"enabled": False},
+    "pgbouncer": {"enabled": False},
+    "clickhouse": {"enabled": False},
+    "zookeeper": {"enabled": False},
 }
 
 

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -31,6 +31,8 @@ VALUES_DISABLE_EVERYTHING = {
 def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
     exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found", ignore_errors=True)
+    exec_subprocess("kubectl delete clusterrole clickhouse-operator-posthog --ignore-not-found")
+    exec_subprocess("kubectl delete clusterrolebinding clickhouse-operator-posthog --ignore-not-found")
     for namespace in namespaces:
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
     log.debug("✅ Done!")

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -32,8 +32,7 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
     for namespace in namespaces:
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
-        if namespace != 'default':
-            exec_subprocess(f"kubectl delete namespace {namespace} --ignore-not-found")
+    exec_subprocess(f"kubectl delete chi --all --all-namespaces --ignore-not-found")
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/utils.py
+++ b/ci/kubetest/utils.py
@@ -31,11 +31,9 @@ VALUES_DISABLE_EVERYTHING = {
 def cleanup_k8s(namespaces=["default", NAMESPACE]):
     log.debug("🔄 Making sure the k8s cluster is empty...")
     for namespace in namespaces:
-        cmd = "kubectl delete all --all -n {namespace}".format(namespace=namespace)
-        cmd_run = subprocess.run(cmd, shell=True)
-        cmd_return_code = cmd_run.returncode
-        if cmd_return_code:
-            pytest.fail("❌ Error while running '{}'. Return code: {}".format(cmd, cmd_return_code))
+        exec_subprocess(f"kubectl delete all --all -n {namespace}")
+        if namespace != 'default':
+            exec_subprocess(f"kubectl delete namespace {namespace} --ignore-not-found")
     log.debug("✅ Done!")
 
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,4 +4,4 @@ target-branch: main
 chart-dirs:
   - charts
 additional-commands:
-  - helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' {{ .Path }}
+  - helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' {{ .Path }}


### PR DESCRIPTION
## Description

This PR is a breaking change, allowing users to connect to an external clickhouse. https://github.com/PostHog/charts-clickhouse/issues/190

This involved some bigger changes:
- (Breaking) `clickhouse.host` value has been removed and will error if used going forward
- (Breaking) `clickhouse.cluster` has been added - previously `clickhouse.database` was used to determine generated cluster name
- (Breaking) `clickhouse.replication` was removed - this is currently unsupported by the app and will require significant work to support. Related: https://github.com/PostHog/posthog/issues/8134
- (Breaking) `clickhouse.enabled` semantics changed - previously it tried to spin up posthog without any clickhouse support which wouldn't really work.
- (Fix) `clickhouse.user` was previously not respected, instead an `admin` user was always created.
- (Feature) `externalClickhouse` has been added. If you want to use external clickhouse, set `clickhouse.enabled: false` and set `externalClickhouse` values. host, cluster, user are always required and either password- or secrets-based auth is available. Note that a clickhouse cluster is required for posthog to run

Documentation PR: https://github.com/PostHog/posthog.com/pull/2855

In practice though using external clickhouse never worked due to a myriad of issues (see PRs linking here)

Code structure notes:
- I extracted snippets and helpers that are clickhouse-related to `_clickhouse.tpl` file. Proposing we follow this pattern going forward as well.
- `_clickhouse.tpl` is unit-tested using a helper template in `charts/posthog/templates/test-templates/clickhouse-env.yaml`. Files in that folder are not tested.
- I added a clickhouse connectivity test testing connecting to both external and internal clickhouse via the web pod. 
- Some more test utils iteration was done to cut down on boilerplate. Opinions welcome :bow: 

Related TODOs:
- [x] Figure out a release plan for this and #271 
- [x] Update documentation with update notes
- [x] Update documentation with notes on using external clickhouse and altinity cloud specifically. https://github.com/PostHog/charts-clickhouse/issues/279
    - [x] Figure out how to use protobuf with external service https://github.com/PostHog/posthog/pull/8333

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
