### PR TITLE
clickhouse-operator: upgrade from 0.16.1 to 0.18.4

### DIFF
--- a/charts/posthog/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/posthog/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -9,6 +9,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -27,7 +29,7 @@ spec:
           type: string
           description: Operator version
           priority: 1 # show in wide view
-          jsonPath: .status.version
+          jsonPath: .status.chop-version
         - name: clusters
           type: integer
           description: Clusters count
@@ -78,6 +80,11 @@ spec:
           description: Client access endpoint
           priority: 1 # show in wide view
           jsonPath: .status.endpoint
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
       schema:
@@ -103,9 +110,15 @@ spec:
               type: object
               description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               properties:
-                version:
+                chop-version:
                   type: string
-                  description: "Version"
+                  description: "ClickHouse operator version"
+                chop-commit:
+                  type: string
+                  description: "ClickHouse operator git commit SHA"
+                chop-date:
+                  type: string
+                  description: "ClickHouse operator build date"
                 clusters:
                   type: integer
                   minimum: 0
@@ -236,7 +249,7 @@ spec:
                     - "enabled"
                 restart:
                   type: string
-                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
+                  description: "This is a 'soft restart' button. When set to 'RollingUpdate' operator will restart ClickHouse pods in a graceful way. Remove it after the use in order to avoid unneeded restarts"
                   enum:
                     - ""
                     - "RollingUpdate"
@@ -290,6 +303,7 @@ spec:
                   properties:
                     policy:
                       type: string
+                      description: DEPRECATED
                     configMapPropagationTimeout:
                       type: integer
                       description: |

--- a/charts/posthog/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/posthog/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -9,6 +9,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -27,7 +29,7 @@ spec:
           type: string
           description: Operator version
           priority: 1 # show in wide view
-          jsonPath: .status.version
+          jsonPath: .status.chop-version
         - name: clusters
           type: integer
           description: Clusters count
@@ -78,6 +80,11 @@ spec:
           description: Client access endpoint
           priority: 1 # show in wide view
           jsonPath: .status.endpoint
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
       schema:
@@ -103,9 +110,15 @@ spec:
               type: object
               description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               properties:
-                version:
+                chop-version:
                   type: string
-                  description: "Version"
+                  description: "ClickHouse operator version"
+                chop-commit:
+                  type: string
+                  description: "ClickHouse operator git commit SHA"
+                chop-date:
+                  type: string
+                  description: "ClickHouse operator build date"
                 clusters:
                   type: integer
                   minimum: 0
@@ -236,7 +249,7 @@ spec:
                     - "enabled"
                 restart:
                   type: string
-                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
+                  description: "This is a 'soft restart' button. When set to 'RollingUpdate' operator will restart ClickHouse pods in a graceful way. Remove it after the use in order to avoid unneeded restarts"
                   enum:
                     - ""
                     - "RollingUpdate"
@@ -290,6 +303,7 @@ spec:
                   properties:
                     policy:
                       type: string
+                      description: DEPRECATED
                     configMapPropagationTimeout:
                       type: integer
                       description: |

--- a/charts/posthog/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/charts/posthog/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -6,6 +6,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -25,6 +27,11 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
+        - name: age
+          type: date
+          description: Age of the resource
+          # Displayed in all priorities
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object
@@ -37,151 +44,250 @@ spec:
             spec:
               type: object
               description: |
-                allows define some of settings for `clickhouse-operator` itself,
+                Allows to define settings of the clickhouse-operator.
                 More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
-                look to etc-clickhouse-operator* ConfigMaps if you need more control
+                Check into etc-clickhouse-operator* ConfigMaps if you need more control
               x-kubernetes-preserve-unknown-fields: true
               properties:
