### PR TITLE
CI - helm unittest fixes

### DIFF
--- a/charts/posthog/templates/_snippet-error-on-invalid-values.tpl
+++ b/charts/posthog/templates/_snippet-error-on-invalid-values.tpl
@@ -1,91 +1,51 @@
 {{/* Checks whether invalid values are set */}}
 {{- define "snippet.error-on-invalid-values" }}
   {{- if and .Values.postgresql.enabled .Values.externalPostgresql.postgresqlHost }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "externalPostgresql.postgresqlHost cannot be set if postgresql.enabled is true" ""
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "externalPostgresql.postgresqlHost cannot be set if postgresql.enabled is true" "") nil -}}
+
   {{- else if and .Values.redis.enabled .Values.externalRedis.host }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "externalRedis.host cannot be set if redis.enabled is true" ""
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "externalRedis.host cannot be set if redis.enabled is true" "") nil -}}
+
   {{- else if and .Values.kafka.enabled .Values.externalKafka.brokers }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "externalKafka.brokers cannot be set if kafka.enabled is true" ""
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "externalKafka.brokers cannot be set if kafka.enabled is true" "") nil -}}
+
   {{- else if and .Values.clickhouse.enabled .Values.externalClickhouse.host }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "externalClickhouse.host cannot be set if clickhouse.enabled is true" ""
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "externalClickhouse.host cannot be set if clickhouse.enabled is true" "") nil -}}
+
   {{- else if and .Values.clickhouse.enabled .Values.externalClickhouse.cluster }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "externalClickhouse.cluster cannot be set if clickhouse.enabled is true" ""
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "externalClickhouse.cluster cannot be set if clickhouse.enabled is true" "") nil -}}
+
   {{- else if .Values.certManager }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "certManager value has been renamed to cert-manager"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-3xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "certManager value has been renamed to cert-manager" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-3xx") nil -}}
+
   {{- else if .Values.beat }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "beat deployment has been removed"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-7xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "beat deployment has been removed" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-7xx") nil -}}
+
   {{- else if .Values.clickhouseOperator }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "clickhouseOperator values are no longer valid"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-9xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "clickhouseOperator values are no longer valid" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-9xx") nil -}}
+
   {{- else if or .Values.redis.port .Values.redis.host .Values.redis.password }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "redis.port, redis.host and redis.password are no longer valid"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-11xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "redis.port, redis.host and redis.password are no longer valid" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-11xx") nil -}}
+
   {{- else if .Values.clickhouse.host }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "clickhouse.host has been moved to externalClickhouse.host"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "clickhouse.host has been moved to externalClickhouse.host" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
+
   {{- else if .Values.clickhouse.replication }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "clickhouse.replication has been removed"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-12xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "clickhouse.replication has been removed" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-12xx") nil -}}
+
   {{- else if .Values.postgresql.postgresqlHost }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "postgresql.postgresqlHost has been moved to externalPostgresql.postgresqlHost"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "postgresql.postgresqlHost has been moved to externalPostgresql.postgresqlHost" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
+
   {{- else if .Values.postgresql.postgresqlPort }}
-    {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-      "postgresql.postgresqlPort has been moved to externalPostgresql.postgresqlPort"
-      "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
-    ) nil -}}
-  
+    {{- required (printf (include "snippet.error-on-invalid-values-template" .) "postgresql.postgresqlPort has been moved to externalPostgresql.postgresqlPort" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
+
   {{- else if .Values.postgresql.postgresqlUsername }}
     {{- if ne .Values.postgresql.postgresqlUsername "postgres" }}
-      {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-        "postgresql.postgresqlUsername has been removed"
-        "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
-      ) nil -}}
+      {{- required (printf (include "snippet.error-on-invalid-values-template" .) "postgresql.postgresqlUsername has been removed" "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx") nil -}}
     {{- end -}}
 
     {{- if .Values.clickhouse.useNodeSelector }}
-      {{- required (printf (include "snippet.error-on-invalid-values-template" .)
-        "clickhouse.useNodeSelector has been removed"
-        "please use the clickhouse.nodeSelector variable instead"
-      ) nil -}}
+      {{- required (printf (include "snippet.error-on-invalid-values-template" .) "clickhouse.useNodeSelector has been removed" "please use the clickhouse.nodeSelector variable instead") nil -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Description
With #319 we've slightly changed the formatting of `charts/posthog/templates/_snippet-error-on-invalid-values.tpl`. While this is still a valid YAML and Helm can install the templates successfully it was breaking our Helm unittest suite.

```
 FAIL  PostHog plugins HPA definition	charts/posthog/tests/plugins-hpa.yaml
	- should be empty if plugins.enabled and plugins.hpa.enabled are set to false
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be empty if plugins.enabled is true and plugins.hpa.enabled is set to false
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be not empty if plugins.enabled and plugins.hpa.enabled are set to true
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should have the correct apiVersion
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be the correct kind
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action
```

Let's move back to the previous formatting so that CI can be ✅ again.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is passing again
```
Charts:      1 passed, 1 total
Test Suites: 31 passed, 31 total
Tests:       187 passed, 187 total
Snapshot:    25 passed, 25 total
Time:        6.710652125s
```

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
