### PR TITLE
feat: Add redis memory policy

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -449,7 +449,7 @@ redis:
       ## The maxmemory configuration directive is used in order to configure Redis to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
       ## see https://redis.io/topics/lru-cache for more details
-      - "--maxmemory 4500mb"
+      - "--maxmemory 200mb"
       ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
       ## maxmemory-policy configuration directive
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -445,6 +445,7 @@ redis:
 
       # -- Persistent Volume size.
       size: 5Gi
+    # -- Array with additional command line flags for Redis master.
     extraFlags:
       ## The maxmemory configuration directive is used in order to configure Redis to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -450,7 +450,7 @@ redis:
       ## The maxmemory configuration directive is used in order to configure Redis to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
       ## see https://redis.io/topics/lru-cache for more details
-      - "--maxmemory 200mb"
+      - "--maxmemory 400mb"
       ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
       ## maxmemory-policy configuration directive
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -439,6 +439,10 @@ redis:
     existingSecretPasswordKey: ""
   
   commonConfiguration: |-
+      # Enable AOF https://redis.io/topics/persistence#append-only-file
+      appendonly yes
+      # Disable RDB persistence, AOF persistence already enabled.
+      save ""
       ## The maxmemory configuration directive is used in order to configure Redis to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
       ## see https://redis.io/topics/lru-cache for more details

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -445,6 +445,16 @@ redis:
 
       # -- Persistent Volume size.
       size: 5Gi
+    extraFlags:
+      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
+      ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
+      ## see https://redis.io/topics/lru-cache for more details
+      - "--maxmemory 4500mb"
+      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
+      ## maxmemory-policy configuration directive
+      ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
+      ## to make space for the new data added
+      - "--maxmemory-policy allkeys-lru"
 
 externalRedis:
   # -- External Redis host to use.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -437,6 +437,17 @@ redis:
     #    NOTE: ignored unless `redis.auth.existingSecret` parameter is set.
     #
     existingSecretPasswordKey: ""
+  
+  commonConfiguration: |-
+      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
+      ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
+      ## see https://redis.io/topics/lru-cache for more details
+      maxmemory 4500mb
+      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
+      ## maxmemory-policy configuration directive
+      ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
+      ## to make space for the new data added
+      maxmemory-policy allkeys-lru
 
   master:
     persistence:
@@ -445,16 +456,6 @@ redis:
 
       # -- Persistent Volume size.
       size: 5Gi
-    extraFlags:
-      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
-      ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
-      ## see https://redis.io/topics/lru-cache for more details
-      - "--maxmemory 4500mb"
-      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
-      ## maxmemory-policy configuration directive
-      ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
-      ## to make space for the new data added
-      - "--maxmemory-policy allkeys-lru"
 
 externalRedis:
   # -- External Redis host to use.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -437,21 +437,6 @@ redis:
     #    NOTE: ignored unless `redis.auth.existingSecret` parameter is set.
     #
     existingSecretPasswordKey: ""
-  
-  commonConfiguration: |-
-      # Enable AOF https://redis.io/topics/persistence#append-only-file
-      appendonly yes
-      # Disable RDB persistence, AOF persistence already enabled.
-      save ""
-      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
-      ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
-      ## see https://redis.io/topics/lru-cache for more details
-      maxmemory 4500mb
-      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
-      ## maxmemory-policy configuration directive
-      ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
-      ## to make space for the new data added
-      maxmemory-policy allkeys-lru
 
   master:
     persistence:
@@ -460,6 +445,16 @@ redis:
 
       # -- Persistent Volume size.
       size: 5Gi
+    extraFlags:
+      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
+      ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
+      ## see https://redis.io/topics/lru-cache for more details
+      - "--maxmemory 4500mb"
+      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
+      ## maxmemory-policy configuration directive
+      ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
+      ## to make space for the new data added
+      - "--maxmemory-policy allkeys-lru"
 
 externalRedis:
   # -- External Redis host to use.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Similar to https://github.com/PostHog/posthog/pull/9573 
Except on the chart we want to set it to close to the default disk size, but with buffer because ([here](https://redis.io/docs/manual/eviction/#how-the-eviction-process-works))
> we continuously cross the boundaries of the memory limit, by going over it, and then by evicting keys to return back under the limits.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Installed locally with 1-click default values file & local charts repo, jumped into the redis pod to check mem config "(note that before it was 0 and noevict)
```
$ redis-cli
> info memory
...
maxmemory:4718592000
maxmemory_human:4.39G
maxmemory_policy:allkeys-lru
...
```
It's possible to override in values (updated having set extraFlags to have 200mb) & verified that I saw the corresponding maxmemory value.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