-                watchNamespaces:
-                  type: array
-                  description: "List of namespaces where clickhouse-operator watches for events."
-                  items:
-                    type: string
-                chCommonConfigsPath:
-                  type: string
-                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
-                chHostConfigsPath:
-                  type: string
-                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
-                chUsersConfigsPath:
-                  type: string
-                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
-                chiTemplatesPath:
-                  type: string
-                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
-                statefulSetUpdateTimeout:
-                  type: integer
-                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
-                statefulSetUpdatePollPeriod:
-                  type: integer
-                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
-                onStatefulSetCreateFailureAction:
-                  type: string
-                  description: |
-                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-                    Possible options:
-                    1. abort - do nothing, just break the process and wait for admin.
-                    2. delete - delete newly created problematic StatefulSet.
-                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
-                onStatefulSetUpdateFailureAction:
-                  type: string
-                  description: |
-                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-                    Possible options:
-                    1. abort - do nothing, just break the process and wait for admin.
-                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
-                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
-                chConfigUserDefaultProfile:
-                  type: string
-                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
-                chConfigUserDefaultQuota:
-                  type: string
-                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
-                chConfigUserDefaultNetworksIP:
-                  type: array
-                  description: "ClickHouse server configuration `<networks><ip>...</ip></networks>` for any <user>"
-                  items:
-                    type: string
-                chConfigUserDefaultPassword:
-                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
-                  type: string
-                chConfigNetworksHostRegexpTemplate:
-                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
-                  type: string
-                chUsername:
-                  type: string
-                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
-                chPassword:
-                  type: string
-                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
-                chCredentialsSecretNamespace:
-                  type: string
-                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
-                chCredentialsSecretName:
-                  type: string
-                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
-                chPort:
-                  type: integer
-                  minimum: 1
-                  maximum: 65535
-                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
-                logtostderr:
-                  type: string
-                  description: "boolean, allows logs to stderr"
-                alsologtostderr:
-                  type: string
-                  description: "boolean allows logs to stderr and files both"
-                v:
-                  type: string
-                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
-                stderrthreshold:
-                  type: string
-                vmodule:
-                  type: string
-                log_backtrace_at:
-                  type: string
-                reconcileThreadsNumber:
-                  type: integer
-                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
-                  minimum: 1
-                  maximum: 65535
-                reconcileWaitExclude:
-                  type: string
-                reconcileWaitInclude:
-                  type: string
-                excludeFromPropagationLabels:
-                  type: array
-                  description: |
-                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
-                    exclude labels from the following list
-                  items:
-                    type: string
-                appendScopeLabels:
-                  type: string
-                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                    - "LabelShardScopeIndex"
-                    - "LabelReplicaScopeIndex"
-                    - "LabelCHIScopeIndex"
-                    - "LabelCHIScopeCycleSize"
-                    - "LabelCHIScopeCycleIndex"
-                    - "LabelCHIScopeCycleOffset"
-                    - "LabelClusterScopeIndex"
-                    - "LabelClusterScopeCycleSize"
-                    - "LabelClusterScopeCycleIndex"
-                    - "LabelClusterScopeCycleOffset"
+                watch:
+                  type: object
+                  properties:
+                    namespaces:
+                      type: array
+                      description: "List of namespaces where clickhouse-operator watches for events."
+                      items:
+                        type: string
+                clickhouse:
+                  type: object
+                  properties:
+                    configuration:
+                      type: object
+                      properties:
+                        file:
+                          type: object
+                          properties:
+                            path:
+                              type: object
+                              properties:
+                                common:
+                                  type: string
+                                  description: "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located. Default - config.d"
+                                host:
+                                  type: string
+                                  description: "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located. Default - conf.d"
+                                user:
+                                  type: string
+                                  description: "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI."
+                        user:
+                          type: object
+                          properties:
+                            default:
+                              type: object
+                              properties:
+                                profile:
+                                  type: string
+                                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
+                                quota:
+                                  type: string
+                                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
+                                networksIP:
+                                  type: array
+                                  description: "ClickHouse server configuration `<networks><ip>...</ip></networks>` for any <user>"
+                                  items:
+                                    type: string
+                                password:
+                                  type: string
+                                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
+                        network:
+                          type: object
+                          properties:
+                            hostRegexpTemplate:
+                              type: string
+                              description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
+                    access:
+                      type: object
+                      properties:
+                        scheme:
+                          type: string
+                          description: "The scheme to user for connecting to ClickHouse. One of http or https"
+                        username:
+                          type: string
+                          description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
+                        password:
+                          type: string
+                          description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
+                        secret:
+                          type: object
+                          properties:
+                            namespace:
+                              type: string
+                              description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
+                            name:
+                              type: string
+                              description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
+                        port:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "port to be used by operator to connect to ClickHouse instances"
+                template:
+                  type: object
+                  properties:
+                    chi:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                          description: "Path to folder where ClickHouseInstallationTemplate .yaml manifests are located."
+                reconcile:
+                  type: object
+                  properties:
+                    runtime:
+                      type: object
+                      properties:
+                        threadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile in parallel, 10 by default"
+                    statefulSet:
+                      type: object
+                      properties:
+                        create:
+                          type: object
+                          properties:
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                                Possible options:
+                                1. abort - do nothing, just break the process and wait for admin.
+                                2. delete - delete newly created problematic StatefulSet.
+                                3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
+                        update:
+                          type: object
+                          properties:
+                            timeout:
+                              type: integer
+                              description: "How many seconds to wait for created/updated StatefulSet to be Ready"
+                            pollInterval:
+                              type: integer
+                              description: "How many seconds to wait between checks for created/updated StatefulSet status"
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                                Possible options:
+                                1. abort - do nothing, just break the process and wait for admin.
+                                2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                                3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
+                    host:
+                      type: object
+                      properties:
+                        wait:
+                          type: object
+                          properties:
+                            exclude:
+                              type: boolean
+                            include:
+                              type: boolean
+                annotation:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+                label:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+                      description: |
+                        When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                        exclude labels from the following list
+                    appendScope:
+                      type: string
+                      description: |
+                        Whether to append *Scope* labels to StatefulSet and Pod
+                        - "LabelShardScopeIndex"
+                        - "LabelReplicaScopeIndex"
+                        - "LabelCHIScopeIndex"
+                        - "LabelCHIScopeCycleSize"
+                        - "LabelCHIScopeCycleIndex"
+                        - "LabelCHIScopeCycleOffset"
+                        - "LabelClusterScopeIndex"
+                        - "LabelClusterScopeCycleSize"
+                        - "LabelClusterScopeCycleIndex"
+                        - "LabelClusterScopeCycleOffset"
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                statefulSet:
+                  type: object
+                  properties:
+                    revisionHistoryLimit:
+                      type: integer
+                pod:
+                  type: object
+                  properties:
+                    terminationGracePeriod:
+                      type: integer
+                logger:
+                  type: object
+                  properties:
+                    logtostderr:
+                      type: string
+                      description: "boolean, allows logs to stderr"
+                    alsologtostderr:
+                      type: string
+                      description: "boolean allows logs to stderr and files both"
+                    v:
+                      type: string
+                      description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
+                    stderrthreshold:
+                      type: string
+                    vmodule:
+                      type: string
+                      description: |
+                        Comma-separated list of filename=N, where filename (can be a pattern) must have no .go ext, and N is a V level.
+                        Ex.: file*=2 sets the 'V' to 2 in all files with names like file*.
+                    log_backtrace_at:
+                      type: string
+                      description: |
+                        It can be set to a file and line number with a logging line.
+                        Ex.: file.go:123
+                        Each time when this line is being executed, a stack trace will be written to the Info log.
 

--- a/charts/posthog/templates/clickhouse-operator/clusterrole.yaml
+++ b/charts/posthog/templates/clickhouse-operator/clusterrole.yaml
@@ -13,6 +13,8 @@ kind: ClusterRole
 metadata:
   name: clickhouse-operator-posthog
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 rules:
 - apiGroups:
     - ""
@@ -20,13 +22,13 @@ rules:
     - configmaps
     - services
   verbs:
-    - create
-    - delete
     - get
