### PR TITLE
CI - remove hardcoded image

### DIFF
--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -4,15 +4,8 @@ import yaml
 from helpers.clickhouse import get_clickhouse_table_counts_on_all_nodes
 from helpers.utils import cleanup_helm, cleanup_k8s, install_chart, is_posthog_healthy, wait_for_pods_to_be_ready
 
-# :KLUDGE: There's unrelated code here that can be removed long-term once:
-#   - https://github.com/PostHog/posthog/pull/8730 is merged (custom image)
-#   - We've removed the need for CLICKHOUSE_REPLICATION under https://github.com/PostHog/posthog/issues/8652
 VALUES_WITH_SHARDING = """
 cloud: "local"
-
-image:
-  repository: macobo/posthog-test
-  sha: sha256:0148396b08058b33918ed1f38f095d7e2970774cdeb93fbb6d6fe9db781eec67
 
 env:
 - name: CLICKHOUSE_REPLICATION


### PR DESCRIPTION
## Description
Remove hardcoded image we were using in `ci/kubetest/test_clickhouse_sharding.py`. I don't think that's the source of some flakiness we are seeing in this test but this is definitely something we should clean up.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
