### PR TITLE
test(object-storage): add functional external object storage test

### DIFF
--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -178,9 +178,7 @@ def apply_manifest(manifest_yaml: str):
     with tempfile.NamedTemporaryFile() as manifest_file_obj:
         manifest_file_obj.write(manifest_yaml.encode('utf-8'))
         manifest_file_obj.flush()
-        exec_subprocess(f"""
-            kubectl apply -f {manifest_file_obj.name}
-        """)
+        exec_subprocess(f"kubectl apply -f {manifest_file_obj.name}")
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -173,6 +173,17 @@ def install_custom_resources(filename, namespace="posthog"):
     log.debug("✅ Done!")
 
 
+def apply_manifest(manifest_yaml: str):
+    log.debug(f"🔄 Applying {manifest_yaml}...")
+    with tempfile.NamedTemporaryFile() as manifest_file_obj:
+        manifest_file_obj.write(manifest_yaml.encode('utf-8'))
+        manifest_file_obj.flush()
+        exec_subprocess(f"""
+            kubectl apply -f {manifest_file_obj.name}
+        """)
+    log.debug("✅ Done!")
+
+
 def exec_subprocess(cmd, ignore_errors=False):
     log.debug(f"Running: `{cmd}`")
     cmd_run = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -176,7 +176,7 @@ def install_custom_resources(filename, namespace="posthog"):
 def apply_manifest(manifest_yaml: str):
     log.debug(f"🔄 Applying {manifest_yaml}...")
     with tempfile.NamedTemporaryFile() as manifest_file_obj:
-        manifest_file_obj.write(manifest_yaml.encode('utf-8'))
+        manifest_file_obj.write(manifest_yaml.encode("utf-8"))
         manifest_file_obj.flush()
         exec_subprocess(f"kubectl apply -f {manifest_file_obj.name}")
     log.debug("✅ Done!")

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -27,17 +27,17 @@ def test_can_use_external_object_storage_with_secret_specified():
     # Use a separately installed minio as the external object storage
     exec_subprocess(
         cmd=f"""
-        helm install minio minio \
-            --debug --namespace posthog \
-            --set persistence.enabled=false \
-            --set mode=standalone \
-            --set resources.requests.memory=100Mi \
-            --set buckets[0].name=posthog \
-            --set buckets[0].policy=none \
-            --set buckets[0].purge=false \
-            --set rootUser={username} \
-            --set rootPassword={password} \
-            --repo https://charts.min.io/
+            helm install minio minio \
+                --debug --namespace posthog \
+                --set persistence.enabled=false \
+                --set mode=standalone \
+                --set resources.requests.memory=100Mi \
+                --set buckets[0].name=posthog \
+                --set buckets[0].policy=none \
+                --set buckets[0].purge=false \
+                --set rootUser={username} \
+                --set rootPassword={password} \
+                --repo https://charts.min.io/
         """
     )
 

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 import tempfile
 import pytest
 from helpers.utils import (
+    apply_manifest,
     cleanup_k8s,
     create_namespace_if_not_exists,
     exec_subprocess,
@@ -62,10 +63,3 @@ def test_can_use_external_object_storage_with_secret_specified():
 def before_each_cleanup():
     cleanup_k8s()
     create_namespace_if_not_exists()
-
-
-def apply_manifest(manifest_yaml: str):
-    with tempfile.NamedTemporaryFile() as manifest_file_obj:
-        manifest_file_obj.write(manifest_yaml.encode("utf-8"))
-        manifest_file_obj.flush()
-        return exec_subprocess(cmd=f"kubectl apply -f {manifest_file_obj.name}")

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -68,8 +68,4 @@ def apply_manifest(manifest_yaml: str):
     with tempfile.NamedTemporaryFile() as manifest_file_obj:
         manifest_file_obj.write(manifest_yaml.encode("utf-8"))
         manifest_file_obj.flush()
-        return exec_subprocess(
-            f"""
-            kubectl apply -f {manifest_file_obj.name}
-        """
-        )
+        return exec_subprocess(cmd=f"kubectl apply -f {manifest_file_obj.name}")

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -38,8 +38,9 @@ def test_can_use_external_object_storage_with_secret_specified():
             --set rootUser={username} \
             --set rootPassword={password} \
             --repo https://charts.min.io/
-    """
+        """
     )
+
     # Install PostHog with internal MinIO disabled, but configured to point to
     # separate MinIO installation.
     install_chart(

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -1,13 +1,8 @@
 from base64 import b64encode
-import tempfile
+
 import pytest
-from helpers.utils import (
-    apply_manifest,
-    cleanup_k8s,
-    create_namespace_if_not_exists,
-    exec_subprocess,
-    install_chart,
-)
+
+from helpers.utils import apply_manifest, cleanup_k8s, create_namespace_if_not_exists, exec_subprocess, install_chart
 
 
 def test_can_use_external_object_storage_with_secret_specified():

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -1,0 +1,75 @@
+from base64 import b64encode
+import tempfile
+import pytest
+from helpers.utils import (
+    cleanup_k8s,
+    create_namespace_if_not_exists,
+    exec_subprocess,
+    install_chart,
+)
+
+
+def test_can_use_external_object_storage_with_secret_specified():
+    # MinIO credentials
+    username = "some-user"
+    password = "some-password"
+
+    # Add in a secret for minio access
+    apply_manifest(
+        manifest_yaml=f"""
+            apiVersion: v1
+            kind: Secret
+            data:
+                root-user: {b64encode(username.encode()).decode()}
+                root-password: {b64encode(password.encode()).decode()}
+            metadata:
+                name: object-storage-config
+                namespace: posthog
+        """
+    )
+
+    # Use a separately installed minio as the external object storage
+    exec_subprocess(
+        cmd=f"""
+        helm install minio minio \
+            --debug --namespace posthog \
+            --set persistence.enabled=false \
+            --set mode=standalone \
+            --set resources.requests.memory=100Mi \
+            --set buckets[0].name=posthog \
+            --set buckets[0].policy=none \
+            --set buckets[0].purge=false \
+            --set rootUser={username} \
+            --set rootPassword={password} \
+            --repo https://charts.min.io/
+    """
+    )
+    # Install PostHog with internal MinIO disabled, but configured to point to
+    # separate MinIO installation.
+    install_chart(
+        values="""
+            minio:
+                enabled: false
+            externalObjectStorage:
+                endpoint: http://minio
+                bucket: posthog
+                existingSecret: object-storage-config
+        """
+    )
+
+
+@pytest.fixture(autouse=True)
+def before_each_cleanup():
+    cleanup_k8s()
+    create_namespace_if_not_exists()
+
+
+def apply_manifest(manifest_yaml: str):
+    with tempfile.NamedTemporaryFile() as manifest_file_obj:
+        manifest_file_obj.write(manifest_yaml.encode("utf-8"))
+        manifest_file_obj.flush()
+        return exec_subprocess(
+            f"""
+            kubectl apply -f {manifest_file_obj.name}
+        """
+        )


### PR DESCRIPTION
I wanted to add this one as I wanted initially to use role based auth
for access to S3, thereby not actually specifying the access key and
secret. I ended up just adding a test (and making some additions to
streaming logging in the previous PR), and just adding one where we do
specify access key and secret.

Perhaps will consider service account role later.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
