### PR TITLE
CI/GCP: use OIDC

### DIFF
--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -10,24 +10,42 @@ name: e2e - Google Cloud Platform (install)
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+
+env:
+  # This is needed until k8s v1.25
+  # https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+  USE_GKE_GCLOUD_AUTH_PLUGIN: True
 
 jobs:
   gcp-install:
     runs-on: ubuntu-20.04
     if: github.repository == 'PostHog/charts-clickhouse'
-    steps:
 
+    #
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # We use OpenID Connect (OIDC) to allow this GitHub Action to access and manage
+    # GCP resources without needing to store the GCP credentials as long-lived GitHub secrets.
+    #
+    # see: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform
+    #
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set up GCP Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0
       with:
-        project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
+        workload_identity_provider: 'projects/494532703488/locations/global/workloadIdentityPools/github/providers/github'
+        service_account: 'github@posthog-helm-chart-testing.iam.gserviceaccount.com'
+        access_token_lifetime: '7200s'
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+      install_components: 'gke-gcloud-auth-plugin'
 
     - name: Install doctl to manage 'posthog.cc' DNS
       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -45,7 +45,8 @@ jobs:
 
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v0
-      install_components: 'gke-gcloud-auth-plugin'
+      with:
+        install_components: 'gke-gcloud-auth-plugin'
 
     - name: Install doctl to manage 'posthog.cc' DNS
       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -10,7 +10,8 @@ name: e2e - Google Cloud Platform (install)
 on:
   workflow_dispatch:
   push:
-
+    branches:
+      - main
 env:
   # This is needed until k8s v1.25
   # https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke


### PR DESCRIPTION
## Description
While troubleshooting some e2e CI failures for both GCP and AWS, I ended up doing some minor fixes to our e2e CI test for GCP.

1. Use OIDC auth instead of hardcoded credentials
2. Remove the deprecated `gcp auth plugin` (closes #386)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ (at least for the auth part), no warnings are thrown like before due to the auth plugin deprecation.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
