### PR TITLE
ci(e2e): run AWS, DO, Google Cloud e2e tests on main branch push

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -9,6 +9,9 @@ name: e2e - Amazon Web Services (install)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   aws-install:

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -9,6 +9,9 @@ name: e2e - DigitalOcean (install)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   do-install:

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -9,6 +9,9 @@ name: e2e - Google Cloud Platform (install)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   gcp-install:


### PR DESCRIPTION
This was triggered by our EKS deployment starting to fail due to a
[networking
change](https://github.com/PostHog/charts-clickhouse/pull/267), but we
did not pick up the issue for some time.

It would be ideal that we run these on PRs also, but I've gone for just
main for now such that we at least know when main it broken. I think
some optimizations might be in order before these are enabled on PRs,
contraints being we are using let's encrypt and I'm not sure if e.g.
hitting rate limits here is likely. Maybe this is too defensive?

Other options for PRs: run on github comment etc.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
