### PR TITLE
CI - change k8s version for DO

### DIFF
--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -40,7 +40,7 @@ jobs:
       run: |
         doctl k8s clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \
-          --version 1.21.5-do.0 \
+          --version 1.21.9-do.0 \
           --tag="provisioned_by:github_action" \
           --size s-2vcpu-4gb \
           --count 2 \


### PR DESCRIPTION
## Description
See title. We need to change it as the previous one is not available anymore:

```
doctl k8s clusters create \
    helm-test-e2e-do-install-5c418b0 \
    --version 1.21.5-do.0 \
    --tag="provisioned_by:github_action" \
    --size s-2vcpu-4gb \
    --count 2 \
    --wait
  shell: /usr/bin/bash -e {0}
Error: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 (request "9a[3](https://github.com/PostHog/charts-clickhouse/runs/5182026377?check_suite_focus=true#step:6:3)d9592-ae15-[4](https://github.com/PostHog/charts-clickhouse/runs/5182026377?check_suite_focus=true#step:6:4)bc2-8fff-[6](https://github.com/PostHog/charts-clickhouse/runs/5182026377?check_suite_focus=true#step:6:6)cad931[7](https://github.com/PostHog/charts-clickhouse/runs/5182026377?check_suite_focus=true#step:6:7)f72b") validation error: invalid version slug
```

DO changelog is available [here](https://docs.digitalocean.com/products/kubernetes/changelog/).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
