### PR TITLE
fix(clickhouse-operator): pin docker image version

### DIFF
--- a/charts/posthog/templates/clickhouse-operator/deployment.yaml
+++ b/charts/posthog/templates/clickhouse-operator/deployment.yaml
@@ -3,7 +3,7 @@
 #
 # NAMESPACE=posthog
 # COMMENT=
-# OPERATOR_IMAGE=altinity/clickhouse-operator:latest
+# OPERATOR_IMAGE=altinity/clickhouse-operator:0.19.0
 # METRICS_EXPORTER_IMAGE=altinity/metrics-exporter:latest
 #
 # Setup Deployment for clickhouse-operator
@@ -47,7 +47,7 @@ spec:
             name: etc-clickhouse-operator-usersd-files
       containers:
         - name: clickhouse-operator
-          image: altinity/clickhouse-operator:latest
+          image: altinity/clickhouse-operator:0.19.0
           imagePullPolicy: Always
           volumeMounts:
             - name: etc-clickhouse-operator-folder

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -28,7 +28,7 @@ URL="https://raw.githubusercontent.com/Altinity/clickhouse-operator/${CLICKHOUSE
 #
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-test-clickhouse-operator}"
 METRICS_EXPORTER_NAMESPACE="${OPERATOR_NAMESPACE}"
-OPERATOR_IMAGE="${OPERATOR_IMAGE:-altinity/clickhouse-operator:latest}"
+OPERATOR_IMAGE="${OPERATOR_IMAGE:-altinity/clickhouse-operator:0.19.0}"
 METRICS_EXPORTER_IMAGE="${METRICS_EXPORTER_IMAGE:-altinity/metrics-exporter:latest}"
 
 curl -s "${URL}" | \
@@ -57,16 +57,16 @@ kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/templa
 FILES="${CHART_PATH}/templates/clickhouse-operator/*"
 for f in $FILES
 do
-    sed -i '' '1i\
+    sed -i'' '1i\
 {{- if .Values.clickhouse.enabled }}
     ' "$f"
 
-    sed -i '' '$a\
+    sed -i'' '$a\
 {{- end }}
     ' "$f"
 
-    sed -i '' 's/#namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
+    sed -i'' 's/#namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
-    sed -i '' 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
+    sed -i'' 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
 done


### PR DESCRIPTION
Previously we were using the latest available image. Here we pin to the
latest image.

It looks like they version the chart and the operator image the same. It
may be worth pinning them to the same version. However, this will cause
the operator to downgrade in existing installs, so here I'm opting to
try to keep the image version the same as current installs.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
