### PR TITLE
feat(objects-storage): Use `OBJECT_STORAGE_ENDPOINT` var

### DIFF
--- a/charts/posthog/templates/_object_storage.tpl
+++ b/charts/posthog/templates/_object_storage.tpl
@@ -13,13 +13,22 @@
 {{- end -}}
 {{- end -}}
 
+{{/* Unify endpoint logic to support host, port specification */}}
+{{- define "posthog.externalObjectStorage.endpoint" -}}
+{{- if .Values.externalObjectStorage.endpoint -}}
+{{- .Values.externalObjectStorage.endpoint -}}
+{{- else if .Values.externalObjectStorage.host -}}
+{{- .Values.externalObjectStorage.host -}}:{{- .Values.externalObjectStorage.port -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Common Object Storage ENV variables and helpers used by PostHog */}}
 {{- define "snippet.objectstorage-env" }}
 
 {{/* MINIO */}}
 {{- if .Values.minio.enabled }}
-- name: OBJECT_STORAGE_HOST
-  value: {{ include "posthog.objectStorage.fullname" . }}
+- name: OBJECT_STORAGE_ENDPOINT
+  value: {{ include "posthog.objectStorage.fullname" . }}:{{ .Values.minio.service.ports.api }}
 - name: OBJECT_STORAGE_PORT
   value: {{ .Values.minio.service.ports.api | quote }}
 - name: OBJECT_STORAGE_BUCKET
@@ -45,11 +54,9 @@
 {{- end -}}
 
 {{/* External Object Storage */}}
-{{- else if .Values.externalObjectStorage.host }}
-- name: OBJECT_STORAGE_HOST
-  value: {{ .Values.externalObjectStorage.host }}
-- name: OBJECT_STORAGE_PORT
-  value: {{ .Values.externalObjectStorage.port | quote }}
+{{- else if include "posthog.externalObjectStorage.endpoint" . }}
+- name: OBJECT_STORAGE_ENDPOINT
+  value: {{ include "posthog.externalObjectStorage.endpoint" . }}
 - name: OBJECT_STORAGE_BUCKET
   value: {{ .Values.externalObjectStorage.bucket }}
 - name: OBJECT_STORAGE_ACCESS_KEY_ID

--- a/charts/posthog/templates/_object_storage.tpl
+++ b/charts/posthog/templates/_object_storage.tpl
@@ -18,7 +18,8 @@
 {{- if .Values.externalObjectStorage.endpoint -}}
 {{- .Values.externalObjectStorage.endpoint -}}
 {{- else if .Values.externalObjectStorage.host -}}
-{{- .Values.externalObjectStorage.host -}}:{{- .Values.externalObjectStorage.port -}}
+{{- /* NOTE: if host is specified we default to https. Use endpoint for more flexibility */ -}}
+https://{{- .Values.externalObjectStorage.host -}}:{{- .Values.externalObjectStorage.port -}}
 {{- end -}}
 {{- end -}}
 
@@ -28,7 +29,7 @@
 {{/* MINIO */}}
 {{- if .Values.minio.enabled }}
 - name: OBJECT_STORAGE_ENDPOINT
-  value: {{ include "posthog.objectStorage.fullname" . }}:{{ .Values.minio.service.ports.api }}
+  value: http://{{ include "posthog.objectStorage.fullname" . }}:{{ .Values.minio.service.ports.api }}
 - name: OBJECT_STORAGE_PORT
   value: {{ .Values.minio.service.ports.api | quote }}
 - name: OBJECT_STORAGE_BUCKET

--- a/charts/posthog/tests/object-storage-settings.yaml
+++ b/charts/posthog/tests/object-storage-settings.yaml
@@ -54,7 +54,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: OBJECT_STORAGE_ENDPOINT
-            value: RELEASE-NAME-posthog-minio:19000
+            value: http://RELEASE-NAME-posthog-minio:19000
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -88,7 +88,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: OBJECT_STORAGE_ENDPOINT
-            value: RELEASE-NAME-posthog-minio:19000
+            value: http://RELEASE-NAME-posthog-minio:19000
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -130,7 +130,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: OBJECT_STORAGE_ENDPOINT
-            value: host_name:12345
+            value: https://host_name:12345
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -163,7 +163,7 @@ tests:
     set:
       cloud: local
       externalObjectStorage:
-        endpoint: host_name:12345
+        endpoint: https://host_name:12345
         bucket: bucket_name
         existingSecret: existing_secret
     asserts:
@@ -171,7 +171,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: OBJECT_STORAGE_ENDPOINT
-            value: host_name:12345
+            value: https://host_name:12345
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/posthog/tests/object-storage-settings.yaml
+++ b/charts/posthog/tests/object-storage-settings.yaml
@@ -24,11 +24,7 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OBJECT_STORAGE_HOST
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: OBJECT_STORAGE_PORT
+            name: OBJECT_STORAGE_ENDPOINT
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
@@ -57,13 +53,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OBJECT_STORAGE_HOST
-            value: RELEASE-NAME-posthog-minio
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: OBJECT_STORAGE_PORT
-            value: "19000"
+            name: OBJECT_STORAGE_ENDPOINT
+            value: RELEASE-NAME-posthog-minio:19000
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -96,13 +87,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OBJECT_STORAGE_HOST
-            value: RELEASE-NAME-posthog-minio
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: OBJECT_STORAGE_PORT
-            value: "19000"
+            name: OBJECT_STORAGE_ENDPOINT
+            value: RELEASE-NAME-posthog-minio:19000
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -143,13 +129,49 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OBJECT_STORAGE_HOST
-            value: host_name
+            name: OBJECT_STORAGE_ENDPOINT
+            value: host_name:12345
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: OBJECT_STORAGE_PORT
-            value: "12345"
+            name: OBJECT_STORAGE_BUCKET
+            value: bucket_name
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: existing_secret
+                key: root-user
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: existing_secret
+                key: root-password
+
+  - it: should use the correct variables when `externalObjectStorage.endpoint` is configured
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/plugins-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      externalObjectStorage:
+        endpoint: host_name:12345
+        bucket: bucket_name
+        existingSecret: existing_secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_ENDPOINT
+            value: host_name:12345
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -806,9 +806,11 @@ minio:
 ## External Object Storage configuration
 ##
 externalObjectStorage:
-  # -- Host of the external object storage.
+  # -- Endpoint of the external object storage.
+  endpoint: 
+  # -- Host of the external object storage. Deprecated: use endpoint instead
   host:
-  # -- Port of the external object storage.
+  # -- Port of the external object storage. Deprecated: use endpoint instead
   port:
   # -- Bucket name to use.
   bucket:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -806,7 +806,7 @@ minio:
 ## External Object Storage configuration
 ##
 externalObjectStorage:
-  # -- Endpoint of the external object storage.
+  # -- Endpoint of the external object storage. e.g. https://s3.us-east-1.amazonaws.com
   endpoint: 
   # -- Host of the external object storage. Deprecated: use endpoint instead
   host:


### PR DESCRIPTION
Previously we were setting `OBJECT_STORAGE_HOST` and
`OBJECT_STORAGE_PORT`. However, the var we use in the app is
`OBJECT_STORAGE_ENDPOINT`. This updates to use that var.

We also offer the option to either specify `endpoint` or `host` and
`port`, for backwards compat.

I've added as a patch release. Given that this would not currently be functional, I'd suggest there is no reason to do otherwise.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
