### PR TITLE
feat(plugins-server-runner): add deployment for plugins server runner

### DIFF
--- a/charts/posthog/templates/plugins-runner-deployment.yaml
+++ b/charts/posthog/templates/plugins-runner-deployment.yaml
@@ -89,8 +89,6 @@ spec:
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: PLUGIN_SERVER_INGESTION
-          value: 'false'
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}

--- a/charts/posthog/templates/plugins-runner-deployment.yaml
+++ b/charts/posthog/templates/plugins-runner-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.plugins-server-runner.enabled -}}
+{{- if .Values.pluginsServerRunner.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,15 +11,15 @@ spec:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
         role: plugins-server-runner
-  {{- if not .Values.plugins-server-runner.hpa.enabled }}
-  replicas: {{ .Values.plugins-server-runner.replicacount }}
+  {{- if not .Values.pluginsServerRunner.hpa.enabled }}
+  replicas: {{ .Values.pluginsServerRunner.replicacount }}
   {{- end }}
   template:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      {{- if .Values.plugins-server-runner.podAnnotations }}
-{{ toYaml .Values.plugins-server-runner.podAnnotations | indent 8 }}
+      {{- if .Values.pluginsServerRunner.podAnnotations }}
+{{ toYaml .Values.pluginsServerRunner.podAnnotations | indent 8 }}
       {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
@@ -28,28 +28,28 @@ spec:
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
-        {{- if .Values.plugins-server-runner.podLabels }}
-{{ toYaml .Values.plugins-server-runner.podLabels | indent 8 }}
+        {{- if .Values.pluginsServerRunner.podLabels }}
+{{ toYaml .Values.pluginsServerRunner.podLabels | indent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
-      {{- if .Values.plugins-server-runner.affinity }}
+      {{- if .Values.pluginsServerRunner.affinity }}
       affinity:
-{{ toYaml .Values.plugins-server-runner.affinity | indent 8 }}
+{{ toYaml .Values.pluginsServerRunner.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.plugins-server-runner.nodeSelector }}
+      {{- if .Values.pluginsServerRunner.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.plugins-server-runner.nodeSelector | indent 8 }}
+{{ toYaml .Values.pluginsServerRunner.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.plugins-server-runner.tolerations }}
+      {{- if .Values.pluginsServerRunner.tolerations }}
       tolerations:
-{{ toYaml .Values.plugins-server-runner.tolerations | indent 8 }}
+{{ toYaml .Values.pluginsServerRunner.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.plugins-server-runner.schedulerName }}
-      schedulerName: "{{ .Values.plugins-server-runner.schedulerName }}"
+      {{- if .Values.pluginsServerRunner.schedulerName }}
+      schedulerName: "{{ .Values.pluginsServerRunner.schedulerName }}"
       {{- end }}
-      {{- if .Values.plugins-server-runner.priorityClassName }}
-      priorityClassName: "{{ .Values.plugins-server-runner.priorityClassName }}"
+      {{- if .Values.pluginsServerRunner.priorityClassName }}
+      priorityClassName: "{{ .Values.pluginsServerRunner.priorityClassName }}"
       {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
@@ -94,11 +94,11 @@ spec:
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}
-{{- if .Values.plugins-server-runner.env }}
-{{ toYaml .Values.plugins-server-runner.env | indent 8 }}
+{{- if .Values.pluginsServerRunner.env }}
+{{ toYaml .Values.pluginsServerRunner.env | indent 8 }}
 {{- end }}
         resources:
-{{ toYaml .Values.plugins-server-runner.resources | indent 12 }}
+{{ toYaml .Values.pluginsServerRunner.resources | indent 12 }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/plugins-runner-deployment.yaml
+++ b/charts/posthog/templates/plugins-runner-deployment.yaml
@@ -56,7 +56,7 @@ spec:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-plugins
+      - name: {{ .Chart.Name }}-plugins-server-runner
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:

--- a/charts/posthog/templates/plugins-runner-deployment.yaml
+++ b/charts/posthog/templates/plugins-runner-deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.plugins-server-runner.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-plugins-server-runner
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: plugins-server-runner
+  {{- if not .Values.plugins-server-runner.hpa.enabled }}
+  replicas: {{ .Values.plugins-server-runner.replicacount }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.plugins-server-runner.podAnnotations }}
+{{ toYaml .Values.plugins-server-runner.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: plugins-server-runner
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.plugins-server-runner.podLabels }}
+{{ toYaml .Values.plugins-server-runner.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- if .Values.plugins-server-runner.affinity }}
+      affinity:
+{{ toYaml .Values.plugins-server-runner.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.plugins-server-runner.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.plugins-server-runner.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.plugins-server-runner.tolerations }}
+      tolerations:
+{{ toYaml .Values.plugins-server-runner.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.plugins-server-runner.schedulerName }}
+      schedulerName: "{{ .Values.plugins-server-runner.schedulerName }}"
+      {{- end }}
+      {{- if .Values.plugins-server-runner.priorityClassName }}
+      priorityClassName: "{{ .Values.plugins-server-runner.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-plugins
+        image: {{ template "posthog.image.fullPath" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            ./bin/plugin-server-runner --no-restart-loop
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        env:
+        # Kafka env variables
+        {{- include "snippet.kafka-env" . | indent 8 }}
+
+        # Redis env variables
+        {{- include "snippet.redis-env" . | indent 8 }}
+
+        # statsd env variables
+        {{- include "snippet.statsd-env" . | indent 8 }}
+
+        - name: SENTRY_DSN
+          value: {{ .Values.sentryDSN | quote }}
+        - name: DEPLOYMENT
+          value: {{ template "posthog.deploymentEnv" . }}
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "posthog.fullname" . }}
+              key: posthog-secret
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        - name: CAPTURE_INTERNAL_METRICS
+          value: {{ .Values.web.internalMetrics.capture| quote }}
+        - name: PLUGIN_SERVER_INGESTION
+          value: 'false'
+        - name: HELM_INSTALL_INFO
+          value: {{ template "posthog.helmInstallInfo" . }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.plugins-server-runner.env }}
+{{ toYaml .Values.plugins-server-runner.env | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.plugins-server-runner.resources | indent 12 }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+{{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -181,10 +181,10 @@ plugins:
   affinity: {}
 
 
-plugins-server-runner:
+pluginsServerRunner:
    # -- Whether to install the PostHog plugin-server-runner stack or not.
   enabled: true
-  
+
   # -- Count of plugin-server-runner pods to run. This setting is ignored if `plugin-server-runner.hpa.enabled` is set to `true`.
   replicacount: 1
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -181,6 +181,37 @@ plugins:
   affinity: {}
 
 
+plugins-server-runner:
+   # -- Whether to install the PostHog plugin-server-runner stack or not.
+  enabled: true
+  
+  # -- Count of plugin-server-runner pods to run. This setting is ignored if `plugin-server-runner.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the plugin stack.
+    enabled: false
+    # -- CPU threshold percent for the plugin-server-runner stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the plugin-server-runner stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the plugin-server-runner stack HorizontalPodAutoscaler.
+    maxpods: 10
+
+  # -- Additional env variables to inject into the plugin-server-runner stack deployment.
+  env: []
+
+  # -- Resource limits for the plugin-server-runner stack deployment.
+  resources:
+    {}
+
+  # -- Node labels for the plugin-server-runner stack deployment.
+  nodeSelector: {}
+  # -- Toleration labels for the plugin-server-runner stack deployment.
+  tolerations: []
+  # -- Affinity settings for the plugin-server-runner stack deployment.
+  affinity: {}
+
 email:
   # -- SMTP service host.
   host:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.34.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.34.0"
+  default: ":server-mode"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This adds a new deployment that should be used exclusively for running
plugin code. The driver here is to ensure ingestion is not interrupted
by badly behaving plugins.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
