### PR TITLE
fix(object-storage): ensure OBJECT_STORAGE_ENABLED="true"

### DIFF
--- a/charts/posthog/templates/_object_storage.tpl
+++ b/charts/posthog/templates/_object_storage.tpl
@@ -28,6 +28,8 @@ https://{{- .Values.externalObjectStorage.host -}}:{{- .Values.externalObjectSto
 
 {{/* MINIO */}}
 {{- if .Values.minio.enabled }}
+- name: OBJECT_STORAGE_ENABLED
+  value: "true"
 - name: OBJECT_STORAGE_ENDPOINT
   value: http://{{ include "posthog.objectStorage.fullname" . }}:{{ .Values.minio.service.ports.api }}
 - name: OBJECT_STORAGE_PORT
@@ -56,6 +58,8 @@ https://{{- .Values.externalObjectStorage.host -}}:{{- .Values.externalObjectSto
 
 {{/* External Object Storage */}}
 {{- else if include "posthog.externalObjectStorage.endpoint" . }}
+- name: OBJECT_STORAGE_ENABLED
+  value: "true"
 - name: OBJECT_STORAGE_ENDPOINT
   value: {{ include "posthog.externalObjectStorage.endpoint" . }}
 - name: OBJECT_STORAGE_BUCKET

--- a/charts/posthog/tests/object-storage-settings.yaml
+++ b/charts/posthog/tests/object-storage-settings.yaml
@@ -24,6 +24,10 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
+            name: OBJECT_STORAGE_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: OBJECT_STORAGE_ENDPOINT
       - notContains:
           path: spec.template.spec.containers[0].env
@@ -50,6 +54,11 @@ tests:
       cloud: local
       minio.enabled: true
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_ENABLED
+            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -84,6 +93,11 @@ tests:
       minio.enabled: true
       minio.auth.existingSecret: secret_name
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_ENABLED
+            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -129,6 +143,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: OBJECT_STORAGE_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: OBJECT_STORAGE_ENDPOINT
             value: https://host_name:12345
       - contains:
@@ -167,6 +186,11 @@ tests:
         bucket: bucket_name
         existingSecret: existing_secret
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBJECT_STORAGE_ENABLED
+            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
When MinIO or external storage is set, we also need to make sure the
OBJECT_STORAGE_ENABLED env var is set.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
