### PR TITLE
feat(busybox): allow specifying a custom image

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -1,7 +1,7 @@
 {{/* Common initContainers-wait-for-service-dependencies definition */}}
 {{- define "_snippet-initContainers-wait-for-service-dependencies" }}
 - name: wait-for-service-dependencies
-  image: busybox:1.34
+  image: {{ .Values.busybox.image }}
   env:
     {{- include "snippet.clickhouse-env" . | nindent 4 }}
   command:

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -32,3 +32,24 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  - it: should allow specifying a custom busybox image for init containers
+    template: templates/web-deployment.yaml
+    set:
+      cloud: local
+      busybox:
+        image: some-customer-image
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: some-customer-image
+
+  - it: should have a default image for init containers
+    template: templates/web-deployment.yaml
+    set:
+      cloud: local
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.34
+

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -983,3 +983,7 @@ prometheus-redis-exporter:
 ###
 ###
 installCustomStorageClass: false
+
+busybox:
+  # -- Specify the image to use for e.g. init containers
+  image: busybox:1.34


### PR DESCRIPTION
In cases where you do not have access to dockerhub, it becomes necessary
to be able to specify an image from a different repo.

Refers #379

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
