### PR TITLE
fix(clickhouse): make operator sync cmd work on both mac and linux

### DIFF
--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -62,6 +62,7 @@ kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/templa
 FILES="${CHART_PATH}/templates/clickhouse-operator/*"
 for f in $FILES
 do
+    # BSD versions, hence here we opt for using perl instead.
     perl -pi -e 'print "{{- if .Values.clickhouse.enabled }}\n" if $. == 1' "$f"
 
     sed -i'' '$a\

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -62,15 +62,15 @@ kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/templa
 FILES="${CHART_PATH}/templates/clickhouse-operator/*"
 for f in $FILES
 do
+    # NOTE: previously we were using sed with the `-i` option to specify that we
+    # should to the modifications in place. The option behaviour between GNU and
     # BSD versions, hence here we opt for using perl instead.
     perl -pi -e 'print "{{- if .Values.clickhouse.enabled }}\n" if $. == 1' "$f"
 
-    sed -i'' '$a\
-{{- end }}
-    ' "$f"
+    echo "{{- end }}" >> "$f"
 
-    sed -i'' 's/#namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
+    perl -pi -e 's/#namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
-    sed -i'' 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
+    perl -pi -e 's/namespace: posthog$/namespace: {{ .Values.clickhouse.namespace | default .Release.Namespace }}/g' "$f"
 
 done

--- a/scripts/clickhouse_operator_sync.sh
+++ b/scripts/clickhouse_operator_sync.sh
@@ -62,9 +62,7 @@ kubectl-slice -f "$TMP_FOLDER/clickhouse-operator.yaml" -o "${CHART_PATH}/templa
 FILES="${CHART_PATH}/templates/clickhouse-operator/*"
 for f in $FILES
 do
-    sed -i'' '1i\
-{{- if .Values.clickhouse.enabled }}
-    ' "$f"
+    perl -pi -e 'print "{{- if .Values.clickhouse.enabled }}\n" if $. == 1' "$f"
 
     sed -i'' '$a\
 {{- end }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
