### PR TITLE
release: update chart to default to 1.34.0

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -15,7 +15,7 @@ version: 17.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.33.0
+appVersion: 1.34.0
 
 dependencies:
   - name: cert-manager

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.34.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.34.0"
+  default: ":release-1.34.0-unstable"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.34.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.34.0-unstable"
+  default: ":release-1.34.0"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -6,10 +6,10 @@ image:
   repository: posthog/posthog
   # -- PostHog image SHA to use (example: `sha256:20af35fca6756d689d6705911a49dd6f2f6631e001ad43377b605cfc7c133eb4`).
   sha:
-  # -- PostHog image tag to use (example: `release-1.33.0`).
+  # -- PostHog image tag to use (example: `release-1.34.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.33.0"
+  default: ":release-1.34.0"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -65,8 +65,8 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
             ignore_errors=True,
         )
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
-        # Also delete any persistent volumes created, these aren't deleted by
-        # the delete all command.
+        # Also delete any persistent volumes created, these aren't deleted by
+        # the delete all command above.
         exec_subprocess(f"kubectl delete pv --all -n {namespace}")
 
     log.debug("✅ Done!")
@@ -76,7 +76,6 @@ def cleanup_helm(namespaces=[NAMESPACE]):
     log.debug("🔄 Making sure helm releases get removed...")
     for namespace in namespaces:
         exec_subprocess(f"helm uninstall posthog --namespace {namespace} || true")
-
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -65,6 +65,9 @@ def cleanup_k8s(namespaces=["default", NAMESPACE]):
             ignore_errors=True,
         )
         exec_subprocess(f"kubectl delete all --all -n {namespace}")
+        # Also delete any persistent volumes created, these aren't deleted by
+        # the delete all command.
+        exec_subprocess(f"kubectl delete pv --all -n {namespace}")
 
     log.debug("✅ Done!")
 
@@ -73,6 +76,7 @@ def cleanup_helm(namespaces=[NAMESPACE]):
     log.debug("🔄 Making sure helm releases get removed...")
     for namespace in namespaces:
         exec_subprocess(f"helm uninstall posthog --namespace {namespace} || true")
+
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -96,6 +96,7 @@ def install_chart(values, namespace=NAMESPACE):
                 --install \
                 --set clickhouse.persistence.enabled=false \
                 --set zookeeper.persistence.enabled=false \
+                --set kafka.persistence.enabled=false \
                 -f {values_file.name} \
                 --set cloud=local \
                 --timeout 30m \

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -100,6 +100,7 @@ def install_chart(values, namespace=NAMESPACE):
                 -f {values_file.name} \
                 --set cloud=local \
                 --set clickhouse.persistence.enabled=false \
+                --set zookeeper.persistence.enabled=false \
                 --timeout 30m \
                 --create-namespace \
                 --namespace {namespace} \

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -5,7 +5,6 @@ import time
 
 import pytest
 import yaml
-from uuid import uuid4
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger()
@@ -91,16 +90,14 @@ def install_chart(values, namespace=NAMESPACE):
         values_file.write(values_yaml)
         values_file.flush()
 
-        release_name = f"posthog-{uuid4()}"
-
         exec_subprocess(
             f"""
             helm upgrade \
                 --install \
-                -f {values_file.name} \
-                --set cloud=local \
                 --set clickhouse.persistence.enabled=false \
                 --set zookeeper.persistence.enabled=false \
+                -f {values_file.name} \
+                --set cloud=local \
                 --timeout 30m \
                 --create-namespace \
                 --namespace {namespace} \

--- a/ci/kubetest/requirements.txt
+++ b/ci/kubetest/requirements.txt
@@ -14,3 +14,6 @@ git+https://github.com/macobo/pytest-split.git@group-tests-by-file
 black==21.12b0
 flake8==4.0.1
 isort==5.10.1
+
+# Pin click due to https://github.com/psf/black/issues/2964
+click==8.0.4

--- a/ci/kubetest/test_statsd_external.py
+++ b/ci/kubetest/test_statsd_external.py
@@ -9,6 +9,10 @@ cloud: local
 externalStatsd:
   host: "external-prometheus-statsd-exporter"
   port: "9125"
+
+clickhouse:
+  persistence: 
+    enabled: false
 """
 
 

--- a/ci/kubetest/test_statsd_external.py
+++ b/ci/kubetest/test_statsd_external.py
@@ -9,10 +9,6 @@ cloud: local
 externalStatsd:
   host: "external-prometheus-statsd-exporter"
   port: "9125"
-
-clickhouse:
-  persistence: 
-    enabled: false
 """
 
 


### PR DESCRIPTION
## Description

This PR:

 1. updates to 1.34.0
 2. due to failing kubetests we disable by default the clickhouse, kafka, zookeeper persistence. We tried deleteing pvc but this still resulted in test failures: https://github.com/PostHog/charts-clickhouse/pull/334
 3. fix the black linter

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
