### PR TITLE
Revert "clickhouse-operator config map: fix `listen_host`"

### DIFF
--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -215,6 +215,8 @@ data:
     <yandex>
         <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
         <listen_host>::</listen_host>
+        <listen_host>0.0.0.0</listen_host>
+        <listen_try>1</listen_try>
     </yandex>
 
   01-clickhouse-02-logger.xml: |

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
@@ -188,6 +188,8 @@ the manifest should match the snapshot when using default values:
         <yandex>
             <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
             <listen_host>::</listen_host>
+            <listen_host>0.0.0.0</listen_host>
+            <listen_try>1</listen_try>
         </yandex>
       01-clickhouse-02-logger.xml: |
         <yandex>


### PR DESCRIPTION
This fix updated the clickhouse chart to not bind on `0.0.0.0`, but only the [ipv6 `0:0:0:0:0:0:0:0` unspecified address](https://www.rfc-editor.org/rfc/rfc3513#section-2.5.2), or `::` for short.

If we do not have ipv6 enabled we will have issues, as we will not be able to bind to any address. The resulting error from clickhouse is e.g.:

```
2022.01.31 14:36:07.584143 [ 7 ] {} <Error> Application: DB::Exception: Listen [::]:8123 failed: Poco::Exception. Code: 1000, e.code() = 0, e.displayText() = DNS error: EAI: Address family for hostname not supported (version 21.6.5.37 (official build))
```

We want to ensure that we also try the ipv4 0.0.0.0. listen_try 1 will ensure that we do not fail to load as long as we succeed in binding to at least one of the listen_hosts. This way we should work on either ipv4 or ipv6 disabled systems.

This is an initial revert just to verify that this indeed resolves this test [failure here for deploying to an aws eks test cluster](https://github.com/PostHog/charts-clickhouse/runs/5004910550?check_suite_focus=true).

I'll look into the initial issue this PR resolved as it would be good not to regress.

There is an option where we say we do not support ipv6 disabled clusters, but I suspect that will limit our compat. considerable.

Reverts PostHog/charts-clickhouse#267