### PR TITLE
CI - upgrade helm unittest to 0.2.8

### DIFF
--- a/.github/workflows/test-unit-helm.yaml
+++ b/.github/workflows/test-unit-helm.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Helm unittest plugin
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.7
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8
 
       - name: Run test suite
         run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -43,7 +43,7 @@ This repo uses several types of test suite targeting different goals:
 We use `helm lint` that can be invoked via: `helm lint --strict --set “cloud=local” charts/posthog`
 
 #### Unit tests
-In order to run the test suite, you need to install the `helm-unittest` plugin. You can do that by running: `helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8`
+In order to run the test suite, you need to install the `helm-unittest` plugin. You can do that by running: `helm plugin install https://github.com/quintush/helm-unittest --version 0.2.8`
 
 For more information about how it works and how to write test cases, please look at the upstream [documentation](https://github.com/quintush/helm-unittest/blob/master/README.md) or to the [tests already available in this repo](https://github.com/PostHog/charts-clickhouse/tree/main/charts/posthog/tests).
 

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -43,7 +43,7 @@ This repo uses several types of test suite targeting different goals:
 We use `helm lint` that can be invoked via: `helm lint --strict --set “cloud=local” charts/posthog`
 
 #### Unit tests
-In order to run the test suite, you need to install the `helm-unittest` plugin. You can do that by running: `helm plugin install https://github.com/quintush/helm-unittest`
+In order to run the test suite, you need to install the `helm-unittest` plugin. You can do that by running: `helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8`
 
 For more information about how it works and how to write test cases, please look at the upstream [documentation](https://github.com/quintush/helm-unittest/blob/master/README.md) or to the [tests already available in this repo](https://github.com/PostHog/charts-clickhouse/tree/main/charts/posthog/tests).
 


### PR DESCRIPTION
## Description
With https://github.com/PostHog/charts-clickhouse/pull/319 we've slightly changed the formatting of charts/posthog/templates/_snippet-error-on-invalid-values.tpl. While this is still a valid YAML and Helm can install the templates successfully it was breaking our Helm unittest suite.
```
FAIL  PostHog plugins HPA definition	charts/posthog/tests/plugins-hpa.yaml
	- should be empty if plugins.enabled and plugins.hpa.enabled are set to false
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be empty if plugins.enabled is true and plugins.hpa.enabled is set to false
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be not empty if plugins.enabled and plugins.hpa.enabled are set to true
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should have the correct apiVersion
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action

	- should be the correct kind
		Error: parse error at (posthog/templates/_snippet-error-on-invalid-values.tpl:25): unclosed action
```

The issue is fixed on version 0.2.8 ([this](https://github.com/quintush/helm-unittest/pull/137) is likely the fix) 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is now ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