+    - list
     - patch
     - update
-    - list
     - watch
+    - create
+    - delete
 - apiGroups:
     - ""
   resources:
@@ -46,12 +48,12 @@ rules:
   resources:
     - persistentvolumeclaims
   verbs:
-    - delete
     - get
     - list
     - patch
     - update
     - watch
+    - delete
 - apiGroups:
     - ""
   resources:
@@ -68,22 +70,22 @@ rules:
   resources:
     - statefulsets
   verbs:
-    - create
-    - delete
     - get
+    - list
     - patch
     - update
-    - list
     - watch
+    - create
+    - delete
 - apiGroups:
     - apps
   resources:
     - replicasets
   verbs:
-    - delete
     - get
     - patch
     - update
+    - delete
 - apiGroups:
     - apps
   resourceNames:
@@ -100,22 +102,22 @@ rules:
   resources:
     - poddisruptionbudgets
   verbs:
-    - create
-    - delete
     - get
+    - list
     - patch
     - update
-    - list
     - watch
+    - create
+    - delete
 - apiGroups:
     - clickhouse.altinity.com
   resources:
     - clickhouseinstallations
   verbs:
-    - delete
     - get
     - patch
     - update
+    - delete
 - apiGroups:
     - clickhouse.altinity.com
   resources:
@@ -141,15 +143,22 @@ rules:
     - clickhouseinstallationtemplates/status
     - clickhouseoperatorconfigurations/status
   verbs:
-    - create
-    - delete
     - get
     - update
     - patch
+    - create
+    - delete
 - apiGroups:
     - ""
   resources:
     - secrets
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
   verbs:
     - get
     - list

--- a/charts/posthog/templates/clickhouse-operator/clusterrolebinding.yaml
+++ b/charts/posthog/templates/clickhouse-operator/clusterrolebinding.yaml
@@ -6,6 +6,8 @@ kind: ClusterRoleBinding
 metadata:
   name: clickhouse-operator-posthog
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -11,172 +11,223 @@ metadata:
   name: etc-clickhouse-operator-files
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 data:
   config.yaml: |
-    ################################################
-    ##
-    ## Watch Namespaces Section
-    ##
-    ################################################
-    
-    # List of namespaces where clickhouse-operator watches for events.
-    # Concurrently running operators should watch on different namespaces
-    #watchNamespaces: ["dev", "test"]
-    watchNamespaces: []
-    
-    ################################################
-    ##
-    ## Additional Configuration Files Section
-    ##
-    ################################################
-    
-    # Path to folder where ClickHouse configuration files common for all instances within CHI are located.
-    chCommonConfigsPath: config.d
-    
-    # Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located.
-    chHostConfigsPath: conf.d
-    
-    # Path to folder where ClickHouse configuration files with users settings are located.
-    # Files are common for all instances within CHI
-    chUsersConfigsPath: users.d
-    
-    # Path to folder where ClickHouseInstallation .yaml manifests are located.
-    # Manifests are applied in sorted alpha-numeric order
-    chiTemplatesPath: templates.d
+    # IMPORTANT
+    # This file is auto-generated from deploy/builder/templates-config.
+    # It will be overwritten upon next sources build.
+    #
+    # Template parameters available:
+    #   watchNamespaces
+    #   chUsername
+    #   chPassword
+    #   password_sha256_hex
     
     ################################################
     ##
-    ## Cluster Create/Update/Delete Objects Section
+    ## Watch Section
     ##
     ################################################
+    watch:
+      # List of namespaces where clickhouse-operator watches for events.
+      # Concurrently running operators should watch on different namespaces
+      #namespaces: ["dev", "test"]
+      namespaces: []
     
-    # How many seconds to wait for created/updated StatefulSet to be Ready
-    statefulSetUpdateTimeout: 300
-    
-    # How many seconds to wait between checks for created/updated StatefulSet status
-    statefulSetUpdatePollPeriod: 5
-    
-    # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-    # Possible options:
-    # 1. abort - do nothing, just break the process and wait for admin
-    # 2. delete - delete newly created problematic StatefulSet
-    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
-    onStatefulSetCreateFailureAction: ignore
-    
-    # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-    # Possible options:
-    # 1. abort - do nothing, just break the process and wait for admin
-    # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
-    # Pod would be recreated by StatefulSet based on rollback-ed configuration
-    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
-    onStatefulSetUpdateFailureAction: rollback
+    clickhouse:
+      configuration:
+        ################################################
+        ##
+        ## Configuration Files Section
+        ##
+        ################################################
+        file:
+          path:
+            # Path to the folder where ClickHouse configuration files common for all instances within a CHI are located.
+            common: config.d
+            # Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.
+            host: conf.d
+            # Path to the folder where ClickHouse configuration files with users settings are located.
+            # Files are common for all instances within a CHI.
+            user: users.d
+        ################################################
+        ##
+        ## Configuration Users Section
+        ##
+        ################################################
+        user:
+          default:
+            # Default values for ClickHouse user configuration
+            # 1. user/profile - string
+            # 2. user/quota - string
+            # 3. user/networks/ip - multiple strings
+            # 4. user/password - string
+            profile: default
+            quota: default
+            networksIP:
+              - "::1"
+              - "127.0.0.1"
+            password: "default"
+        ################################################
+        ##
+        ## Configuration Network Section
+        ##
+        ################################################
+        network:
+          # Default host_regexp to limit network connectivity from outside
+          hostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+      ################################################
+      ##
+      ## Access to ClickHouse instances
+      ##
+      ################################################
+      access:
+        # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
+        # for:
+        # 1. Metrics requests
+        # 2. Schema maintenance
+        # 3. DROP DNS CACHE
+        # User with such credentials can be specified in additional ClickHouse .xml config files,
+        # located in `chUsersConfigsPath` folder
+        username: "clickhouse_operator"
+        password: "clickhouse_operator_password"
+        secret:
+          # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
+          # Can be used instead of explicitly specified username and password
+          namespace: ""
+          name: ""
+        # Port where to connect to ClickHouse instances to
+        port: 8123
     
     ################################################
     ##
