### PR TITLE
chore(ci): explicitly set reclaim policy for volumes

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -76,7 +76,8 @@ jobs:
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
         # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
-        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
+        DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+        kubectl patch storageclass "$DEFAULT_STORAGE_CLASS" -p '{"reclaimPolicy": "Delete"}'
 
     - name: Install PostHog using the Helm chart
       id: helm_install

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -75,7 +75,7 @@ jobs:
           --nodes 3
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
-        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
         kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
 
     - name: Install PostHog using the Helm chart

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation
       run: |
-        # note: we manually specify all the AZs in the region to reduce the
+        # Note: we manually specify all the AZs in the region to reduce the
         # possibility AWS runs out of capacity in a single one, making this
         # test fail.
         ./eksctl create cluster \
@@ -73,6 +73,10 @@ jobs:
           --tags="provisioned_by=github_action" \
           --version 1.21 \
           --nodes 3
+
+        # Note: we explicitly set the reclaim policy of the default StorageClass
+        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
 
     - name: Install PostHog using the Helm chart
       id: helm_install

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -49,6 +49,10 @@ jobs:
           --count 2 \
           --wait
 
+        # Note: we explicitly set the reclaim policy of the default StorageClass
+        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
+
     - name: Install PostHog using the Helm chart
       id: helm_install
       run: |

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -51,7 +51,8 @@ jobs:
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
         # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
-        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
+        DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+        kubectl patch storageclass "$DEFAULT_STORAGE_CLASS" -p '{"reclaimPolicy": "Delete"}'
 
     - name: Install PostHog using the Helm chart
       id: helm_install

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -50,7 +50,7 @@ jobs:
           --wait
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
-        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
         kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
 
     - name: Install PostHog using the Helm chart

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -45,6 +45,8 @@ jobs:
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation
       run: |
+        # Note: num-nodes will be created in each zone, such that if you specify
+        # --num-nodes=4 and choose two locations 8 nodes will be created.
         gcloud container clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --project ${{ secrets.GCP_PROJECT_ID }} \
@@ -54,8 +56,9 @@ jobs:
           --machine-type e2-small \
           --num-nodes 2
 
-        # note: num-nodes will be created in each zone, such that if you specify
-        # --num-nodes=4 and choose two locations 8 nodes will be created.
+        # Note: we explicitly set the reclaim policy of the default StorageClass
+        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
 
     - name: Create new GCP global static IP address
       id: static_ip_creation

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -58,7 +58,8 @@ jobs:
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
         # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
-        kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
+        DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+        kubectl patch storageclass "$DEFAULT_STORAGE_CLASS" -p '{"reclaimPolicy": "Delete"}'
 
     - name: Create new GCP global static IP address
       id: static_ip_creation

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -57,7 +57,7 @@ jobs:
           --num-nodes 2
 
         # Note: we explicitly set the reclaim policy of the default StorageClass
-        # to 'Delete' to make sure we don't keep EBS volumes around after cluster deletion
+        # to 'Delete' to make sure we don't keep disk volumes around after cluster deletion
         kubectl patch storageclass -p '{"reclaimPolicy": "Delete"}'
 
     - name: Create new GCP global static IP address


### PR DESCRIPTION
## Description
Explicitly set the reclaim policy of the default `StorageClass` to `Delete` to make sure we don't keep disk volumes around after cluster deletion.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
