### PR TITLE
CI - fix test_clickhouse_different_image

### DIFF
--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -3,17 +3,12 @@ import pytest
 from helpers.clickhouse import get_clickhouse_pod_spec
 from helpers.utils import cleanup_helm, cleanup_k8s, install_chart, is_posthog_healthy, wait_for_pods_to_be_ready
 
-# :KLUDGE: We need to override image.tag to be more dynamic with supported clickhouse versions.
-# Can remove it once PostHog 1.33.0 is out.
 VALUES_WITH_DIFFERENT_CLICKHOUSE_IMAGE = """
 cloud: "local"
 
-image:
-  tag: latest
-
 clickhouse:
   image:
-    tag: 22.1
+    tag: 21.9.2.17
 """
 
 
@@ -31,4 +26,4 @@ def test_posthog_healthy(kube):
 
 def test_clickhouse_pod_image(kube):
     pod_spec = get_clickhouse_pod_spec(kube)
-    assert pod_spec.containers[0].image == "yandex/clickhouse-server:22.1"
+    assert pod_spec.containers[0].image == "yandex/clickhouse-server:21.9.2.17"


### PR DESCRIPTION
## Description
While trying to figure out the CI failures [here](https://github.com/PostHog/charts-clickhouse/runs/5494641654?check_suite_focus=true), let's do a minor cleanup:

- remove custom `image.tag` override now that default image is >=1.33.0 (so that CI can be more deterministic)
- change supported ClickHouse version as 22.1 will probably not work

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
