### PR TITLE
Unify nodeSelector and env variables

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -32,19 +32,18 @@ spec:
 {{ toYaml .Values.web.podLabels | indent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.web.affinity }}
-      affinity:
-{{ toYaml .Values.web.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.web.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      affinity: {{ toYaml .Values.web.affinity | nindent 12 }}
       {{- end }}
       {{- if .Values.web.tolerations }}
-      tolerations:
-{{ toYaml .Values.web.tolerations | indent 8 }}
+      tolerations: {{ toYaml .Values.web.tolerations | nindent 12 }}
       {{- end }}
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.web.nodeSelector | nindent 12 }}
+      {{- end }}
+
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
       {{- if .Values.web.schedulerName }}
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}
@@ -69,6 +68,16 @@ spec:
 
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
+
+        # Add common env variables
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 }}
+        {{- end }}
+
+        # Add events specific env variables
+        {{- if .Values.events.env }}
+        {{ toYaml .Values.events.env | indent 8 }}
+        {{- end }}
 
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}
@@ -106,12 +115,7 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.web.env }}
-{{ toYaml .Values.web.env | indent 8 }}
-{{- end }}
+
         livenessProbe:
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -21,10 +21,16 @@ spec:
 {{ toYaml .Values.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.hooks.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
+      {{- if .Values.migrate.affinity }}
+      affinity: {{ toYaml .Values.migrate.affinity | nindent 12 }}
       {{- end }}
+      {{- if .Values.migrate.tolerations }}
+      tolerations: {{ toYaml .Values.migrate.tolerations | nindent 12 }}
+      {{- end }}
+      {{- if .Values.migrate.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.migrate.nodeSelector | nindent 12 }}
+      {{- end }}
+
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
@@ -42,17 +48,19 @@ spec:
         env:
         # Redis env variables
         {{- include "snippet.redis-env" . | indent 8 }}
+
+        # Add common env variables
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 }}
+        {{- end }}
+
+        # Add migrate specific env variables
+        {{- if .Values.migrate.env }}
+        {{ toYaml .Values.migrate.env | indent 8 }}
+        {{- end }}
+
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.worker.env }}
-{{ toYaml .Values.worker.env | indent 8 }}
-{{- end }}
-{{- if .Values.hooks.migrate.env }}
-{{ toYaml .Values.hooks.migrate.env | indent 8 }}
-{{- end }}
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}
         - name: DEPLOYMENT
@@ -75,8 +83,7 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-        resources:
-{{ toYaml .Values.hooks.migrate.resources | indent 10 }}
+        resources: {{ toYaml .Values.migrate.migrate.resources | nindent 10 }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -26,19 +26,17 @@ spec:
 {{ toYaml .Values.pgbouncer.podLabels | indent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.pgbouncer.affinity }}
-      affinity:
-{{ toYaml .Values.pgbouncer.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.pgbouncer.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.pgbouncer.nodeSelector | indent 8 }}
+      affinity: {{ toYaml .Values.pgbouncer.affinity | nindent 12 }}
       {{- end }}
       {{- if .Values.pgbouncer.tolerations }}
-      tolerations:
-{{ toYaml .Values.pgbouncer.tolerations | indent 8 }}
+      tolerations: {{ toYaml .Values.pgbouncer.tolerations | nindent 12 }}
       {{- end }}
+      {{- if .Values.pgbouncer.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.pgbouncer.nodeSelector | nindent 12 }}
+      {{- end }}
+
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.pgbouncer.schedulerName }}
       schedulerName: "{{ .Values.pgbouncer.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -73,6 +73,16 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
 
+        # Add common env variables
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 }}
+        {{- end }}
+
+        # Add plugins specific env variables
+        {{- if .Values.plugins.env }}
+        {{ toYaml .Values.plugins.env | indent 8 }}
+        {{- end }}
+
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: DEPLOYMENT
@@ -98,12 +108,7 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.plugins.env }}
-{{ toYaml .Values.plugins.env | indent 8 }}
-{{- end }}
+
         resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -32,19 +32,18 @@ spec:
 {{ toYaml .Values.web.podLabels | indent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.web.affinity }}
