### PR TITLE
CI - bump 'e2e - k6 ingestion test' to 60m

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -6,7 +6,7 @@ on:
     paths:
       - ci/**
       - charts/**
-      - .github/workflows/test-helm-chart.yaml
+      - .github/workflows/test-k6.yaml
 
 jobs:
   test-chart:

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-chart:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       # Keep running even if one variation of the job fail


### PR DESCRIPTION
## Description
Bump the `e2e - k6 ingestion test` CI test timeout from 30 to 60m. 

## Why?
I'm debugging a flaky test and I can't reproduce the issue outside GitHub Actions. I have the feeling this might be a silly timeout that is only visible now after we added the plugin-server healthcheck & deployed the new build (that contains more migrations).  

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is still ❌ but I think it's worth merging this anyway a we can now see the error.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
