### PR TITLE
temp(release): bump docker image tag to release-1.35.0-unstable

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.34.2`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.34.2"
+  default: ":release-1.35.0-unstable"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
NOTE: this is for break the release, and should not be merged as is, but rather update to use the stable docker image tag