### PR TITLE
minor plugins-server cleanup

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -102,10 +102,6 @@ spec:
         {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- if .Values.plugins.ingestion.enabled }}
-        - name: PLUGIN_SERVER_INGESTION
-          value: 'true'
-        {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -18,9 +18,9 @@ spec:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      {{- if .Values.plugins.podAnnotations }}
-{{ toYaml .Values.plugins.podAnnotations | indent 8 }}
-      {{- end }}
+        {{- if .Values.plugins.podAnnotations }}
+        {{- toYaml .Values.plugins.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
@@ -29,21 +29,21 @@ spec:
         date: "{{ now | unixEpoch }}"
         {{- end }}
         {{- if .Values.plugins.podLabels }}
-{{ toYaml .Values.plugins.podLabels | indent 8 }}
+        {{- toYaml .Values.plugins.podLabels | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.plugins.affinity }}
       affinity:
-{{ toYaml .Values.plugins.affinity | indent 8 }}
+        {{- toYaml .Values.plugins.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.plugins.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.plugins.nodeSelector | indent 8 }}
+        {{- toYaml .Values.plugins.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.plugins.tolerations }}
       tolerations:
-{{ toYaml .Values.plugins.tolerations | indent 8 }}
+        {{- toYaml .Values.plugins.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.plugins.schedulerName }}
       schedulerName: "{{ .Values.plugins.schedulerName }}"
@@ -53,11 +53,11 @@ spec:
       {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+        {{- toYaml .Values.image.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- if .Values.plugins.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.plugins.podSecurityContext "enabled" | toYaml | nindent 8 }}
-      {{- end }}      
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-plugins
         image: {{ template "posthog.image.fullPath" . }}
@@ -69,16 +69,16 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
         env:
         # Kafka env variables
-        {{- include "snippet.kafka-env" . | indent 8 }}
+        {{- include "snippet.kafka-env" . | nindent 8 }}
 
         # Object Storage env variables
-        {{- include "snippet.objectstorage-env" . | indent 8 }}
+        {{- include "snippet.objectstorage-env" . | nindent 8 }}
 
         # Redis env variables
-        {{- include "snippet.redis-env" . | indent 8 }}
+        {{- include "snippet.redis-env" . | nindent 8 }}
 
         # statsd env variables
-        {{- include "snippet.statsd-env" . | indent 8 }}
+        {{- include "snippet.statsd-env" . | nindent 8 }}
 
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
@@ -99,17 +99,18 @@ spec:
         {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 8 }}
-{{- end }}
-{{- if .Values.plugins.env }}
-{{ toYaml .Values.plugins.env | indent 8 }}
-{{- end }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.env }}
+        {{- toYaml .Values.plugins.env | nindent 8 }}
+        {{- end }}
         resources:
-{{ toYaml .Values.plugins.resources | indent 12 }}
+          {{- toYaml .Values.plugins.resources | nindent 12 }}
         {{- if .Values.plugins.securityContext.enabled }}
-        securityContext: {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 12 }}
-        {{- end }}      
+        securityContext:
+          {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -93,10 +93,6 @@ spec:
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- if .Values.plugins.ingestion.enabled }}
-        - name: PLUGIN_SERVER_INGESTION
-          value: 'true'
-        {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
         {{- if .Values.env }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -124,10 +124,6 @@ spec:
         {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- if .Values.plugins.ingestion.enabled }}
-        - name: PLUGIN_SERVER_INGESTION
-          value: 'true'
-        {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -98,10 +98,6 @@ spec:
         {{- include "snippet.email-env" . | nindent 8 }}
         - name: CAPTURE_INTERNAL_METRICS
           value: {{ .Values.web.internalMetrics.capture| quote }}
-        {{- if .Values.plugins.ingestion.enabled }}
-        - name: PLUGIN_SERVER_INGESTION
-          value: 'true'
-        {{- end }}
         - name: HELM_INSTALL_INFO
           value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -172,10 +172,6 @@ plugins:
    # -- Whether to install the PostHog plugin-server stack or not.
   enabled: true
 
-  ingestion:
-    # -- Whether to enable plugin-server based ingestion
-    enabled: true
-
   # -- Count of plugin-server pods to run. This setting is ignored if `plugin-server.hpa.enabled` is set to `true`.
   replicacount: 1
 


### PR DESCRIPTION
## Description

This PR cleans up minor things about the plugins deployment:
1. Consistent style for doing indentation
2. Removing `plugins.ingestion.enabled` from the chart, which has been dead for many versions of posthog.

Using this as a baseline of following changes (optional plugin-server split)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Trusting unit tests + did a few test `helm template` runs.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
