### PR TITLE
Fix bumping chart version

### DIFF
--- a/.github/workflows/bump-version-workflow-dispatch.yaml
+++ b/.github/workflows/bump-version-workflow-dispatch.yaml
@@ -71,6 +71,7 @@ jobs:
           helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
           helm repo add jetstack https://charts.jetstack.io
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -74,6 +74,7 @@ jobs:
           helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
           helm repo add jetstack https://charts.jetstack.io
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1


### PR DESCRIPTION
https://github.com/PostHog/charts-clickhouse/pull/294 broke this by not
adding the new repo prior to packaging the helm chart in gh action

Error was:
```
2s
Run helm/chart-releaser-action@v1.2.1
Run owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
Looking up latest tag...
Discovering changed charts since 'posthog-15.2.0'...
Installing chart-releaser...
Adding cr directory to PATH...
Packaging chart 'charts/posthog'...
Error: no repository definition for https://grafana.github.io/helm-charts
Usage:
  cr package [CHART_PATH] [...] [flags]
```