### PR TITLE
ci(deploy): add sha/keep install options to cloud provider tests 

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -11,12 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: The posthog docker image to deploy
+        description: |
+          The posthog docker image to deploy. If unspecified we'll use the Helm
+          chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy
+          For debugging purposes, to not tear down the cluster after deploy.
         required: true
         default: false
         type: boolean

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -14,6 +14,11 @@ on:
         description: 'The posthog docker image to deploy'
         required: false
         type: string
+      keep-after-install:
+        description: ''
+        required: true
+        default: "false"
+        type: boolean
 
   push:
     branches:
@@ -168,7 +173,7 @@ jobs:
         filename: ci/k6/ingestion-test.js
 
     - name: Delete the k8s cluster and all the associated resources
-      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
+      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         ./eksctl delete cluster \
           --region=us-east-1 \
@@ -177,7 +182,7 @@ jobs:
           --wait
 
     - name: Delete the DNS record
-      if: ${{ always() && steps.dns_creation.outcome == 'success' }}
+      if: ${{ always() && steps.dns_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         DNS_RECORD_ID=$(doctl compute domain records list posthog.cc --no-header --format ID,Name | grep ${{ steps.vars.outputs.dns_record }} | awk '{print $1}')
         doctl compute domain records delete \

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -9,6 +9,12 @@ name: e2e - Amazon Web Services (install)
 
 on:
   workflow_dispatch:
+    inputs:
+      posthog-image-sha:
+        description: 'The posthog docker image to deploy'
+        required: false
+        type: string
+
   push:
     branches:
       - main
@@ -80,6 +86,7 @@ jobs:
         helm upgrade --install \
           -f ci/values/amazon_web_services.yaml \
           --set "ingress.hostname=${{ steps.vars.outputs.fqdn_record }}" \
+          --set "image.sha=${{ github.event.inputs.posthog-image-sha }}" \
           --timeout 20m \
           --create-namespace \
           --namespace posthog \

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -11,13 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: 'The posthog docker image to deploy'
+        description: The posthog docker image to deploy
         required: false
         type: string
       keep-after-install:
-        description: ''
+        description: |
+          For debugging purposes, to not tear down the cluster after deploy
         required: true
-        default: "false"
+        default: false
         type: boolean
 
   push:

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -12,13 +12,13 @@ on:
     inputs:
       posthog-image-sha:
         description: |
-          The posthog docker image to deploy. If unspecified we'll use the Helm
-          chart's default image.
+          Use this specific dockerhub posthog/posthog image sha. If unspecified
+          we'll use the Helm chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy.
+          Keep K8s cluster and Helm deployment after workflow completion.
         required: true
         default: false
         type: boolean

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -11,15 +11,18 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: The posthog docker image to deploy
+        description: |
+          The posthog docker image to deploy. If unspecified we'll use the Helm
+          chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy
+          For debugging purposes, to not tear down the cluster after deploy.
         required: true
         default: false
         type: boolean
+
   push:
     branches:
       - main

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -9,6 +9,11 @@ name: e2e - DigitalOcean (install)
 
 on:
   workflow_dispatch:
+    inputs:
+      posthog-image-sha:
+        description: 'The posthog docker image to deploy'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -57,6 +62,7 @@ jobs:
           --set ingress.hostname="${{ steps.vars.outputs.fqdn_record }}" \
           --set ingress-nginx.controller.service.annotations."service\.beta\.kubernetes\.io/do-loadbalancer-name"="${{ steps.vars.outputs.k8s_cluster_name }}" \
           --set ingress-nginx.controller.service.annotations."service\.beta\.kubernetes\.io/do-loadbalancer-hostname"="${{ steps.vars.outputs.fqdn_record }}" \
+          --set "image.sha=${{ github.event.inputs.posthog-image-sha }}" \
           --timeout 20m \
           --create-namespace \
           --namespace posthog \

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -12,13 +12,13 @@ on:
     inputs:
       posthog-image-sha:
         description: |
-          The posthog docker image to deploy. If unspecified we'll use the Helm
-          chart's default image.
+          Use this specific dockerhub posthog/posthog image sha. If unspecified
+          we'll use the Helm chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy.
+          Keep K8s cluster and Helm deployment after workflow completion.
         required: true
         default: false
         type: boolean

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -11,13 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: 'The posthog docker image to deploy'
+        description: The posthog docker image to deploy
         required: false
         type: string
       keep-after-install:
-        description: ''
+        description: |
+          For debugging purposes, to not tear down the cluster after deploy
         required: true
-        default: "false"
+        default: false
         type: boolean
   push:
     branches:

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -14,6 +14,11 @@ on:
         description: 'The posthog docker image to deploy'
         required: false
         type: string
+      keep-after-install:
+        description: ''
+        required: true
+        default: "false"
+        type: boolean
   push:
     branches:
       - main
@@ -149,7 +154,7 @@ jobs:
         filename: ci/k6/ingestion-test.js
 
     - name: Delete the k8s cluster and all the associated resources
-      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
+      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         doctl k8s cluster delete \
           --dangerous \
@@ -157,7 +162,7 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }}
 
     - name: Delete the DNS record