-    ## ClickHouse Settings Section
+    ## Templates Section
     ##
     ################################################
-    
-    # Default values for ClickHouse user configuration
-    # 1. user/profile - string
-    # 2. user/quota - string
-    # 3. user/networks/ip - multiple strings
-    # 4. user/password - string
-    chConfigUserDefaultProfile: default
-    chConfigUserDefaultQuota: default
-    chConfigUserDefaultNetworksIP:
-      - "::1"
-      - "127.0.0.1"
-    chConfigUserDefaultPassword: "default"
-    
-    # Default host_regexp to limit network connectivity from outside
-    chConfigNetworksHostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+    template:
+      chi:
+        # Path to the folder where ClickHouseInstallation .yaml manifests are located.
+        # Manifests are applied in sorted alpha-numeric order.
+        path: templates.d
     
     ################################################
     ##
-    ## Access to ClickHouse instances
+    ## Reconcile Section
     ##
     ################################################
+    reconcile:
+      runtime:
+        # Max number of concurrent reconciles in progress
+        threadsNumber: 10
     
-    # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
-    # for:
-    # 1. Metrics requests
-    # 2. Schema maintenance
-    # 3. DROP DNS CACHE
-    # User with such credentials can be specified in additional ClickHouse .xml config files,
-    # located in `chUsersConfigsPath` folder
-    chUsername: "clickhouse_operator"
-    chPassword: "clickhouse_operator_password"
+      statefulSet:
+        create:
+          # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+          # Possible options:
+          # 1. abort - do nothing, just break the process and wait for admin
+          # 2. delete - delete newly created problematic StatefulSet
+          # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+          onFailure: ignore
     
-    # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
-    # Can be used instead of explicitly specified username and password
-    chCredentialsSecretNamespace: ""
-    chCredentialsSecretName: ""
+        update:
+          # How many seconds to wait for created/updated StatefulSet to be Ready
+          timeout: 300
+          # How many seconds to wait between checks for created/updated StatefulSet status
+          pollInterval: 5
+          # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+          # Possible options:
+          # 1. abort - do nothing, just break the process and wait for admin
+          # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
+          # Pod would be recreated by StatefulSet based on rollback-ed configuration
+          # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+          onFailure: rollback
     
-    # Port where to connect to ClickHouse instances to
-    chPort: 8123
+      host:
+        # Whether reconciler should wait for host:
+        # to be excluded from cluster OR
+        # to be included into cluster
+        # respectfully
+        wait:
+          exclude: true
+          include: false
+    
+    ################################################
+    ##
+    ## Annotations management
+    ##
+    ################################################
+    annotation:
+      # Applied when:
+      #  1. Propagating annotations from the CHI's `metadata.annotations` to child objects' `metadata.annotations`,
+      #  2. Propagating annotations from the CHI Template's `metadata.annotations` to CHI's `metadata.annotations`,
+      # Include annotations from the following list:
+      # Applied only when not empty. Empty list means "include all, no selection"
+      include: []
+      # Exclude annotations from the following list:
+      exclude: []
+    
+    ################################################
+    ##
+    ## Labels management
+    ##
+    ################################################
+    label:
+      # Applied when:
+      #  1. Propagating labels from the CHI's `metadata.labels` to child objects' `metadata.labels`,
+      #  2. Propagating labels from the CHI Template's `metadata.labels` to CHI's `metadata.labels`,
+      # Include labels from the following list:
+      # Applied only when not empty. Empty list means "include all, no selection"
+      include: []
+      # Exclude labels from the following list:
+      exclude: []
+      # Whether to append *Scope* labels to StatefulSet and Pod.
+      # Full list of available *scope* labels check in labeler.go
+      #  LabelShardScopeIndex
+      #  LabelReplicaScopeIndex
+      #  LabelCHIScopeIndex
+      #  LabelCHIScopeCycleSize
+      #  LabelCHIScopeCycleIndex
+      #  LabelCHIScopeCycleOffset
+      #  LabelClusterScopeIndex
+      #  LabelClusterScopeCycleSize
+      #  LabelClusterScopeCycleIndex
+      #  LabelClusterScopeCycleOffset
+      appendScope: "no"
+    
+    ################################################
+    ##
+    ## StatefulSet management
+    ##
+    ################################################
+    statefulSet:
+      revisionHistoryLimit: 0
+    
+    ################################################
+    ##
+    ## Pod management
+    ##
+    ################################################
+    pod:
+      # Grace period for Pod termination.
+      # How many seconds to wait between sending
+      # SIGTERM and SIGKILL during Pod termination process.
+      # Increase this number is case of slow shutdown.
+      terminationGracePeriod: 30
     
     ################################################
     ##
     ## Log parameters
     ##
     ################################################
-    
-    logtostderr: "true"
-    alsologtostderr: "false"
-    v: "1"
-    stderrthreshold: ""
-    vmodule: ""
-    log_backtrace_at: ""
-    
-    ################################################
-    ##
-    ## Runtime parameters
-    ##
-    ################################################
-    
-    # Max number of concurrent reconciles in progress
-    reconcileThreadsNumber: 10
-    reconcileWaitExclude: true
-    reconcileWaitInclude: false
-    
-    ################################################
-    ##
-    ## Labels management parameters
-    ##
-    ################################################
-    
-    # When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
-    # exclude labels from the following list:
-    #excludeFromPropagationLabels:
-    #  - "labelA"
-    #  - "labelB"
-    
-    # Whether to append *Scope* labels to StatefulSet and Pod.
-    # Full list of available *scope* labels check in labeler.go
-    #  LabelShardScopeIndex
-    #  LabelReplicaScopeIndex
-    #  LabelCHIScopeIndex
-    #  LabelCHIScopeCycleSize
-    #  LabelCHIScopeCycleIndex
-    #  LabelCHIScopeCycleOffset
-    #  LabelClusterScopeIndex
-    #  LabelClusterScopeCycleSize
-    #  LabelClusterScopeCycleIndex
-    #  LabelClusterScopeCycleOffset
-    appendScopeLabels: "no"
-    
-    ################################################
-    ##
-    ## Pod management parameters
-    ##
-    ################################################
-    # Grace period for Pod termination.
-    # How many seconds to wait between sending
-    # SIGTERM and SIGKILL during Pod termination process.
-    # Increase this number is case of slow shutdown.
-    terminationGracePeriod: 30
+    logger:
+      logtostderr: "true"
+      alsologtostderr: "false"
+      v: "1"
+      stderrthreshold: ""
+      vmodule: ""
+      log_backtrace_at: ""
 
 ---
 
