### PR TITLE
Remove the `KAFKA_ENABLED` setting

### DIFF
--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -29,8 +29,6 @@
 {{- $hostWithPrefix := (printf "kafka://%s" $host) }}
 {{- $hostsWithPrefix = append $hostsWithPrefix $hostWithPrefix }}
 {{- end }}
-- name: KAFKA_ENABLED
-  value: "true"
 # Used by PostHog/plugin-server. There is no specific reason for the difference. Expected format: comma-separated list of "host:port"
 - name: KAFKA_HOSTS
 {{- if .Values.kafka.enabled }}

--- a/charts/posthog/tests/kafka-settings.yaml
+++ b/charts/posthog/tests/kafka-settings.yaml
@@ -22,11 +22,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: KAFKA_ENABLED
-            value: "true"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: KAFKA_HOSTS
             value: RELEASE-NAME-posthog-kafka:9092
       - contains:
@@ -51,11 +46,6 @@ tests:
           - "broker1:port1"
           - "broker2:port2"
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: KAFKA_ENABLED
-            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -84,11 +74,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: KAFKA_ENABLED
-            value: "true"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: KAFKA_HOSTS
             value: "broker1:port1"
       - contains:
@@ -112,11 +97,6 @@ tests:
           - broker1:port1
           - broker2:port2
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: KAFKA_ENABLED
-            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
## Description

`KAFKA_ENABLED` has been true by default for a couple of weeks, but now it's being [removed completely](https://github.com/PostHog/posthog/pull/10059).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor