### PR TITLE
Add security context to all deployments

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -26,6 +26,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | events.hpa.cputhreshold | int | `60` | CPU threshold percent for the events stack HorizontalPodAutoscaler. |
 | events.hpa.minpods | int | `1` | Min pods for the events stack HorizontalPodAutoscaler. |
 | events.hpa.maxpods | int | `10` | Max pods for the events stack HorizontalPodAutoscaler. |
+| events.securityContext.enabled | bool | `false` | SecurityContext for events. |
 | web.enabled | bool | `true` | Whether to install the PostHog web stack or not. |
 | web.replicacount | int | `1` | Count of web pods to run. This setting is ignored if `web.hpa.enabled` is set to `true`. |
 | web.hpa.enabled | bool | `false` | Whether to create a HorizontalPodAutoscaler for the web stack. |
@@ -52,6 +53,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | web.readinessProbe.periodSeconds | int | `10` | The readiness probe period seconds |
 | web.readinessProbe.successThreshold | int | `1` | The readiness probe success threshold |
 | web.readinessProbe.timeoutSeconds | int | `2` | The readiness probe timeout seconds |
+| web.securityContext.enabled | bool | `false` | SecurityContext for webservice. |
 | worker.enabled | bool | `true` | Whether to install the PostHog worker stack or not. |
 | worker.replicacount | int | `1` | Count of worker pods to run. This setting is ignored if `worker.hpa.enabled` is set to `true`. |
 | worker.hpa.enabled | bool | `false` | Whether to create a HorizontalPodAutoscaler for the worker stack. |
@@ -63,6 +65,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | worker.nodeSelector | object | `{}` | Node labels for the worker stack deployment. |
 | worker.tolerations | list | `[]` | Toleration labels for the worker stack deployment. |
 | worker.affinity | object | `{}` | Affinity settings for the worker stack deployment. |
+| worker.securityContext.enabled | bool | `false` | SecurityContext for worker. |
 | plugins.enabled | bool | `true` | Whether to install the PostHog plugin-server stack or not. |
 | plugins.ingestion.enabled | bool | `true` | Whether to enable plugin-server based ingestion |
 | plugins.replicacount | int | `1` | Count of plugin-server pods to run. This setting is ignored if `plugin-server.hpa.enabled` is set to `true`. |
@@ -75,6 +78,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | plugins.nodeSelector | object | `{}` | Node labels for the plugin-server stack deployment. |
 | plugins.tolerations | list | `[]` | Toleration labels for the plugin-server stack deployment. |
 | plugins.affinity | object | `{}` | Affinity settings for the plugin-server stack deployment. |
+| plugins.securityContext.enabled | bool | `false` | SecurityContext for plugins. |
 | email.host | string | `nil` | SMTP service host. |
 | email.port | string | `nil` | SMTP service port. |
 | email.user | string | `nil` | SMTP service user. |

--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -26,7 +26,6 @@ The following table lists the configurable parameters of the PostHog chart and t
 | events.hpa.cputhreshold | int | `60` | CPU threshold percent for the events stack HorizontalPodAutoscaler. |
 | events.hpa.minpods | int | `1` | Min pods for the events stack HorizontalPodAutoscaler. |
 | events.hpa.maxpods | int | `10` | Max pods for the events stack HorizontalPodAutoscaler. |
-| events.securityContext.enabled | bool | `false` | SecurityContext for events. |
 | web.enabled | bool | `true` | Whether to install the PostHog web stack or not. |
 | web.replicacount | int | `1` | Count of web pods to run. This setting is ignored if `web.hpa.enabled` is set to `true`. |
 | web.hpa.enabled | bool | `false` | Whether to create a HorizontalPodAutoscaler for the web stack. |
@@ -53,7 +52,6 @@ The following table lists the configurable parameters of the PostHog chart and t
 | web.readinessProbe.periodSeconds | int | `10` | The readiness probe period seconds |
 | web.readinessProbe.successThreshold | int | `1` | The readiness probe success threshold |
 | web.readinessProbe.timeoutSeconds | int | `2` | The readiness probe timeout seconds |
-| web.securityContext.enabled | bool | `false` | SecurityContext for webservice. |
 | worker.enabled | bool | `true` | Whether to install the PostHog worker stack or not. |
 | worker.replicacount | int | `1` | Count of worker pods to run. This setting is ignored if `worker.hpa.enabled` is set to `true`. |
 | worker.hpa.enabled | bool | `false` | Whether to create a HorizontalPodAutoscaler for the worker stack. |
@@ -65,7 +63,6 @@ The following table lists the configurable parameters of the PostHog chart and t
 | worker.nodeSelector | object | `{}` | Node labels for the worker stack deployment. |
 | worker.tolerations | list | `[]` | Toleration labels for the worker stack deployment. |
 | worker.affinity | object | `{}` | Affinity settings for the worker stack deployment. |
-| worker.securityContext.enabled | bool | `false` | SecurityContext for worker. |
 | plugins.enabled | bool | `true` | Whether to install the PostHog plugin-server stack or not. |
 | plugins.ingestion.enabled | bool | `true` | Whether to enable plugin-server based ingestion |
 | plugins.replicacount | int | `1` | Count of plugin-server pods to run. This setting is ignored if `plugin-server.hpa.enabled` is set to `true`. |
@@ -78,7 +75,6 @@ The following table lists the configurable parameters of the PostHog chart and t
 | plugins.nodeSelector | object | `{}` | Node labels for the plugin-server stack deployment. |
 | plugins.tolerations | list | `[]` | Toleration labels for the plugin-server stack deployment. |
 | plugins.affinity | object | `{}` | Affinity settings for the plugin-server stack deployment. |
-| plugins.securityContext.enabled | bool | `false` | SecurityContext for plugins. |
 | email.host | string | `nil` | SMTP service host. |
 | email.port | string | `nil` | SMTP service port. |
 | email.user | string | `nil` | SMTP service user. |

--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -1,6 +1,6 @@
 # PostHog Helm chart configuration
 
