### PR TITLE
fix - index function does not pull nested keys separated by .

### DIFF
--- a/charts/posthog/templates/cert-issuer.yaml
+++ b/charts/posthog/templates/cert-issuer.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   acme:
     # Email address used for ACME registration
-    email: {{ coalesce (index .Values "cert-manager.email") .Values.notificationEmail (printf "noreply@%s" .Values.ingress.hostname) }}
+    email: {{ coalesce (index (index .Values "cert-manager") "email") .Values.notificationEmail (printf "noreply@%s" .Values.ingress.hostname) }}
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Name of a secret used to store the ACME account private key

--- a/charts/posthog/tests/cert-issuer.yaml
+++ b/charts/posthog/tests/cert-issuer.yaml
@@ -94,3 +94,52 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should have default email address for let's encrypt
+    set:
+      ingress.hostname: posthog.cc
+      ingress.letsencrypt: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.acme.email
+          value: "noreply@posthog.cc"
+
+  - it: should have given email address for let's encrypt
+    set:
+      ingress.hostname: posthog.cc
+      cert-manager.email: james.g@posthog.com
+      ingress.letsencrypt: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.acme.email
+          value: "james.g@posthog.com"
+
+  - it: should have given notification email address for let's encrypt
+    set:
+      notificationEmail: jams@posthog.com 
+      ingress.hostname: posthog.cc
+      ingress.letsencrypt: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.acme.email
+          value: "jams@posthog.com"
+
+  - it: should have given ingress email address for let's encrypt
+    set:
+      notificationEmail: jams@posthog.com 
+      ingress.hostname: posthog.cc
+      cert-manager.email: james.g@posthog.com
+      ingress.letsencrypt: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.acme.email
+          value: "james.g@posthog.com"
+  


### PR DESCRIPTION
## Description
Coalesce was skipping the value because it was unable to pull a nested key separated by `.`. Nesting the index calls works.

Now it looks very lispy

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Manually on new cluster

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
