### PR TITLE
Zookeeper: set `autopurge.purgeInterval` as default

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -496,10 +496,13 @@ externalKafka:
 zookeeper:
   # -- Install zookeeper on kubernetes
   enabled: true
-  # -- Name override for zookeeper app
+  # -- Name override for Zookeeper
   nameOverride: posthog-zookeeper
-  # -- replica count for zookeeper
+  # -- Number of ZooKeeper nodes
   replicaCount: 1
+  autopurge:
+    # -- The time interval (in hours) for which the purge task has to be triggered
+    purgeInterval: 1
 
 ###
 ###


### PR DESCRIPTION
## Description
While troubleshooting an issue with a customer we've realised the upstream `autopurge.purgeInterval` default is set to 0 (disabled). This can create issues with the underlying storage if a lot of transaction/logs gets created.

Auto purge determines how many recent snapshots of the database stored in `dataDir` to retain within the time interval specified by `autopurge.purgeInterval` (while deleting the rest).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
