### PR TITLE
chore(plugins): add healthcheck for plugins-deployment

### DIFF
--- a/.devcontainer/setup_container.sh
+++ b/.devcontainer/setup_container.sh
@@ -42,4 +42,7 @@ EOF
 # NOTE: I've pinned the version here
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/d8c9a6c238f714587da4d2ac2dcd0d3d39419ccf/deploy/static/provider/kind/deploy.yaml
 
+# Install k9s for easy debugging https://k9scli.io/
+curl -sS https://webinstall.dev/k9s | bash
+
 echo "printf 'Hello 🦔! To install PostHog into k8s run this:\n\n "helm upgrade --install posthog charts/posthog --set cloud=private"\n'" >> ~/.zshrc

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -66,7 +66,8 @@ spec:
           - ./bin/plugin-server
           - --no-restart-loop
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+        # Expose the port on which the healtchheck endpoint listens
+        - containerPort: 6738
         env:
         # Kafka env variables
         {{- include "snippet.kafka-env" . | nindent 8 }}
@@ -114,8 +115,8 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.plugins.readinessProbe.failureThreshold }}
           httpGet:
-            path: /_health/
-            port: {{ .Values.service.internalPort }}
+            path: /_health
+            port: 6738
             scheme: HTTP
           initialDelaySeconds: {{ .Values.plugins.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.plugins.readinessProbe.periodSeconds }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -101,6 +101,16 @@ spec:
         {{- if .Values.plugins.env }}
         {{- toYaml .Values.plugins.env | nindent 8 }}
         {{- end }}
+        readinessProbe:
+          failureThreshold: {{ .Values.plugins.readinessProbe.failureThreshold }}
+          httpGet:
+            path: /_health/
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.plugins.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.plugins.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.plugins.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.plugins.readinessProbe.timeoutSeconds }}
         resources:
           {{- toYaml .Values.plugins.resources | nindent 12 }}
         {{- if .Values.plugins.securityContext.enabled }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -101,6 +101,16 @@ spec:
         {{- if .Values.plugins.env }}
         {{- toYaml .Values.plugins.env | nindent 8 }}
         {{- end }}
+        livenessProbe:
+          exec:
+            command:
+              # Just check that we can at least exec to the container
+              - "true"
+          failureThreshold: {{ .Values.plugins.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.plugins.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.plugins.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.plugins.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.plugins.livenessProbe.timeoutSeconds }}
         readinessProbe:
           failureThreshold: {{ .Values.plugins.readinessProbe.failureThreshold }}
           httpGet:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -206,13 +206,25 @@ plugins:
   podSecurityContext:
     enabled: false
 
+  livenessProbe:
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 10
+    # -- The liveness probe period seconds
+    periodSeconds: 10
+    # -- The liveness probe success threshold
+    successThreshold: 1
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 2
+
   readinessProbe:
     # -- The readiness probe failure threshold
-    failureThreshold: 6
+    failureThreshold: 3
     # -- The readiness probe initial delay seconds
     initialDelaySeconds: 50
     # -- The readiness probe period seconds
-    periodSeconds: 10
+    periodSeconds: 30
     # -- The readiness probe success threshold
     successThreshold: 1
     # -- The readiness probe timeout seconds

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -206,6 +206,18 @@ plugins:
   podSecurityContext:
     enabled: false
 
+  readinessProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 6
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 50
+    # -- The readiness probe period seconds
+    periodSeconds: 10
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 5
+
 email:
   # -- SMTP service host.
   host:

--- a/ci/kubetest/test_kafka_external.py
+++ b/ci/kubetest/test_kafka_external.py
@@ -14,8 +14,7 @@ cloud: local
 
 externalKafka:
   brokers:
-    - "kafka0:9092"
-    - "kafka1:9092"
+    - "kafka-headless:9092"
 
 #
 # For the purpose of this test, let's disable service persistence


### PR DESCRIPTION
Previously we didn't have one. It's also worth noting that some
kubetests pass atm but only because pods are temporarily marked as ready
due to a lack of a probe. These will need fixing.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
