### PR TITLE
CI - change k8s version for DO (I hope for the last time)

### DIFF
--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -38,9 +38,12 @@ jobs:
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation
       run: |
+        # Get the DO K8 version slug
+        DO_K8S_VERSION=$(doctl k8s options versions -ojson | jq --raw-output 'first(.[] | select(.slug | test("^1.21.[0-9]+-do.[0-9]+$")) | .slug)')
+
         doctl k8s clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \
-          --version 1.21.9-do.0 \
+          --version "$DO_K8S_VERSION" \
           --tag="provisioned_by:github_action" \
           --size s-2vcpu-4gb \
           --count 2 \


### PR DESCRIPTION
## Description
See title. Similar to #298, we need to change it as the previous one is not available anymore:

```
doctl k8s clusters create \
    helm-test-e2e-do-install-567edfd \
    --version 1.21.9-do.0 \
    --tag="provisioned_by:github_action" \
    --size s-2vcpu-4gb \
    --count 2 \
    --wait
  shell: /usr/bin/bash -e {0}
Error: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 (request "[3](https://github.com/PostHog/charts-clickhouse/runs/5464877399?check_suite_focus=true#step:6:3)9c12027-[4](https://github.com/PostHog/charts-clickhouse/runs/5464877399?check_suite_focus=true#step:6:4)c4c-4c8c-9f49-83f[5](https://github.com/PostHog/charts-clickhouse/runs/5464877399?check_suite_focus=true#step:6:5)[7](https://github.com/PostHog/charts-clickhouse/runs/5464877399?check_suite_focus=true#step:6:7)0a25f7[9](https://github.com/PostHog/charts-clickhouse/runs/5464877399?check_suite_focus=true#step:6:9)") validation error: invalid version slug
```

DO changelog is available [here](https://docs.digitalocean.com/products/kubernetes/changelog/).

As I don't want to change this another time, let's fetch the DO K8s version slug at runtime. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally + manually [triggered the job](https://github.com/PostHog/charts-clickhouse/actions/runs/1962355509).

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