-![Version: 19.0.2](https://img.shields.io/badge/Version-19.0.2-informational?style=flat-square) ![AppVersion: 1.35.0](https://img.shields.io/badge/AppVersion-1.35.0-informational?style=flat-square)
+![Version: 19.1.0](https://img.shields.io/badge/Version-19.1.0-informational?style=flat-square) ![AppVersion: 1.35.0](https://img.shields.io/badge/AppVersion-1.35.0-informational?style=flat-square)
 
 ## Configuration
 
@@ -171,6 +171,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | zookeeper.replicaCount | int | `1` | Number of ZooKeeper nodes |
 | zookeeper.autopurge.purgeInterval | int | `1` | The time interval (in hours) for which the purge task has to be triggered |
 | zookeeper.metrics.enabled | bool | `false` | Enable Prometheus to access ZooKeeper metrics endpoint. |
+| zookeeper.metrics.service.annotations."prometheus.io/scrape" | string | `"false"` |  |
 | zookeeper.podAnnotations | string | `nil` |  |
 | clickhouse.enabled | bool | `true` | Whether to install clickhouse. If false, `clickhouse.host` must be set |
 | clickhouse.namespace | string | `nil` | Which namespace to install clickhouse and the `clickhouse-operator` to (defaults to namespace chart is installed to) |

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -52,6 +52,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+     {{- if .Values.events.securityContext.enabled }}
+      securityContext: {{- omit .Values.events.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: {{ .Chart.Name }}-events
         image: {{ template "posthog.image.fullPath" . }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -52,10 +52,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
-     {{- if .Values.events.securityContext.enabled }}
-      securityContext: {{- omit .Values.events.securityContext "enabled" | toYaml | nindent 8 }}
+     {{- if .Values.events.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.events.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-
       containers:
       - name: {{ .Chart.Name }}-events
         image: {{ template "posthog.image.fullPath" . }}
@@ -134,6 +133,9 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+        {{- if .Values.events.securityContext.enabled }}
+        securityContext: {{- omit .Values.events.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -42,8 +42,8 @@ spec:
       {{- if .Values.pgbouncer.schedulerName }}
       schedulerName: "{{ .Values.pgbouncer.schedulerName }}"
       {{- end }}
-      {{- if .Values.pgbouncer.securityContext.enabled }}
-      securityContext: {{- omit .Values.pgbouncer.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.pgbouncer.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.pgbouncer.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}     
       containers:
       - name: {{ .Chart.Name }}-pgbouncer
@@ -96,6 +96,9 @@ spec:
         resources:
 {{ toYaml .Values.pgbouncer.resources | indent 12 }}
 {{- end }}
+        {{- if .Values.pgbouncer.securityContext.enabled }}
+        securityContext: {{- omit .Values.pgbouncer.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}     
     {{- if .Values.pgbouncer.extraVolumes }}
       volumes: {{- toYaml .Values.pgbouncer.extraVolumes | nindent 6 }}
     {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.pgbouncer.schedulerName }}
       schedulerName: "{{ .Values.pgbouncer.schedulerName }}"
       {{- end }}
+      {{- if .Values.pgbouncer.securityContext.enabled }}
+      securityContext: {{- omit .Values.pgbouncer.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}     
       containers:
       - name: {{ .Chart.Name }}-pgbouncer
       {{- if .Values.pgbouncer.image }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -55,6 +55,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.plugins.securityContext.enabled }}
+      securityContext: {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}      
       containers:
       - name: {{ .Chart.Name }}-plugins
         image: {{ template "posthog.image.fullPath" . }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -55,8 +55,8 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if .Values.plugins.securityContext.enabled }}
-      securityContext: {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.plugins.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.plugins.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}      
       containers:
       - name: {{ .Chart.Name }}-plugins
@@ -104,6 +104,9 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}
+        {{- if .Values.plugins.securityContext.enabled }}
+        securityContext: {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}      
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -52,6 +52,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.web.securityContext.enabled }}
+      securityContext: {{- omit .Values.web.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-web
         image: {{ template "posthog.image.fullPath" . }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -52,8 +52,8 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if .Values.web.securityContext.enabled }}
-      securityContext: {{- omit .Values.web.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.web.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.web.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-web
@@ -155,6 +155,9 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+        {{- if .Values.web.securityContext.enabled }}
+        securityContext: {{- omit .Values.web.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -55,6 +55,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.worker.securityContext.enabled }}
+      securityContext: {{- omit .Values.worker.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-workers
         image: {{ template "posthog.image.fullPath" . }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -55,8 +55,8 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if .Values.worker.securityContext.enabled }}
-      securityContext: {{- omit .Values.worker.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.worker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-workers
@@ -109,6 +109,9 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
+        {{- if .Values.worker.securityContext.enabled }}
+        securityContext: {{- omit .Values.worker.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -67,4 +67,25 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false            
           
+  - it: should not have a pod securityContext
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      events.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
   
+  - it: should not have a container securityContext
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      events.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext    

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -32,3 +32,39 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      events.podSecurityContext.enabled: true
+      events.podSecurityContext.runAsUser: 1001
+      events.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+  
+  - it: should have a container securityContext
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      events.securityContext.enabled: true
+      events.securityContext.runAsUser: 1001
+      events.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false            
+          
+  

--- a/charts/posthog/tests/pgbouncer-deployment.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment.yaml
@@ -32,3 +32,39 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.podSecurityContext.enabled: true
+      pgbouncer.podSecurityContext.runAsUser: 1001
+      pgbouncer.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+    
+  - it: should have a container securityContext
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.securityContext.enabled: true
+      pgbouncer.securityContext.runAsUser: 1001
+      pgbouncer.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false            
+          
+  

--- a/charts/posthog/tests/pgbouncer-deployment.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment.yaml
@@ -67,4 +67,25 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false            
           
+  - it: should not have a pod securityContext
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
   
+  - it: should not have a container securityContext
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext  

--- a/charts/posthog/tests/plugins-deployment.yaml
+++ b/charts/posthog/tests/plugins-deployment.yaml
@@ -32,3 +32,39 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      plugins.podSecurityContext.enabled: true
+      plugins.podSecurityContext.runAsUser: 1001
+      plugins.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+  
+  - it: should have a container securityContext
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      plugins.securityContext.enabled: true
+      plugins.securityContext.runAsUser: 1001
+      plugins.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false            
+          
+  

--- a/charts/posthog/tests/plugins-deployment.yaml
+++ b/charts/posthog/tests/plugins-deployment.yaml
@@ -67,4 +67,27 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false            
           
+  - it: should not have a pod securityContext
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      plugins.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+  
+  - it: should not have a container securityContext
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      plugins.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+         
   

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -87,5 +87,28 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false            
           
+  - it: should not have a pod securityContext
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      web.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+  
+  - it: should not have a container securityContext
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      web.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+         
   
   

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -32,3 +32,39 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      web.podSecurityContext.enabled: true
+      web.podSecurityContext.runAsUser: 1001
+      web.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+  
+  - it: should have a container securityContext
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      web.securityContext.enabled: true
+      web.securityContext.runAsUser: 1001
+      web.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false            
+          
+  

--- a/charts/posthog/tests/worker-deployment.yaml
+++ b/charts/posthog/tests/worker-deployment.yaml
@@ -67,4 +67,28 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false            
           
+  - it: should not have a pod securityContext
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      worker.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+  
+  - it: should not have a container securityContext
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      worker.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+         
+  
   

--- a/charts/posthog/tests/worker-deployment.yaml
+++ b/charts/posthog/tests/worker-deployment.yaml
@@ -32,3 +32,39 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      worker.podSecurityContext.enabled: true
+      worker.podSecurityContext.runAsUser: 1001
+      worker.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+  
+  - it: should have a container securityContext
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      worker.securityContext.enabled: true
+      worker.securityContext.runAsUser: 1001
+      worker.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false            
+          
+  

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -47,14 +47,12 @@ events:
     minpods: 1
     # -- Max pods for the events stack HorizontalPodAutoscaler.
     maxpods: 10
-
+  # -- Container security context for the events stack HorizontalPodAutoscaler.
   securityContext:
     enabled: false
-    runAsUser: 101
-    runAsGroup: 101
-    fsGroup: 101
-
-
+  # -- Pod security context for the events stack HorizontalPodAutoscaler.
+  podSecurityContext:
+    enabled: false
 
 web:
   # -- Whether to install the PostHog web stack or not.
@@ -125,13 +123,12 @@ web:
     successThreshold: 1
     # -- The readiness probe timeout seconds
     timeoutSeconds: 2
-
+  # -- Container security context for web stack deployment.
   securityContext:
     enabled: false
-    runAsUser: 101
-    runAsGroup: 101
-    fsGroup: 101
-
+  # -- Pod security context for web stack deployment.
+  podSecurityContext:
+    enabled: false
 
 worker:
   # -- Whether to install the PostHog worker stack or not.
@@ -164,12 +161,12 @@ worker:
   # -- Affinity settings for the worker stack deployment.
   affinity: {}
 
+  # -- Container security context for the worker stack deployment.
   securityContext:
     enabled: false
-    runAsUser: 101
-    runAsGroup: 101
-    fsGroup: 101
-
+  # -- Pod security context for the worker stack deployment.
+  podSecurityContext:
+    enabled: false
 
 plugins:
    # -- Whether to install the PostHog plugin-server stack or not.
@@ -205,12 +202,13 @@ plugins:
   tolerations: []
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
-
+  
+  # -- Container security context for the plugin-server stack deployment.
   securityContext:
     enabled: false
-    runAsUser: 101
-    runAsGroup: 101
-    fsGroup: 101
+  # -- Pod security context for the plugin-server stack deployment.
+  podSecurityContext:
+    enabled: false
 
 email:
   # -- SMTP service host.
@@ -436,13 +434,12 @@ pgbouncer:
   extraVolumeMounts: []
   # -- Additional volumes to be added to the pgbouncer deployment
   extraVolumes: []
-
+  # -- Container security context for the pgbouncer deployment
   securityContext:
-    enabled: true
-    runAsUser: 101
-    runAsGroup: 101
-    fsGroup: 101
-
+    enabled: false
+  # -- Pod security context for the pgbouncer deployment
+  podSecurityContext:
+    enabled: false
 
 ###
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -48,6 +48,13 @@ events:
     # -- Max pods for the events stack HorizontalPodAutoscaler.
     maxpods: 10
 
+  securityContext:
+    enabled: false
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+
+
 
 web:
   # -- Whether to install the PostHog web stack or not.
@@ -119,6 +126,12 @@ web:
     # -- The readiness probe timeout seconds
     timeoutSeconds: 2
 
+  securityContext:
+    enabled: false
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+
 
 worker:
   # -- Whether to install the PostHog worker stack or not.
@@ -150,6 +163,12 @@ worker:
   tolerations: []
   # -- Affinity settings for the worker stack deployment.
   affinity: {}
+
+  securityContext:
+    enabled: false
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
 
 
 plugins:
@@ -187,6 +206,11 @@ plugins:
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
 
+  securityContext:
+    enabled: false
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
 
 email:
   # -- SMTP service host.
@@ -412,6 +436,12 @@ pgbouncer:
   extraVolumeMounts: []
   # -- Additional volumes to be added to the pgbouncer deployment
   extraVolumes: []
+
+  securityContext:
+    enabled: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
 
 
 ###


### PR DESCRIPTION
## Description

Many k8s clusters has a requirement for running as non-root and other security related configs. This adds the possibility to configure this, not only for clickhouse but for all posthog pods.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

It has not been tested. Non breaking, very minor change.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