-      if: ${{ always() && steps.dns_creation.outcome == 'success' }}
+      if: ${{ always() && steps.dns_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         DNS_RECORD_ID=$(doctl compute domain records list posthog.cc --no-header --format ID,Name | grep ${{ steps.vars.outputs.dns_record }} | awk '{print $1}')
         doctl compute domain records delete \

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -11,15 +11,18 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: The posthog docker image to deploy
+        description: |
+          The posthog docker image to deploy. If unspecified we'll use the Helm
+          chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy
+          For debugging purposes, to not tear down the cluster after deploy.
         required: true
         default: false
         type: boolean
+
   push:
     branches:
       - main

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -14,6 +14,11 @@ on:
         description: 'The posthog docker image to deploy'
         required: false
         type: string
+      keep-after-install:
+        description: ''
+        required: true
+        default: "false"
+        type: boolean
   push:
     branches:
       - main
@@ -201,7 +206,7 @@ jobs:
         echo "::set-output name=posthog_web_neg_zones::${POSTHOG_WEB_NEG_ZONES[@]}"
 
     - name: Delete the k8s cluster and all the associated resources
-      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}
+      if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         gcloud container clusters delete \
           --project ${{ secrets.GCP_PROJECT_ID }} \
@@ -210,7 +215,7 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }}
 
     - name: Delete the associated NEG (Network Endpoint Groups)
-      if: ${{ always() && steps.fetch_neg.outcome == 'success' }}
+      if: ${{ always() && steps.fetch_neg.outcome == 'success' && !github.event.inputs.keep-after-install }}
       shell: bash
       run: |
         delete_neg() {
@@ -232,7 +237,7 @@ jobs:
         delete_neg "${{ steps.vars.outputs.posthog_web_neg_name }}" "${{ steps.vars.outputs.posthog_web_neg_zones }}"
 
     - name: Delete the global static IP address
-      if: ${{ always() && steps.static_ip_creation.outcome == 'success' }}
+      if: ${{ always() && steps.static_ip_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         gcloud compute addresses delete \
           --project ${{ secrets.GCP_PROJECT_ID }} \
@@ -241,7 +246,7 @@ jobs:
           ${{ steps.vars.outputs.dns_record }}
 
     - name: Delete the DNS record
-      if: ${{ always() && steps.dns_creation.outcome == 'success' }}
+      if: ${{ always() && steps.dns_creation.outcome == 'success' && !github.event.inputs.keep-after-install }}
       run: |
         DNS_RECORD_ID=$(doctl compute domain records list posthog.cc --no-header --format ID,Name | grep ${{ steps.vars.outputs.dns_record }} | awk '{print $1}')
         doctl compute domain records delete \
@@ -250,7 +255,7 @@ jobs:
           "$DNS_RECORD_ID"
 
     - name: Delete the Google-managed TLS certificate
-      if: ${{ always() }}
+      if: ${{ always() && !github.event.inputs.keep-after-install }}
       run: |
         TLS_CERTIFICATE_NAME=$(gcloud compute ssl-certificates list --project ${{ secrets.GCP_PROJECT_ID }} --global --filter=${{ steps.vars.outputs.dns_record }} --format="value(NAME)")
         if [ -n "$TLS_CERTIFICATE_NAME" ];

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -12,13 +12,13 @@ on:
     inputs:
       posthog-image-sha:
         description: |
-          The posthog docker image to deploy. If unspecified we'll use the Helm
-          chart's default image.
+          Use this specific dockerhub posthog/posthog image sha. If unspecified
+          we'll use the Helm chart's default image.
         required: false
         type: string
       keep-after-install:
         description: |
-          For debugging purposes, to not tear down the cluster after deploy.
+          Keep K8s cluster and Helm deployment after workflow completion.
         required: true
         default: false
         type: boolean

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -11,13 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       posthog-image-sha:
-        description: 'The posthog docker image to deploy'
+        description: The posthog docker image to deploy
         required: false
         type: string
       keep-after-install:
-        description: ''
+        description: |
+          For debugging purposes, to not tear down the cluster after deploy
         required: true
-        default: "false"
+        default: false
         type: boolean
   push:
     branches:

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up GCP Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -9,6 +9,11 @@ name: e2e - Google Cloud Platform (install)
 
 on:
   workflow_dispatch:
+    inputs:
+      posthog-image-sha:
+        description: 'The posthog docker image to deploy'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -88,6 +93,7 @@ jobs:
           -f ci/values/google_cloud_platform.yaml \
           --set "ingress.hostname=${{ steps.vars.outputs.fqdn_record }}" \
           --set "ingress.gcp.ip_name=${{ steps.vars.outputs.dns_record }}" \
+          --set "image.sha=${{ github.event.inputs.posthog-image-sha }}" \
           --timeout 20m \
           --create-namespace \
           --namespace posthog \


### PR DESCRIPTION
As part of testing before the release of a posthog docker image, I wanted to check that the deploys for aws/gcp/do work as expected.

This PR adds two inputs:

 1. `posthog-image-sha` to specify that a specific docker image should be used, identified by sha256 image hash
 2. `keep-after-install` to specify that we want to not delete the installation afterwards, so we can do some further manual validation if needed.