### PR TITLE
chore(CI): bump 'e2e - kubetest (store test durations)' timeout

### DIFF
--- a/.github/workflows/test-kubetest-store-durations.yaml
+++ b/.github/workflows/test-kubetest-store-durations.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   test-kubetest-store-durations:
     runs-on: ubuntu-20.04
+    timeout-minutes: 3600
     steps:
       - uses: actions/checkout@v2
         name: Checkout


### PR DESCRIPTION
## Description
The test is silently failing since a while with 

> The job running on runner GitHub Actions 2 has exceeded the maximum execution time of 360 minutes.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
