### PR TITLE
feat(events): use readyz/livez for healthcheck probes

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -112,29 +112,28 @@ spec:
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}
         livenessProbe:
-          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:
             path: /_livez/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
             # For readiness, we want to use the checks specific to the events
             # role, which may be a subset of all the apps dependencies
             path: /_readyz/?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         startupProbe:
-          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
             # For startup, we want to make sure that everything is in place,
             # including postgres. This does however mean we would not be able to
@@ -142,6 +141,11 @@ spec:
             path: /_readyz/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -124,9 +124,9 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
-            # For readiness, we don't want to bring down a pod if it can't query
-            # postgres. I this case we want to remain up, and still push to kafka
-            path: /_readyz/?exclude=postgres&exclude=postgres_migrations_uptodate
+            # For readiness, we want to use the checks specific to the events
+            # role, which may be a subset of all the apps dependencies
+            path: /_readyz/?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -114,7 +114,7 @@ spec:
         livenessProbe:
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:
-            path: /_health/
+            path: /_livez/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
@@ -124,13 +124,24 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
-            path: /_health/
+            # For readiness, we don't want to bring down a pod if it can't query
+            # postgres. I this case we want to remain up, and still push to kafka
+            path: /_readyz/?exclude=postgres&exclude=postgres_migrations-uptodate
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+        startupProbe:
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          httpGet:
+            # For startup, we want to make sure that everything is in place,
+            # including postgres. This does however mean we would not be able to
+            # deploy new releases when we have a postgres outage
+            path: /_readyz/
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -126,7 +126,7 @@ spec:
           httpGet:
             # For readiness, we don't want to bring down a pod if it can't query
             # postgres. I this case we want to remain up, and still push to kafka
-            path: /_readyz/?exclude=postgres&exclude=postgres_migrations-uptodate
+            path: /_readyz/?exclude=postgres&exclude=postgres_migrations_uptodate
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -134,29 +134,28 @@ spec:
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}
         livenessProbe:
-          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:
             path: /_livez/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
             # For readiness, we want to use the checks specific to the web
             # role, which may be a subset of all the apps dependencies
             path: /_readyz/?role=web
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         startupProbe:
-          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
             # For startup, we want to make sure that everything is in place,
             # including postgres. This does however mean we would not be able to
@@ -164,6 +163,11 @@ spec:
             path: /_readyz/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
+          failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -146,9 +146,9 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
-            # For readiness, we don't want to bring down a web pod if kafka is
-            # down, it is likely only to result in minor degraded functionality.
-            path: /_readyz/?exclude=kafka_connected
+            # For readiness, we want to use the checks specific to the web
+            # role, which may be a subset of all the apps dependencies
+            path: /_readyz/?role=web
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -136,7 +136,7 @@ spec:
         livenessProbe:
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:
-            path: /_health/
+            path: /_livez/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
@@ -146,13 +146,24 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
-            path: /_health/
+            # For readiness, we don't want to bring down a web pod if kafka is
+            # down, it is likely only to result in minor degraded functionality.
+            path: /_readyz/?exclude=kafka_connected
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+        startupProbe:
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          httpGet:
+            # For startup, we want to make sure that everything is in place,
+            # including postgres. This does however mean we would not be able to
+            # deploy new releases when we have a postgres outage
+            path: /_readyz/
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -91,7 +91,7 @@ web:
 
   livenessProbe:
     # -- The liveness probe failure threshold
-    failureThreshold: 5
+    failureThreshold: 3
     # -- The liveness probe initial delay seconds
     initialDelaySeconds: 50
     # -- The liveness probe period seconds
@@ -103,15 +103,15 @@ web:
 
   readinessProbe:
     # -- The readiness probe failure threshold
-    failureThreshold: 10
+    failureThreshold: 3
     # -- The readiness probe initial delay seconds
     initialDelaySeconds: 50
     # -- The readiness probe period seconds
-    periodSeconds: 10
+    periodSeconds: 30
     # -- The readiness probe success threshold
     successThreshold: 1
     # -- The readiness probe timeout seconds
-    timeoutSeconds: 2
+    timeoutSeconds: 5
 
 worker:
   # -- Whether to install the PostHog worker stack or not.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -93,9 +93,9 @@ web:
     # -- The liveness probe failure threshold
     failureThreshold: 3
     # -- The liveness probe initial delay seconds
-    initialDelaySeconds: 50
+    initialDelaySeconds: 0
     # -- The liveness probe period seconds
-    periodSeconds: 10
+    periodSeconds: 5
     # -- The liveness probe success threshold
     successThreshold: 1
     # -- The liveness probe timeout seconds
@@ -105,9 +105,21 @@ web:
     # -- The readiness probe failure threshold
     failureThreshold: 3
     # -- The readiness probe initial delay seconds
-    initialDelaySeconds: 50
+    initialDelaySeconds: 0
     # -- The readiness probe period seconds
     periodSeconds: 30
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 5
+
+  startupProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 6
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 0
+    # -- The readiness probe period seconds
+    periodSeconds: 10
     # -- The readiness probe success threshold
     successThreshold: 1
     # -- The readiness probe timeout seconds


### PR DESCRIPTION
## Description

This adds healthchecks specifically for the events service, with the
intention to ensure that:

 1. on initial start of event pods, they will only be marked as ready if
        all dependencies are reachable
 2. we do not go down if postgres is not reachable

Open question: how to handle docker image version compat.?

Open question: how to handle future changes on the docker image side? Ideally I'd love for the interface to just be `/_livez` and `/_readyz` across the board, and for each service to know what it should care about. Perhaps this is a failure of the `exclude` pattern ? 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

I need to add a test to validate that events doesn't come up if kafka is down.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
