### PR TITLE
add support for kubernetes 1.24

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -21,6 +21,8 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
+          - k3s-channel: v1.24
+            test: install
           - k3s-channel: v1.23
             test: install
           - k3s-channel: v1.22

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">= 1.20-0 <= 1.23-0"
+kubeVersion: ">= 1.20-0 <= 1.24-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -20,7 +20,7 @@ This Helm chart bootstraps a [PostHog](https://posthog.com/) installation on a [
 
 
 ## Prerequisites
-- Kubernetes >=1.20 <= 1.23
+- Kubernetes >=1.20 <= 1.24
 - Helm >= 3.7.0
 
 ## Installation


### PR DESCRIPTION
## Description
We can no longer template the posthog helm chart as our kubernetes version passed that of the support release. Bumping kubernetes support to 1.24



