### PR TITLE
CI/helm-docs: update to 1.8.1 and remove binary from checkout

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -14,8 +14,9 @@ jobs:
 
       - name: Run helm-docs
         run: |
-          GOBIN=$PWD GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs@v1.7.0
+          GOBIN=$PWD go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1
           ./helm-docs --sort-values-order file -t ALL_VALUES.md.gotmpl -o ALL_VALUES.md
+          rm ./helm-docs
 
       - name: Commit bump
         uses: EndBug/add-and-commit@v7


### PR DESCRIPTION
## Description
With https://github.com/PostHog/charts-clickhouse/commit/8a99189084a1abc290d8e3b375b83a8586f2f404 our GH action added to the checkout the `helm-docs` binary. Let's modify the CI action to don't do that. I've also took the opportunity to upgrade the binary to the latest stable (see changelog [here](https://github.com/norwoodj/helm-docs/releases)).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
