### PR TITLE
CI - fix Redis image to 6.2.7-alpine

### DIFF
--- a/ci/kubetest/custom_k8s_resources/redis_external.yaml
+++ b/ci/kubetest/custom_k8s_resources/redis_external.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis:alpine
+        image: redis:6.2.7-alpine
         resources:
           requests:
             cpu: 100m

--- a/ci/kubetest/custom_k8s_resources/redis_external_with_existing_secret.yaml
+++ b/ci/kubetest/custom_k8s_resources/redis_external_with_existing_secret.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis:alpine
+        image: redis:6.2.7-alpine
         args: ["--requirepass", "$(REDIS_PASS)"]
         resources:
           requests:

--- a/ci/kubetest/custom_k8s_resources/redis_external_with_password.yaml
+++ b/ci/kubetest/custom_k8s_resources/redis_external_with_password.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis:alpine
+        image: redis:6.2.7-alpine
         args: ["--requirepass", "staff-broken-apple-misplace-lamp"]
         resources:
           requests:


### PR DESCRIPTION
## Description
CI was using `redis:alpine` as default image and since the release of Redis 7 ([released 6 days ago](https://github.com/redis/redis/releases/tag/7.0.0)) it was making our tests failing as we currently enforce the Redis version range in PostHog to be >=5.0.0,<=6.3.0

https://github.com/PostHog/posthog/blob/a1b2a7544dc16dfeceac4a19d63d426b670628f5/posthog/settings/service_requirements.py#L14

Error message:
> Service redis is in version 7.0.0. Expected range: >=5.0.0,<=6.3.0. PostHog may not work correctly with the current version. To continue anyway, add SKIP_SERVICE_VERSION_REQUIREMENTS=1 as an environment variable

Related to https://github.com/PostHog/posthog/issues/9564 and https://github.com/PostHog/posthog/issues/9576

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