@@ -192,6 +243,7 @@ metadata:
   name: etc-clickhouse-operator-confd-files
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 data:
 
@@ -209,6 +261,7 @@ metadata:
   name: etc-clickhouse-operator-configd-files
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 data:
   01-clickhouse-01-listen.xml: |
@@ -268,6 +321,7 @@ metadata:
   name: etc-clickhouse-operator-templatesd-files
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 data:
   001-templates.json.example: |
@@ -302,7 +356,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:19.3.7",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",
@@ -369,6 +423,7 @@ metadata:
   name: etc-clickhouse-operator-usersd-files
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 data:
   01-clickhouse-user.xml: |

--- a/charts/posthog/templates/clickhouse-operator/deployment.yaml
+++ b/charts/posthog/templates/clickhouse-operator/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
   name: clickhouse-operator
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 spec:
   replicas: 1
@@ -125,5 +126,8 @@ spec:
               mountPath: /etc/clickhouse-operator/templates.d
             - name: etc-clickhouse-operator-usersd-folder
               mountPath: /etc/clickhouse-operator/users.d
+          ports:
+            - containerPort: 8888
+              name: metrics
 
 {{- end }}

--- a/charts/posthog/templates/clickhouse-operator/service.yaml
+++ b/charts/posthog/templates/clickhouse-operator/service.yaml
@@ -15,6 +15,7 @@ metadata:
   name: clickhouse-operator-metrics
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
   labels:
+    clickhouse.altinity.com/chop: 0.18.4
     app: clickhouse-operator
 spec:
   ports:

--- a/charts/posthog/templates/clickhouse-operator/serviceaccount.yaml
+++ b/charts/posthog/templates/clickhouse-operator/serviceaccount.yaml
@@ -11,5 +11,7 @@ kind: ServiceAccount
 metadata:
   name: clickhouse-operator
   namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}
+  labels:
+    clickhouse.altinity.com/chop: 0.18.4
 
 {{- end }}

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/clusterrole.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/clusterrole.yaml.snap
@@ -3,6 +3,8 @@ the manifest should match the snapshot when using default values:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        clickhouse.altinity.com/chop: 0.18.4
       name: clickhouse-operator-posthog
       namespace: NAMESPACE
     rules:
@@ -12,13 +14,13 @@ the manifest should match the snapshot when using default values:
       - configmaps
       - services
       verbs:
-      - create
-      - delete
       - get
+      - list
       - patch
       - update
-      - list
       - watch
+      - create
+      - delete
     - apiGroups:
       - ""
       resources:
@@ -38,12 +40,12 @@ the manifest should match the snapshot when using default values:
       resources:
       - persistentvolumeclaims
       verbs:
-      - delete
       - get
       - list
       - patch
       - update
       - watch
+      - delete
     - apiGroups:
       - ""
       resources:
@@ -60,22 +62,22 @@ the manifest should match the snapshot when using default values:
       resources:
       - statefulsets
       verbs:
-      - create
-      - delete
       - get
+      - list
       - patch
       - update
-      - list
       - watch
+      - create
+      - delete
     - apiGroups:
       - apps
       resources:
       - replicasets
       verbs:
-      - delete
       - get
       - patch
       - update
+      - delete
     - apiGroups:
       - apps
       resourceNames:
@@ -92,22 +94,22 @@ the manifest should match the snapshot when using default values:
       resources:
       - poddisruptionbudgets
       verbs:
-      - create
-      - delete
       - get
+      - list
       - patch
       - update
-      - list
       - watch
+      - create
+      - delete
     - apiGroups:
       - clickhouse.altinity.com
       resources:
       - clickhouseinstallations
       verbs:
-      - delete
       - get
       - patch
       - update
+      - delete
     - apiGroups:
       - clickhouse.altinity.com
       resources:
@@ -133,15 +135,22 @@ the manifest should match the snapshot when using default values:
       - clickhouseinstallationtemplates/status
       - clickhouseoperatorconfigurations/status
       verbs:
-      - create
-      - delete
       - get
       - update
       - patch
+      - create
+      - delete
     - apiGroups:
       - ""
       resources:
       - secrets
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
       verbs:
       - get
       - list

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/clusterrolebinding.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/clusterrolebinding.yaml.snap
@@ -3,6 +3,8 @@ the manifest should match the snapshot when using default values:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        clickhouse.altinity.com/chop: 0.18.4
       name: clickhouse-operator-posthog
       namespace: NAMESPACE
     roleRef:

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
@@ -3,173 +3,224 @@ the manifest should match the snapshot when using default values:
     apiVersion: v1
     data:
       config.yaml: |
