### PR TITLE
Remove `/bin/sh -c` from deployment commands

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -56,10 +56,7 @@ spec:
       - name: {{ .Chart.Name }}-events
         image: {{ template "posthog.image.fullPath" . }}
         command:
-          - /bin/sh
-          - -c
-          - |
-            ./bin/docker-server
+          - ./bin/docker-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -60,10 +60,8 @@ spec:
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - /bin/sh
-          - -c
-          - |
-            ./bin/plugin-server --no-restart-loop
+          - ./bin/plugin-server
+          - --no-restart-loop
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         env:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -56,10 +56,7 @@ spec:
       - name: {{ .Chart.Name }}-web
         image: {{ template "posthog.image.fullPath" . }}
         command:
-          - /bin/sh
-          - -c
-          - |
-            ./bin/docker-server
+          - ./bin/docker-server
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -60,10 +60,8 @@ spec:
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - /bin/sh
-          - -c
-          - |
-            ./bin/docker-worker-celery --with-scheduler
+          - ./bin/docker-worker-celery
+          - --with-scheduler
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         env:


### PR DESCRIPTION
## Description
Many deployments in the chart started containers using `/bin/sh -c` despite only running a single command and not a multi-line script. This PR switches those deployments to run the commands directly, which is both simpler and eliminates the issue of propagating SIGTERM signals to the applications (as discovered in https://github.com/PostHog/posthog/issues/9440).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
I deployed PostHog to my cluster with these changes and verified that all the deployments started normally and successfully.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
