### PR TITLE
Make email for ACME optional in values

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | service.annotations | object | `{}` | PostHog service annotations. |
 | cert-manager.enabled | bool | `false` | Whether to install `cert-manager` resources. |
 | cert-manager.installCRDs | bool | `true` | Whether to install `cert-manager` CRDs. |
+| cert-manager.email | string | `james.g@posthog.com` | Email address to get notified about ACME certs |
 | cert-manager.podDnsPolicy | string | `"None"` |  |
 | cert-manager.podDnsConfig.nameservers[0] | string | `"8.8.8.8"` |  |
 | cert-manager.podDnsConfig.nameservers[1] | string | `"1.1.1.1"` |  |

--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -10,6 +10,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| notificationEmail | string | `nil` | Email of who is managing the stack - to receive notifications about the stack |
 | cloud | string | `nil` | Cloud service being deployed on (example: `aws`, `azure`, `do`, `gcp`, `other`). |
 | image.repository | string | `"posthog/posthog"` | PostHog image repository to use. |
 | image.sha | string | `nil` | PostHog image SHA to use (example: `sha256:20af35fca6756d689d6705911a49dd6f2f6631e001ad43377b605cfc7c133eb4`). |
@@ -99,7 +100,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | service.annotations | object | `{}` | PostHog service annotations. |
 | cert-manager.enabled | bool | `false` | Whether to install `cert-manager` resources. |
 | cert-manager.installCRDs | bool | `true` | Whether to install `cert-manager` CRDs. |
-| cert-manager.email | string | `james.g@posthog.com` | Email address to get notified about ACME certs |
+| cert-manager.email | string | `nil` | Email address to get notified about ACME certs. Defaults to global email for notifications on chart. |
 | cert-manager.podDnsPolicy | string | `"None"` |  |
 | cert-manager.podDnsConfig.nameservers[0] | string | `"8.8.8.8"` |  |
 | cert-manager.podDnsConfig.nameservers[1] | string | `"1.1.1.1"` |  |

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: james.g@posthog.com
+    email: {{ .Values.cert-manager.email }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ index .Values "cert-manager.email" }}
+    email: {{ coalesce .Values.notificationEmail (index .Values "cert-manager.email") "none" }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ .Values.cert-manager.email }}
+    email: {{ .Values.certManager.email }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ coalesce .Values.notificationEmail (index .Values "cert-manager.email") "none" }}
+    email: {{ coalesce (index .Values "cert-manager.email") .Values.notificationEmail "none" }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ .Values.certManager.email }}
+    email: {{ index .Values "cert-manager.email" }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -274,9 +274,9 @@ cert-manager:
   # -- Whether to install `cert-manager` CRDs.
   installCRDs: true
   # -- Who to email if the certificate is about to expire
-  # -- Defaults to James.g@posthog.com but feel free (please)
+  # -- Defaults to `Null` but feel free (please)
   # -- to replace this with whoever is managing the stack
-  email: james.g@posthog.com 
+  email: None 
 
   #
   # [Workaround] - do not use the local DNS for the 'cert-manager' pods since it would return local IPs

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -274,9 +274,8 @@ cert-manager:
   # -- Whether to install `cert-manager` CRDs.
   installCRDs: true
   # -- Who to email if the certificate is about to expire
-  # -- Defaults to `Null` but feel free (please)
-  # -- to replace this with whoever is managing the stack
-  email: None 
+  # -- Defaults to `notificationEmail` if it is available 
+  email: null 
 
   #
   # [Workaround] - do not use the local DNS for the 'cert-manager' pods since it would return local IPs

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -274,8 +274,8 @@ cert-manager:
   # -- Whether to install `cert-manager` CRDs.
   installCRDs: true
   # -- Who to email if the certificate is about to expire
-  # -- Defaults to James.g@posthog.com but feel free (please) replace this 
-  # -- with whoever is managing the stack
+  # -- Defaults to James.g@posthog.com but feel free (please)
+  # -- to replace this with whoever is managing the stack
   email: james.g@posthog.com 
 
   #

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -273,6 +273,10 @@ cert-manager:
   enabled: false
   # -- Whether to install `cert-manager` CRDs.
   installCRDs: true
+  # -- Who to email if the certificate is about to expire
+  # -- Defaults to James.g@posthog.com but feel free (please) replace this 
+  # -- with whoever is managing the stack
+  email: james.g@posthog.com 
 
   #
   # [Workaround] - do not use the local DNS for the 'cert-manager' pods since it would return local IPs


### PR DESCRIPTION
## Description
Make using `james.g@posthog.com` optional as the ACME email address associated with cert manager

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Locally on home cluster box

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