-        ################################################
-        ##
-        ## Watch Namespaces Section
-        ##
-        ################################################
-
-        # List of namespaces where clickhouse-operator watches for events.
-        # Concurrently running operators should watch on different namespaces
-        #watchNamespaces: ["dev", "test"]
-        watchNamespaces: []
-
-        ################################################
-        ##
-        ## Additional Configuration Files Section
-        ##
-        ################################################
-
-        # Path to folder where ClickHouse configuration files common for all instances within CHI are located.
-        chCommonConfigsPath: config.d
-
-        # Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located.
-        chHostConfigsPath: conf.d
-
-        # Path to folder where ClickHouse configuration files with users settings are located.
-        # Files are common for all instances within CHI
-        chUsersConfigsPath: users.d
-
-        # Path to folder where ClickHouseInstallation .yaml manifests are located.
-        # Manifests are applied in sorted alpha-numeric order
-        chiTemplatesPath: templates.d
+        # IMPORTANT
+        # This file is auto-generated from deploy/builder/templates-config.
+        # It will be overwritten upon next sources build.
+        #
+        # Template parameters available:
+        #   watchNamespaces
+        #   chUsername
+        #   chPassword
+        #   password_sha256_hex
 
         ################################################
         ##
-        ## Cluster Create/Update/Delete Objects Section
+        ## Watch Section
         ##
         ################################################
+        watch:
+          # List of namespaces where clickhouse-operator watches for events.
+          # Concurrently running operators should watch on different namespaces
+          #namespaces: ["dev", "test"]
+          namespaces: []
 
-        # How many seconds to wait for created/updated StatefulSet to be Ready
-        statefulSetUpdateTimeout: 300
-
-        # How many seconds to wait between checks for created/updated StatefulSet status
-        statefulSetUpdatePollPeriod: 5
-
-        # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-        # Possible options:
-        # 1. abort - do nothing, just break the process and wait for admin
-        # 2. delete - delete newly created problematic StatefulSet
-        # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
-        onStatefulSetCreateFailureAction: ignore
-
-        # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
-        # Possible options:
-        # 1. abort - do nothing, just break the process and wait for admin
-        # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
-        # Pod would be recreated by StatefulSet based on rollback-ed configuration
-        # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
-        onStatefulSetUpdateFailureAction: rollback
+        clickhouse:
+          configuration:
+            ################################################
+            ##
+            ## Configuration Files Section
+            ##
+            ################################################
+            file:
+              path:
+                # Path to the folder where ClickHouse configuration files common for all instances within a CHI are located.
+                common: config.d
+                # Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.
+                host: conf.d
+                # Path to the folder where ClickHouse configuration files with users settings are located.
+                # Files are common for all instances within a CHI.
+                user: users.d
+            ################################################
+            ##
+            ## Configuration Users Section
+            ##
+            ################################################
+            user:
+              default:
+                # Default values for ClickHouse user configuration
+                # 1. user/profile - string
+                # 2. user/quota - string
+                # 3. user/networks/ip - multiple strings
+                # 4. user/password - string
+                profile: default
+                quota: default
+                networksIP:
+                  - "::1"
+                  - "127.0.0.1"
+                password: "default"
+            ################################################
+            ##
+            ## Configuration Network Section
+            ##
+            ################################################
+            network:
+              # Default host_regexp to limit network connectivity from outside
+              hostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+          ################################################
+          ##
+          ## Access to ClickHouse instances
+          ##
+          ################################################
+          access:
+            # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
+            # for:
+            # 1. Metrics requests
+            # 2. Schema maintenance
+            # 3. DROP DNS CACHE
+            # User with such credentials can be specified in additional ClickHouse .xml config files,
+            # located in `chUsersConfigsPath` folder
+            username: "clickhouse_operator"
+            password: "clickhouse_operator_password"
+            secret:
+              # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
+              # Can be used instead of explicitly specified username and password
+              namespace: ""
+              name: ""
+            # Port where to connect to ClickHouse instances to
+            port: 8123
 
         ################################################
         ##
-        ## ClickHouse Settings Section
+        ## Templates Section
         ##
         ################################################
-
-        # Default values for ClickHouse user configuration
-        # 1. user/profile - string
-        # 2. user/quota - string
-        # 3. user/networks/ip - multiple strings
-        # 4. user/password - string
-        chConfigUserDefaultProfile: default
-        chConfigUserDefaultQuota: default
-        chConfigUserDefaultNetworksIP:
-          - "::1"
-          - "127.0.0.1"
-        chConfigUserDefaultPassword: "default"
-
-        # Default host_regexp to limit network connectivity from outside
-        chConfigNetworksHostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+        template:
+          chi:
+            # Path to the folder where ClickHouseInstallation .yaml manifests are located.
+            # Manifests are applied in sorted alpha-numeric order.
+            path: templates.d
 
         ################################################
         ##
-        ## Access to ClickHouse instances
+        ## Reconcile Section
         ##
         ################################################
+        reconcile:
+          runtime:
+            # Max number of concurrent reconciles in progress
+            threadsNumber: 10
 
-        # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
-        # for:
-        # 1. Metrics requests
-        # 2. Schema maintenance
-        # 3. DROP DNS CACHE
-        # User with such credentials can be specified in additional ClickHouse .xml config files,
-        # located in `chUsersConfigsPath` folder
-        chUsername: "clickhouse_operator"
-        chPassword: "clickhouse_operator_password"
+          statefulSet:
+            create:
+              # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+              # Possible options:
+              # 1. abort - do nothing, just break the process and wait for admin
+              # 2. delete - delete newly created problematic StatefulSet
+              # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+              onFailure: ignore
 
-        # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
-        # Can be used instead of explicitly specified username and password
-        chCredentialsSecretNamespace: ""
-        chCredentialsSecretName: ""
+            update:
+              # How many seconds to wait for created/updated StatefulSet to be Ready
+              timeout: 300
+              # How many seconds to wait between checks for created/updated StatefulSet status
+              pollInterval: 5
+              # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+              # Possible options:
+              # 1. abort - do nothing, just break the process and wait for admin
+              # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
+              # Pod would be recreated by StatefulSet based on rollback-ed configuration
+              # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+              onFailure: rollback
 
