### PR TITLE
Customize logging parameters

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -194,6 +194,8 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.settings | object | `{}` |  |
 | clickhouse.defaultSettings.format_schema_path | string | `"/etc/clickhouse-server/config.d/"` |  |
 | clickhouse.podAnnotations | string | `nil` |  |
+| clickhouse.logtostderr | bool | `"true"` | Whether allows logs to stderr |
+| clickhouse.loglevel | bool | `debug` | Log level |
 | externalClickhouse.host | string | `nil` | Host of the external cluster. This is required when clickhouse.enabled is false |
 | externalClickhouse.cluster | string | `nil` | Name of the external cluster to run DDL queries on. This is required when clickhouse.enabled is false |
 | externalClickhouse.database | string | `"posthog"` | Database name for the external cluster |

--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -123,7 +123,7 @@ data:
     ##
     ################################################
     
-    logtostderr: {{ .Values.clickhouse.logtostderr | default "true" }}
+    logtostderr: {{ .Values.clickhouse.logtostderr | default "true" | quote }}
     alsologtostderr: "false"
     v: "1"
     stderrthreshold: ""

--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -123,7 +123,7 @@ data:
     ##
     ################################################
     
-    logtostderr: "true"
+    logtostderr: {{ .Values.clickhouse.logtostderr | default "true" }}
     alsologtostderr: "false"
     v: "1"
     stderrthreshold: ""
@@ -223,7 +223,7 @@ data:
     <yandex>
         <logger>
             <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
-            <level>debug</level>
+            <level>{{ .Values.clickhouse.loglevel | default "debug" }}</level>
             <log>/var/log/clickhouse-server/clickhouse-server.log</log>
             <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
             <size>1000M</size>

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -528,10 +528,6 @@ clickhouse:
   # servers:
   # - host: posthog-posthog-zookeeper
   #   port: 2181
-  # set log level of clickhouse
-  loglevel: debug
-  # allows logs to stderr
-  logtostderr: "true"
 
   image:
     # -- ClickHouse image repository.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -528,6 +528,8 @@ clickhouse:
   # servers:
   # - host: posthog-posthog-zookeeper
   #   port: 2181
+  loglevel: info
+  logtostderr: "false"
 
   image:
     # -- ClickHouse image repository.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -528,8 +528,10 @@ clickhouse:
   # servers:
   # - host: posthog-posthog-zookeeper
   #   port: 2181
-  loglevel: info
-  logtostderr: "false"
+  # set log level of clickhouse
+  loglevel: debug
+  # allows logs to stderr
+  logtostderr: "true"
 
   image:
     # -- ClickHouse image repository.

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -70,3 +70,7 @@ do
     sed -i '' 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
 done
+
+# Add a {{ .Values.clickhouse.parameter }} for to stderror and log level settings
+sed -i '' 's/<level>debug<\/level>$/<level>{{ .Values.clickhouse.loglevel | default "debug" }}<\/level>/g' "${CHART_PATH}/templates/clickhouse-operator/configmap.yaml"
+sed -i '' 's/logtostderr: "true"$/logtostderr: {{ .Values.clickhouse.logtostderr | default "true" | quote }}/g' "${CHART_PATH}/templates/clickhouse-operator/configmap.yaml"


### PR DESCRIPTION
## Description
Deploying application in gcp creates a huge amount of noise in logging, because all logs that are written in stderr marked as "ERROR"
Moreover, debug logs creates lots of messages in the pod, so it will be nice to have possibility to decrease log level.


## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
this changes is pretty small so it was tested by running "helm template"

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
