### PR TITLE
Kafka - fix for `externalKafka.brokers`

### DIFF
--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -31,14 +31,14 @@
 {{- end }}
 - name: KAFKA_ENABLED
   value: "true"
-# Used by PostHog/plugin-server. Expected format: comma-separated list of "host:port"
+# Used by PostHog/plugin-server. There is no specific reason for the difference. Expected format: comma-separated list of "host:port"
 - name: KAFKA_HOSTS
 {{- if .Values.kafka.enabled }}
   value: {{ ( include "posthog.kafka.brokers" . ) }}
 {{ else }}
   value: {{ join "," .Values.externalKafka.brokers | quote }}
 {{- end }}
-# Used by PostHog/web. Expected format: comma-separated list of "kafka://host:port"
+# Used by PostHog/web. There is no specific reason for the difference. Expected format: comma-separated list of "kafka://host:port"
 - name: KAFKA_URL
 {{- if .Values.kafka.enabled }}
   value: {{ printf "kafka://%s" ( include "posthog.kafka.brokers" . ) }}

--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -1,31 +1,48 @@
 {{/* Common Kafka ENV variables and helpers used by PostHog */}}
 
 {{/* Return the Kafka fullname */}}
-{{- define "posthog.kafka.fullname" -}}
-{{- if .Values.kafka.fullnameOverride -}}
-{{- .Values.kafka.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else if .Values.kafka.nameOverride -}}
-{{- printf "%s-%s" .Release.Name .Values.kafka.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "posthog.kafka.fullname" }}
+{{- if .Values.kafka.fullnameOverride }}
+{{- .Values.kafka.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.kafka.nameOverride }}
+{{- printf "%s-%s" .Release.Name .Values.kafka.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- else -}}
-{{- printf "%s-%s" (include "posthog.fullname" .) "kafka" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- printf "%s-%s" (include "posthog.fullname" .) "kafka" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 
 {{/* Return the Kafka hosts (brokers) */}}
-{{- define "posthog.kafka.brokers" -}}
-{{- if .Values.kafka.enabled }}
-    {{- printf "%s:%d" (include "posthog.kafka.fullname" .) (.Values.kafka.service.port | int) -}}
+{{- define "posthog.kafka.brokers"}}
+{{- if .Values.kafka.enabled -}}
+    {{- printf "%s:%d" (include "posthog.kafka.fullname" .) (.Values.kafka.service.port | int) }}
 {{- else -}}
-    {{- printf "%s" .Values.externalKafka.brokers -}}
-{{- end -}}
-{{- end -}}
+    {{- printf "%s" .Values.externalKafka.brokers }}
+{{- end }}
+{{- end }}
 
 {{/* ENV used by PostHog deployments for connecting to Kafka */}}
+
 {{- define "snippet.kafka-env" }}
-- name: KAFKA_HOSTS
-  value: "{{ include "posthog.kafka.brokers" . }}"
-- name: KAFKA_URL
-  value: "kafka://{{ include "posthog.kafka.brokers" . }}"
+
+{{- $hostsWithPrefix := list }}
+{{- range $host := .Values.externalKafka.brokers }}
+{{- $hostWithPrefix := (printf "kafka://%s" $host) }}
+{{- $hostsWithPrefix = append $hostsWithPrefix $hostWithPrefix }}
+{{- end }}
 - name: KAFKA_ENABLED
   value: "true"
+# Used by PostHog/plugin-server. Expected format: comma-separated list of "host:port"
+- name: KAFKA_HOSTS
+{{- if .Values.kafka.enabled }}
+  value: {{ ( include "posthog.kafka.brokers" . ) }}
+{{ else }}
+  value: {{ join "," .Values.externalKafka.brokers | quote }}
+{{- end }}
+# Used by PostHog/web. Expected format: comma-separated list of "kafka://host:port"
+- name: KAFKA_URL
+{{- if .Values.kafka.enabled }}
+  value: {{ printf "kafka://%s" ( include "posthog.kafka.brokers" . ) }}
+{{ else }}
+  value: {{ join "," $hostsWithPrefix | quote }}
+{{- end }}
 {{- end }}

--- a/charts/posthog/templates/test-templates.yaml
+++ b/charts/posthog/templates/test-templates.yaml
@@ -6,6 +6,8 @@ data:
 {{- include "snippet.clickhouse-env" . | nindent 2 }}
 {{- else if .Values.testTemplates.postgresqlEnvTest -}}
 {{- include "snippet.postgresql-migrate-env" . | nindent 2 }}
+{{- else if .Values.testTemplates.kafkaEnvTest -}}
+{{- include "snippet.kafka-env" . | nindent 2 }}
 {{- else if .Values.testTemplates.prometheusStatsdExporterEnvTest -}}
 {{- include "snippet.statsd-env" . | nindent 2 }}
 {{- end -}}

--- a/charts/posthog/templates/test-templates.yaml
+++ b/charts/posthog/templates/test-templates.yaml
@@ -6,8 +6,6 @@ data:
 {{- include "snippet.clickhouse-env" . | nindent 2 }}
 {{- else if .Values.testTemplates.postgresqlEnvTest -}}
 {{- include "snippet.postgresql-migrate-env" . | nindent 2 }}
-{{- else if .Values.testTemplates.kafkaEnvTest -}}
-{{- include "snippet.kafka-env" . | nindent 2 }}
 {{- else if .Values.testTemplates.prometheusStatsdExporterEnvTest -}}
 {{- include "snippet.statsd-env" . | nindent 2 }}
 {{- end -}}

--- a/charts/posthog/tests/kafka-settings.yaml
+++ b/charts/posthog/tests/kafka-settings.yaml
@@ -1,0 +1,129 @@
+suite: Kafka settings propagated to pods
+templates:
+  # This list may be too broad or too narrow, I've just added to all deployments
+  # that use the django backend.
+  - templates/web-deployment.yaml
+  - templates/worker-deployment.yaml
+  - templates/events-deployment.yaml
+  - templates/migrate.job.yaml
+  # NOTE: we need to include this as it is required by the other templates
+  - templates/secrets.yaml
+
+tests:
+  - it: should use internal Kafka as default
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_HOSTS
+            value: RELEASE-NAME-posthog-kafka:9092
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_URL
+            value: kafka://RELEASE-NAME-posthog-kafka:9092
+
+
+  - it: should use internal Kafka when `kafka.enabled` is set to `true` and `externalKafka.brokers` is configured
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: true
+      externalKafka:
+        brokers:
+          - "broker1:port1"
+          - "broker2:port2"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_HOSTS
+            value: RELEASE-NAME-posthog-kafka:9092
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_URL
+            value: kafka://RELEASE-NAME-posthog-kafka:9092
+
+  - it: should use external Kafka when `kafka.enabled` is set to `false` and `externalKafka.brokers` is configured
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:port1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_HOSTS
+            value: "broker1:port1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_URL
+            value: kafka://broker1:port1
+
+  - it: should use external Kafka when `kafka.enabled` is set to `false` and `externalKafka.brokers` is configured (multiple brokers)
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:port1
+          - broker2:port2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_HOSTS
+            value: "broker1:port1,broker2:port2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_URL
+            value: kafka://broker1:port1,kafka://broker2:port2

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -485,8 +485,8 @@ kafka:
       - posthog-posthog-zookeeper:2181
 
 externalKafka:
-  # - External Kafka brokers. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided in a comma separated list, e.g. `host1:port1,host2:port2`.
-  brokers: ""
+  # - External Kafka brokers. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided as array/list.
+  brokers: []
 
 
 ###
@@ -533,7 +533,7 @@ clickhouse:
   image:
     # -- ClickHouse image repository.
     repository: yandex/clickhouse-server
-    # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. 
+    # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
     tag: "21.6.5"
 
   # -- Toleration labels for clickhouse pod assignment

--- a/ci/kubetest/test_kafka_external.py
+++ b/ci/kubetest/test_kafka_external.py
@@ -16,7 +16,9 @@ kafka:
   enabled: false
 
 externalKafka:
-  brokers: "kafka0:9092,kafka1:9092"
+  brokers:
+    - "kafka0:9092"
+    - "kafka1:9092"
 
 #
 # For the purpose of this test, let's disable service persistence


### PR DESCRIPTION
## Description
Make `externalKafka.brokers` a list and build `KAFKA_HOSTS` and `KAFKA_URL` out of the items in there. Unfortunately we don't use the same name as well as format for those two environment variables:

- `KAFKA_HOSTS` is used by the `plugin-server` and expects a string of comma-separated items in the form "host1:port1"
- `KAFKA_URL` is used by PostHog/web and expects a string of comma separated items in the form "kafka://host1:port1"

As unifying the names and format in `posthog/posthog` will require to wait for a release, let's abstract this by handing the differences directly in the Helm chart. 

## Type of change
Note: we are adding bump major to this PR so we will release a new major version of the chart including this change and #271.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be passing ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
