### PR TITLE
fix(email): ensure email.existingSecretKey is used

### DIFF
--- a/charts/posthog/templates/_email.tpl
+++ b/charts/posthog/templates/_email.tpl
@@ -1,0 +1,26 @@
+{{/* Common email ENV variables and helpers used by PostHog */}}
+
+{{/* ENV used by posthog deployments for connecting to smtp */}}
+{{- define "snippet.email-env" }}
+- name: EMAIL_HOST
+  value: {{ default "" .Values.email.host | quote }}
+- name: EMAIL_PORT
+  value: {{ default "" .Values.email.port | quote }}
+- name: EMAIL_HOST_USER
+  value: {{ default "" .Values.email.user | quote }}
+- name: EMAIL_HOST_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.email.existingSecret }}
+      name: {{ .Values.email.existingSecret }}
+    {{- else }}
+      name: {{ template "posthog.fullname" . }}
+    {{- end }}
+      key: smtp-password
+- name: EMAIL_USE_TLS
+  value: {{ default "false" .Values.email.use_tls | quote }}
+- name: EMAIL_USE_SSL
+  value: {{ default "false" .Values.email.use_ssl | quote }}
+- name: DEFAULT_FROM_EMAIL
+  value: {{ .Values.email.from_email | quote }}
+{{- end }}

--- a/charts/posthog/templates/_email.tpl
+++ b/charts/posthog/templates/_email.tpl
@@ -16,7 +16,7 @@
     {{- else }}
       name: {{ template "posthog.fullname" . }}
     {{- end }}
-      key: smtp-password
+      key: {{ default "smtp-password" .Values.email.existingSecretKey | quote }}
 - name: EMAIL_USE_TLS
   value: {{ default "false" .Values.email.use_tls | quote }}
 - name: EMAIL_USE_SSL

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -92,31 +92,11 @@ spec:
         - name: STATSD_PORT
           value: "9125"
         {{- end }}
-        - name: EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: EMAIL_HOST_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.email.existingSecret }}
-              name: {{ .Values.email.existingSecret }}
-            {{- else }}
-              name: {{ template "posthog.fullname" . }}
-            {{- end }}
-              key: smtp-password
-        - name: EMAIL_USE_TLS
-          value: {{ default "false" .Values.email.use_tls | quote }}
-        - name: EMAIL_USE_SSL
-          value: {{ default "false" .Values.email.use_ssl | quote }}
-        - name: DEFAULT_FROM_EMAIL
-          value: {{ .Values.email.from_email | quote }}
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -63,37 +63,17 @@ spec:
             secretKeyRef:
               name: {{ template "posthog.fullname" . }}
               key: posthog-secret
-        - name: EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: EMAIL_HOST_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.email.existingSecret }}
-              name: {{ .Values.email.existingSecret }}
-            {{- else }}
-              name: {{ template "posthog.fullname" . }}
-            {{- end }}
-              key: smtp-password
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.postgresql-migrate-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}
         - name: KAFKA_URL
           value: {{ template "posthog.kafka.url" . }}
         {{- end }}
-        - name: EMAIL_USE_TLS
-          value: {{ default "false" .Values.email.use_tls | quote }}
-        - name: EMAIL_USE_SSL
-          value: {{ default "false" .Values.email.use_ssl | quote }}
-        - name: DEFAULT_FROM_EMAIL
-          value: {{ .Values.email.from_email | quote }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
         resources:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -92,27 +92,6 @@ spec:
         - name: STATSD_PORT
           value: "9125"
         {{- end }}
-        - name: EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: EMAIL_HOST_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.email.existingSecret }}
-              name: {{ .Values.email.existingSecret }}
-            {{- else }}
-              name: {{ template "posthog.fullname" . }}
-            {{- end }}
-              key: smtp-password
-        - name: EMAIL_USE_TLS
-          value: {{ default "false" .Values.email.use_tls | quote }}
-        - name: EMAIL_USE_SSL
-          value: {{ default "false" .Values.email.use_ssl | quote }}
-        - name: DEFAULT_FROM_EMAIL
-          value: {{ .Values.email.from_email | quote }}
         - name: SAML_ENTITY_ID
           value: {{ default "" .Values.saml.entity_id | quote }}
         - name: SAML_ACS_URL
@@ -139,6 +118,7 @@ spec:
           value: clickhouse
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -88,31 +88,11 @@ spec:
         - name: STATSD_PORT
           value: "9125"
         {{- end }}
-        - name: EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: EMAIL_HOST_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.email.existingSecret }}
-              name: {{ .Values.email.existingSecret }}
-            {{- else }}
-              name: {{ template "posthog.fullname" . }}
-            {{- end }}
-              key: smtp-password
-        - name: EMAIL_USE_TLS
-          value: {{ default "false" .Values.email.use_tls | quote }}
-        - name: EMAIL_USE_SSL
-          value: {{ default "false" .Values.email.use_ssl | quote }}
-        - name: DEFAULT_FROM_EMAIL
-          value: {{ .Values.email.from_email | quote }}
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
         {{- if .Values.kafka.enabled }}

--- a/charts/posthog/tests/email-settings.yaml
+++ b/charts/posthog/tests/email-settings.yaml
@@ -1,0 +1,190 @@
+suite: Email settings propagated to pods
+templates:
+  # This list may be too broad or too narrow, I've just added to all deployments
+  # that use the django backend.
+  - templates/web-deployment.yaml
+  - templates/worker-deployment.yaml
+  - templates/events-deployment.yaml
+  - templates/migrate.job.yaml
+  # NOTE: we need to include this as it is required by the other templates
+  - templates/secrets.yaml
+
+tests:
+  - it: should use email.existingSecret and email.existingSecretKey when set
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      email:
+        existingSecret: my-existing-secret
+        existingSecretKey: some-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-existing-secret
+                key: some-key
+
+  - it: should use email.existingSecret with default secret key
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      email:
+        existingSecret: my-existing-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-existing-secret
+                key: smtp-password
+
+  - it: should use smtp settings from values email.*
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      email:
+        from_email: no-reply@somedomain.fake
+        host: smtp.somedomain.fake
+        port: "9999"
+        user: some-user
+
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_FROM_EMAIL
+            value: no-reply@somedomain.fake
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST
+            value: smtp.somedomain.fake
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_PORT
+            value: "9999"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST_USER
+            value: some-user
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-posthog
+                key: smtp-password
+
+  - it: should set tls/ssl to false when set
+    # NOTE: in other tests we can be reasonably confident that asserts aren't
+    # just aligning with defaults, here our values space is small, so we
+    # explicitly check.
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      email:
+        use_tls: false
+        use_ssl: false
+
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_TLS
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_SSL
+            value: "false"
+
+  - it: should set tls/ssl to true when set
+    # NOTE: in other tests we can be reasonably confident that asserts aren't
+    # just aligning with defaults, here our values space is small, so we
+    # explicitly check.
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      email:
+        use_tls: true
+        use_ssl: true
+
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_TLS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_SSL
+            value: "true"
+
+  - it: should render with no values set, i.e. with default chart values
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_PORT
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_HOST_USER
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_TLS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAIL_USE_SSL
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_FROM_EMAIL
+            value: null


### PR DESCRIPTION
## Description

Previously we would ignore the values `email.existingSecretKey` and default to "smtp-password" dispite it being an option in the chart values.yaml. Here I've added some template unittesting and factored out these env settings into a snippet. See individual commits for separate tasks.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

I'm relying on the unittests here, and the existing k8s integration tests.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
