### PR TITLE
Set default/allow_nondeterministic_mutations to 1

### DIFF
--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -50,6 +50,7 @@ the manifest should match the snapshot when using default values:
             }
         profiles:
           default/allow_experimental_window_functions: "1"
+          default/allow_nondeterministic_mutations: "1"
         settings:
           format_schema_path: /etc/clickhouse-server/config.d/
         users:

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -211,6 +211,7 @@ tests:
           path: spec.configuration.profiles
           value:
             default/allow_experimental_window_functions: "1"
+            default/allow_nondeterministic_mutations: "1"
 
   - it: handles custom profiles configuration
     set:
@@ -223,6 +224,7 @@ tests:
           path: spec.configuration.profiles
           value:
             default/allow_experimental_window_functions: "1"
+            default/allow_nondeterministic_mutations: "1"
             default/max_execution_time: "90"
             default/max_memory_usage: "20000000000"
 
@@ -236,6 +238,7 @@ tests:
           path: spec.configuration.profiles
           value:
             default/allow_experimental_window_functions: "0"
+            default/allow_nondeterministic_mutations: "1"
 
   - it: default configuration settings should be correct
     asserts:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -644,6 +644,8 @@ clickhouse:
   ## -- Default user profile configuration for Clickhouse. !!! Please DO NOT override this !!!
   defaultProfiles:
     default/allow_experimental_window_functions: "1"
+    default/allow_nondeterministic_mutations: "1"
+
 
   ## -- Clickhouse cluster layout. (Experimental, use at own risk)
   ## For a full list of options, see https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md


### PR DESCRIPTION
## Description

Sets allow_nondeterministic_mutations=1. 

This will allow us to do operations like `dictGet` on `ALTER TABLE ... UPDATE`.

Linked PRs:

- https://github.com/PostHog/posthog-cloud-infra/pull/174
- https://github.com/PostHog/posthog/pull/9722

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
