### PR TITLE
ClickHouse - parametrize settings and podAnnotations

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -26,7 +26,7 @@ spec:
           {{- toYaml .Values.clickhouse.layout | nindent 10 }}
 
     settings:
-      format_schema_path: /etc/clickhouse-server/config.d/
+      {{- merge dict .Values.clickhouse.settings .Values.clickhouse.defaultSettings | toYaml | nindent 6 }}
 
     files:
       events.proto: |
@@ -54,6 +54,10 @@ spec:
   templates:
     podTemplates:
       - name: pod-template
+          {{- if .Values.clickhouse.podAnnotations }}
+        metadata:
+          annotations: {{ toYaml .Values.clickhouse.podAnnotations | nindent 12 }}
+          {{- end }}
         spec:
           {{- if .Values.clickhouse.affinity }}
           affinity: {{ toYaml .Values.clickhouse.affinity | nindent 12 }}

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -226,7 +226,6 @@ tests:
             default/max_execution_time: "90"
             default/max_memory_usage: "20000000000"
 
-
   - it: handles custom profiles overriding defaults
     set:
       clickhouse.profiles.default/allow_experimental_window_functions: "0"
@@ -237,6 +236,40 @@ tests:
           path: spec.configuration.profiles
           value:
             default/allow_experimental_window_functions: "0"
+
+  - it: default configuration settings should be correct
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.settings
+          value:
+            format_schema_path: /etc/clickhouse-server/config.d/
+
+  - it: handles custom configuration settings
+    set:
+      clickhouse.settings:
+        prometheus/endpoint: /metrics
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.settings
+          value:
+            format_schema_path: /etc/clickhouse-server/config.d/
+            prometheus/endpoint: /metrics
+
+  - it: handles custom configuration settings overriding defaults
+    set:
+      clickhouse.settings:
+        format_schema_path: /custom_path
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.configuration.settings
+          value:
+            format_schema_path: /custom_path
 
   - it: handles custom users and passwords
     set:
@@ -305,3 +338,21 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec.configuration.clusters[0].layout
+
+  - it: podAnnotations should not be set by default
+    asserts:
+      - equal:
+          path: spec.templates.podTemplates[0].metadata
+          value: null
+
+  - it: podAnnotations setting should work
+    set:
+      clickhouse.podAnnotations:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.templates.podTemplates[0].metadata.annotations
+          value:
+            key1: value1
+            key2: value2

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -276,6 +276,8 @@ tests:
       clickhouse.user: someuser
       clickhouse.password: somepass
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.configuration.users
           value:
@@ -286,6 +288,8 @@ tests:
 
   - it: sets default clickhouse-server image
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.templates.podTemplates[0].spec.containers[0].image
           value: "yandex/clickhouse-server:21.6.5"
@@ -295,6 +299,8 @@ tests:
       clickhouse.image.repository: altinity/clickhouse-server
       clickhouse.image.tag: 22.1
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.templates.podTemplates[0].spec.containers[0].image
           value: "altinity/clickhouse-server:22.1"
@@ -304,6 +310,8 @@ tests:
       clickhouse.layout.shardsCount: 3
       clickhouse.layout.replicasCount: 2
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.configuration.clusters[0].layout
           value:
@@ -336,11 +344,15 @@ tests:
               - name: replica1
               - name: replica2
     asserts:
+      - hasDocuments:
+          count: 1
       - matchSnapshot:
           path: spec.configuration.clusters[0].layout
 
-  - it: podAnnotations should not be set by default
+  - it: spec.templates.podTemplates.[0].metadata should not be set by default
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.templates.podTemplates[0].metadata
           value: null
@@ -351,6 +363,8 @@ tests:
         key1: value1
         key2: value2
     asserts:
+      - hasDocuments:
+          count: 1
       - equal:
           path: spec.templates.podTemplates[0].metadata.annotations
           value:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -18,8 +18,8 @@ sentryDSN:
 
 # -- Environment variables to inject into every PostHog deployment.
 env: []
-# env: 
-#   - name: FOO 
+# env:
+#   - name: FOO
 #     value: bar
 
 migrate:
@@ -577,8 +577,10 @@ clickhouse:
     size: 20Gi
 
   ## -- Clickhouse user profile configuration.
-  ## You can use this to override settings, for example `default/max_memory_usage: 40000000000`
-  ## For a full list of clickhouse settings, see https://clickhouse.com/docs/en/operations/settings/settings/
+  ## You can use this to override profile settings, for example `default/max_memory_usage: 40000000000`
+  ## For the full list of settings, see:
+  ## - https://clickhouse.com/docs/en/operations/settings/settings-profiles/
+  ## - https://clickhouse.com/docs/en/operations/settings/settings/
   profiles: {}
 
   ## -- Default user profile configuration for Clickhouse. Don't overwrite this!
@@ -591,6 +593,29 @@ clickhouse:
   layout:
     shardsCount: 1
     replicasCount: 1
+
+  ## -- ClickHouse settings configuration.
+  ## You can use this to override settings, for example `prometheus/port: 9363`
+  ## For the full list of settings, see:
+  ## - https://clickhouse.com/docs/en/operations/settings/settings/
+  settings: {}
+    # Uncomment those lines if you want to enable the built-in Prometheus HTTP endpoint in ClickHouse.
+    # prometheus/endpoint: /metrics
+    # prometheus/port: 9363
+    # prometheus/metrics: true
+    # prometheus/events: true
+    # prometheus/asynchronous_metrics: true
+
+  ## -- Default settings configuration for ClickHouse. Don't overwrite this!
+  defaultSettings:
+    format_schema_path: /etc/clickhouse-server/config.d/
+
+  ## -- ClickHouse pod(s) annotation.
+  podAnnotations:
+    # Uncomment those lines if you want Prometheus server to scrape ClickHouse pods metrics.
+    # prometheus.io/scrape: "true"
+    # prometheus.io/path: /metrics
+    # prometheus.io/port: "9363"
 
 ## External clickhouse configuration
 ##


### PR DESCRIPTION
## Description
* makes the ClickHouse `spec.configuration.settings` knobs configurable via `values.yaml` by adding new `clickhouse.settings` and `clickhouse.defaultSettings` inputs
* makes the ClickHouse pod(s) annotation configurable via `values.yaml` by adding a new `clickhouse.podAnnotations` input

The change is expected to be a no-op.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
