### PR TITLE
test(clickhouse): wait on desired state, not intermediary

### DIFF
--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 import yaml
 
 from helpers.clickhouse import get_clickhouse_table_counts_on_all_nodes

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 import yaml
 
 from helpers.clickhouse import get_clickhouse_table_counts_on_all_nodes

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -52,7 +52,8 @@ def test_upgrading_to_more_shards(kube):
     install_chart(new_values)
 
     # Wait for new replicas to come up and for tables to be created
-    for attempt in range(24):
+    start = time.time()
+    while time.time() - start < 120:
         number_of_hosts, table_counts = get_clickhouse_table_counts_on_all_nodes(kube)
         if number_of_hosts == 6 and len(set(table_counts)) == 1:
             break


### PR DESCRIPTION
Previously we were using kubernetes details to decide if ClickHouse had
scaled up correctly. This appeared to fail quite regularly though, so
instead I am using one ClickHouse properties to decide if we converge on
the desired state.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
