### PR TITLE
fix - fix for none being invalid email for letsencrypt

### DIFF
--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ coalesce (index .Values "cert-manager.email") .Values.notificationEmail "none" }}
+    email: {{ coalesce (index .Values "cert-manager.email") .Values.notificationEmail (printf "noreply@%s" .Values.ingress.hostname) }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1,6 +1,9 @@
 # -- Cloud service being deployed on (example: `aws`, `azure`, `do`, `gcp`, `other`).
 cloud:
 
+# -- Notification email for notifications to be sent to from the PostHog stack
+notificationEmail:
+
 image:
   # -- PostHog image repository to use.
   repository: posthog/posthog
@@ -275,6 +278,7 @@ cert-manager:
   installCRDs: true
   # -- Who to email if the certificate is about to expire
   # -- Defaults to `notificationEmail` if it is available
+  # -- Base default is noreply@<your-ingress-hostname>
   email: null
 
   #


### PR DESCRIPTION
## Description
This is in response to a bug introduced in removing `james.g@posthog.com` from cert-manager letsencrypt configs.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Locally

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