-        # Port where to connect to ClickHouse instances to
-        chPort: 8123
+          host:
+            # Whether reconciler should wait for host:
+            # to be excluded from cluster OR
+            # to be included into cluster
+            # respectfully
+            wait:
+              exclude: true
+              include: false
+
+        ################################################
+        ##
+        ## Annotations management
+        ##
+        ################################################
+        annotation:
+          # Applied when:
+          #  1. Propagating annotations from the CHI's `metadata.annotations` to child objects' `metadata.annotations`,
+          #  2. Propagating annotations from the CHI Template's `metadata.annotations` to CHI's `metadata.annotations`,
+          # Include annotations from the following list:
+          # Applied only when not empty. Empty list means "include all, no selection"
+          include: []
+          # Exclude annotations from the following list:
+          exclude: []
+
+        ################################################
+        ##
+        ## Labels management
+        ##
+        ################################################
+        label:
+          # Applied when:
+          #  1. Propagating labels from the CHI's `metadata.labels` to child objects' `metadata.labels`,
+          #  2. Propagating labels from the CHI Template's `metadata.labels` to CHI's `metadata.labels`,
+          # Include labels from the following list:
+          # Applied only when not empty. Empty list means "include all, no selection"
+          include: []
+          # Exclude labels from the following list:
+          exclude: []
+          # Whether to append *Scope* labels to StatefulSet and Pod.
+          # Full list of available *scope* labels check in labeler.go
+          #  LabelShardScopeIndex
+          #  LabelReplicaScopeIndex
+          #  LabelCHIScopeIndex
+          #  LabelCHIScopeCycleSize
+          #  LabelCHIScopeCycleIndex
+          #  LabelCHIScopeCycleOffset
+          #  LabelClusterScopeIndex
+          #  LabelClusterScopeCycleSize
+          #  LabelClusterScopeCycleIndex
+          #  LabelClusterScopeCycleOffset
+          appendScope: "no"
+
+        ################################################
+        ##
+        ## StatefulSet management
+        ##
+        ################################################
+        statefulSet:
+          revisionHistoryLimit: 0
+
+        ################################################
+        ##
+        ## Pod management
+        ##
+        ################################################
+        pod:
+          # Grace period for Pod termination.
+          # How many seconds to wait between sending
+          # SIGTERM and SIGKILL during Pod termination process.
+          # Increase this number is case of slow shutdown.
+          terminationGracePeriod: 30
 
         ################################################
         ##
         ## Log parameters
         ##
         ################################################
-
-        logtostderr: "true"
-        alsologtostderr: "false"
-        v: "1"
-        stderrthreshold: ""
-        vmodule: ""
-        log_backtrace_at: ""
-
-        ################################################
-        ##
-        ## Runtime parameters
-        ##
-        ################################################
-
-        # Max number of concurrent reconciles in progress
-        reconcileThreadsNumber: 10
-        reconcileWaitExclude: true
-        reconcileWaitInclude: false
-
-        ################################################
-        ##
-        ## Labels management parameters
-        ##
-        ################################################
-
-        # When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
-        # exclude labels from the following list:
-        #excludeFromPropagationLabels:
-        #  - "labelA"
-        #  - "labelB"
-
-        # Whether to append *Scope* labels to StatefulSet and Pod.
-        # Full list of available *scope* labels check in labeler.go
-        #  LabelShardScopeIndex
-        #  LabelReplicaScopeIndex
-        #  LabelCHIScopeIndex
-        #  LabelCHIScopeCycleSize
-        #  LabelCHIScopeCycleIndex
-        #  LabelCHIScopeCycleOffset
-        #  LabelClusterScopeIndex
-        #  LabelClusterScopeCycleSize
-        #  LabelClusterScopeCycleIndex
-        #  LabelClusterScopeCycleOffset
-        appendScopeLabels: "no"
-
-        ################################################
-        ##
-        ## Pod management parameters
-        ##
-        ################################################
-        # Grace period for Pod termination.
-        # How many seconds to wait between sending
-        # SIGTERM and SIGKILL during Pod termination process.
-        # Increase this number is case of slow shutdown.
-        terminationGracePeriod: 30
+        logger:
+          logtostderr: "true"
+          alsologtostderr: "false"
+          v: "1"
+          stderrthreshold: ""
+          vmodule: ""
+          log_backtrace_at: ""
     kind: ConfigMap
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: etc-clickhouse-operator-files
       namespace: NAMESPACE
   2: |
@@ -179,6 +230,7 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: etc-clickhouse-operator-confd-files
       namespace: NAMESPACE
   3: |
@@ -227,6 +279,7 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: etc-clickhouse-operator-configd-files
       namespace: NAMESPACE
   4: |
