### PR TITLE
migrate job: use the new `./bin/migrate` script

### DIFF
--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -37,6 +37,7 @@ spec:
           - /bin/sh
           - -c
           - |
+            python manage.py notify_helm_install || true
             ./bin/migrate
 
         env:

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -33,16 +33,12 @@ spec:
       containers:
       - name: migrate-job
         image: {{ template "posthog.image.fullPath" . }}
-        # switch over to using /bin/migrate once 1.34 is released - https://github.com/PostHog/posthog/pull/8872
         command:
           - /bin/sh
           - -c
           - |
-            set -e
-            python manage.py notify_helm_install || true
-            python manage.py migrate
-            python manage.py migrate_clickhouse
-            python manage.py run_async_migrations --check
+            ./bin/migrate
+
         env:
         # Kafka env variables
         {{- include "snippet.kafka-env" . | indent 8 }}


### PR DESCRIPTION
## Description

@tiina303 I think we forgot to do this as part of the release?

As we are now on 1.34, let's use the new `bin/migrate` script instead of copy pasting it's content. By doing that we remove any possibility of code drift between the repos.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