-      affinity:
-{{ toYaml .Values.web.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.web.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      affinity: {{ toYaml .Values.web.affinity | nindent 12 }}
       {{- end }}
       {{- if .Values.web.tolerations }}
-      tolerations:
-{{ toYaml .Values.web.tolerations | indent 8 }}
+      tolerations: {{ toYaml .Values.web.tolerations | nindent 12 }}
       {{- end }}
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.web.nodeSelector | nindent 12 }}
+      {{- end }}
+
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- if .Values.web.affinity }}
       {{- if .Values.web.schedulerName }}
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}
@@ -69,6 +68,16 @@ spec:
 
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
+
+        # Add common env variables
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 }}
+        {{- end }}
+
+        # Add web specific env variables
+        {{- if .Values.web.env }}
+        {{ toYaml .Values.web.env | indent 8 }}
+        {{- end }}
 
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}
@@ -128,12 +137,7 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.web.env }}
-{{ toYaml .Values.web.env | indent 8 }}
-{{- end }}
+
         livenessProbe:
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -32,19 +32,17 @@ spec:
 {{ toYaml .Values.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.worker.affinity }}
-      affinity:
-{{ toYaml .Values.worker.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.worker.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.worker.nodeSelector | indent 8 }}
+      affinity: {{ toYaml .Values.worker.affinity | nindent 12 }}
       {{- end }}
       {{- if .Values.worker.tolerations }}
-      tolerations:
-{{ toYaml .Values.worker.tolerations | indent 8 }}
+      tolerations: {{ toYaml .Values.worker.tolerations | nindent 12 }}
       {{- end }}
+      {{- if .Values.worker.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.worker.nodeSelector | nindent 12 }}
+      {{- end }}
+
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.worker.schedulerName }}
       schedulerName: "{{ .Values.worker.schedulerName }}"
       {{- end }}
@@ -72,6 +70,16 @@ spec:
 
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
+
+        # Add common env variables
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 }}
+        {{- end }}
+
+        # Add worker specific env variables
+        {{- if .Values.worker.env }}
+        {{ toYaml .Values.worker.env | indent 8 }}
+        {{- end }}
 
         - name: SITE_URL
           value: {{ template "posthog.site.url" . }}
@@ -101,12 +109,7 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.worker.env }}
-{{ toYaml .Values.worker.env | indent 8 }}
-{{- end }}
+
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
       initContainers:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -23,9 +23,20 @@ env:
   - name: EVENT_PROPERTY_USAGE_INTERVAL_SECONDS
     value: "86400"
 
+
 migrate:
   # -- Whether to install the PostHog migrate job or not.
   enabled: true
+
+  # -- Node labels for the migrate job.
+  nodeSelector: {}
+
+  # -- Toleration labels the migrate job.
+  tolerations: []
+
+  # -- Affinity settings the migrate job.
+  affinity: {}
+
 
 events:
   # -- Whether to install the PostHog events stack or not.
@@ -43,6 +54,16 @@ events:
     minpods: 1
     # -- Max pods for the events stack HorizontalPodAutoscaler.
     maxpods: 10
+
+  # -- Node labels for the events stack deployment.
+  nodeSelector: {}
+
+  # -- Toleration labels the events stack deployment.
+  tolerations: []
+
+  # -- Affinity settings the events stack deployment.
+  affinity: {}
+
 
 web:
   # -- Whether to install the PostHog web stack or not.
@@ -388,8 +409,19 @@ pgbouncer:
   replicacount: 1
   # -- Additional env vars to be added to the pgbouncer deployment
   env: []
+
+  # -- Node labels for the pgbouncer stack deployment.
+  nodeSelector: {}
+
+  # -- Toleration labels for the pgbouncer stack deployment.
+  tolerations: []
+
+  # -- Affinity settings for the pgbouncer stack deployment.
+  affinity: {}
+
   # -- Additional volumeMounts to be added to the pgbouncer deployment
   extraVolumeMounts: []
+
   # -- Additional volumes to be added to the pgbouncer deployment
   extraVolumes: []
 
@@ -534,7 +566,7 @@ clickhouse:
   image:
     # -- ClickHouse image repository.
     repository: yandex/clickhouse-server
-    # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. 
+    # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
     tag: "21.6.5"
 
   # -- Toleration labels for clickhouse pod assignment
@@ -624,16 +656,6 @@ cloudwatch:
     readHead: "On"
     readTail: "Off"
 
-
-# Provide affinity for hooks if needed
-hooks:
-  # -- Affinity settings for hooks
-  affinity: {}
-  migrate:
-    # -- Env variables for migate hooks
-    env: []
-    # -- Hook job resource limits/requests
-    resources: {}
 
 serviceAccount:
   # -- Configures if a ServiceAccount with this name should be created


### PR DESCRIPTION
## Description
- make sure deployments & migrate job have the option to configure `affinity`, `tolerations` and `nodeSelector`
- rename `.Values.hooks.migrate` to `.Values.migration`

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