@@ -264,7 +317,7 @@ the manifest should match the snapshot when using default values:
                     "containers" : [
                       {
                         "name": "clickhouse",
-                        "image": "yandex/clickhouse-server:19.3.7",
+                        "image": "clickhouse/clickhouse-server:22.3",
                         "ports": [
                           {
                             "name": "http",
@@ -318,6 +371,7 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: etc-clickhouse-operator-templatesd-files
       namespace: NAMESPACE
   5: |
@@ -369,5 +423,6 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: etc-clickhouse-operator-usersd-files
       namespace: NAMESPACE

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/deployment.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/deployment.yaml.snap
@@ -5,6 +5,7 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: clickhouse-operator
       namespace: NAMESPACE
     spec:
@@ -79,6 +80,9 @@ the manifest should match the snapshot when using default values:
           - image: altinity/metrics-exporter:latest
             imagePullPolicy: Always
             name: metrics-exporter
+            ports:
+            - containerPort: 8888
+              name: metrics
             volumeMounts:
             - mountPath: /etc/clickhouse-operator
               name: etc-clickhouse-operator-folder

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/service.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/service.yaml.snap
@@ -5,6 +5,7 @@ the manifest should match the snapshot when using default values:
     metadata:
       labels:
         app: clickhouse-operator
+        clickhouse.altinity.com/chop: 0.18.4
       name: clickhouse-operator-metrics
       namespace: NAMESPACE
     spec:

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/serviceaccount.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/serviceaccount.yaml.snap
@@ -3,5 +3,7 @@ the manifest should match the snapshot when using default values:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        clickhouse.altinity.com/chop: 0.18.4
       name: clickhouse-operator
       namespace: NAMESPACE

--- a/charts/posthog/tests/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/tests/clickhouse-operator/configmap.yaml
@@ -28,7 +28,9 @@ tests:
           value:
             name: etc-clickhouse-operator-files
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-files metadata.namespace override via Release.Namespace should work
     release:
@@ -42,7 +44,9 @@ tests:
           value:
             name: etc-clickhouse-operator-files
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-confd-files metadata.namespace override via clickhouse.namespace should work
     set:
@@ -56,7 +60,9 @@ tests:
           value:
             name: etc-clickhouse-operator-confd-files
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-confd-files metadata.namespace override via Release.Namespace should work
     release:
@@ -70,7 +76,9 @@ tests:
           value:
             name: etc-clickhouse-operator-confd-files
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-configd-files metadata.namespace override via clickhouse.namespace should work
     set:
@@ -84,7 +92,9 @@ tests:
           value:
             name: etc-clickhouse-operator-configd-files
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-configd-files metadata.namespace override via Release.Namespace should work
     release:
@@ -98,7 +108,9 @@ tests:
           value:
             name: etc-clickhouse-operator-configd-files
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-templatesd-files metadata.namespace override via clickhouse.namespace should work
     set:
@@ -112,7 +124,9 @@ tests:
           value:
             name: etc-clickhouse-operator-templatesd-files
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-templatesd-files metadata.namespace override via Release.Namespace should work
     release:
@@ -126,7 +140,9 @@ tests:
           value:
             name: etc-clickhouse-operator-templatesd-files
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-usersd-files metadata.namespace override via clickhouse.namespace should work
     set:
@@ -140,7 +156,9 @@ tests:
           value:
             name: etc-clickhouse-operator-usersd-files
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: ConfigMap/etc-clickhouse-operator-usersd-files metadata.namespace override via Release.Namespace should work
     release:
@@ -154,4 +172,6 @@ tests:
           value:
             name: etc-clickhouse-operator-usersd-files
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4

--- a/charts/posthog/tests/clickhouse-operator/deployment.yaml
+++ b/charts/posthog/tests/clickhouse-operator/deployment.yaml
@@ -27,7 +27,9 @@ tests:
           value:
             name: clickhouse-operator
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: metadata.namespace override via Release.Namespace should work
     release:
@@ -40,4 +42,6 @@ tests:
           value:
             name: clickhouse-operator
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4

--- a/charts/posthog/tests/clickhouse-operator/service.yaml
+++ b/charts/posthog/tests/clickhouse-operator/service.yaml
@@ -27,7 +27,9 @@ tests:
           value:
             name: clickhouse-operator-metrics
             namespace: custom-namespace
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: metadata.namespace override via Release.Namespace should work
     release:
@@ -40,4 +42,6 @@ tests:
           value:
             name: clickhouse-operator-metrics
             namespace: custom-namespace-from-release
-            labels: { app: clickhouse-operator }
+            labels:
+              app: clickhouse-operator
+              clickhouse.altinity.com/chop: 0.18.4

--- a/charts/posthog/tests/clickhouse-operator/serviceaccount.yaml
+++ b/charts/posthog/tests/clickhouse-operator/serviceaccount.yaml
@@ -27,6 +27,8 @@ tests:
           value:
             name: clickhouse-operator
             namespace: custom-namespace
+            labels:
+              clickhouse.altinity.com/chop: 0.18.4
 
   - it: metadata.namespace override via Release.Namespace should work
     release:
@@ -39,3 +41,5 @@ tests:
           value:
             name: clickhouse-operator
             namespace: custom-namespace-from-release
+            labels:
+              clickhouse.altinity.com/chop: 0.18.4

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -18,7 +18,7 @@ TMP_FOLDER="$(mktemp -d)"
 trap 'rm -rf -- "$TMP_FOLDER"' EXIT
 
 OPERATOR_NAMESPACE="posthog"
-CLICKHOUSE_OPERATOR_TAG="0.16.1"
+CLICKHOUSE_OPERATOR_TAG="0.18.4"
 URL="https://raw.githubusercontent.com/Altinity/clickhouse-operator/${CLICKHOUSE_OPERATOR_TAG}/deploy/operator/clickhouse-operator-install-template.yaml"
 
 #
@@ -31,7 +31,7 @@ METRICS_EXPORTER_NAMESPACE="${OPERATOR_NAMESPACE}"
 # NOTE: we pin to 0.19.0 here which is different to the 0.16.1 manifest version.
 # Prior to pinning we were specifying latest, so to ensure that the version
 # doesn't change on existing installs we pin to latest as of writing, thereby
-# mitigating the possibility that chart will unexpectedly update, while also 
+# mitigating the possibility that chart will unexpectedly update, while also
 # maintaining current functionality.
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-altinity/clickhouse-operator:0.19.0}"
 METRICS_EXPORTER_IMAGE="${METRICS_EXPORTER_IMAGE:-altinity/metrics-exporter:latest}"


### PR DESCRIPTION
## Description
Upgrade the `clickhouse-operator` from version `0.16.1` to `0.18.4`. This brings some reliability and security fixes from upstream (full changelog is available [here](https://github.com/Altinity/clickhouse-operator/releases)).

As we can see from the diff, there are few CRD changes that we need to considered as breaking changes on our end. Release notes are available [here](https://github.com/PostHog/posthog.com/pull/3421). 

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
1️⃣  CI is ✅ 

2️⃣  manually tested the upgrade path locally:

* new installation: ✅ 
* old installation (from `main`) -> upgrade (from this branch): CH pod doesn't get restarted, only the operator pod (as expected) ✅  
* old installation (from `main`) -> upgrade (from this branch) without following the release notes: CH pod doesn't get restarted, only the operator pod (as expected) ✅  

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
