### PR TITLE
Revert "Add CLICKHOUSE_PORT as option for externalClickhouse configs"

### DIFF
--- a/charts/posthog/templates/_clickhouse.tpl
+++ b/charts/posthog/templates/_clickhouse.tpl
@@ -18,8 +18,6 @@
 {{- else -}}
 - name: CLICKHOUSE_HOST
   value: {{ required "externalClickhouse.host is required if not clickhouse.enabled" .Values.externalClickhouse.host | quote }}
-- name: CLICKHOUSE_PORT
-  value: {{ .Values.externalClickhouse.port | quote }}
 - name: CLICKHOUSE_CLUSTER
   value: {{ required "externalClickhouse.cluster is required if not clickhouse.enabled" .Values.externalClickhouse.cluster | quote }}
 - name: CLICKHOUSE_DATABASE

--- a/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/_clickhouse.tpl.yaml.snap
@@ -34,8 +34,6 @@ should render with external clickhouse:
   1: |
     - name: CLICKHOUSE_HOST
       value: foo.bar.net
-    - name: CLICKHOUSE_PORT
-      value: "9000"
     - name: CLICKHOUSE_CLUSTER
       value: somecluster
     - name: CLICKHOUSE_DATABASE
@@ -52,8 +50,6 @@ should render with external clickhouse with more custom settings:
   1: |
     - name: CLICKHOUSE_HOST
       value: foo.bar.net
-    - name: CLICKHOUSE_PORT
-      value: "9000"
     - name: CLICKHOUSE_CLUSTER
       value: customCluster
     - name: CLICKHOUSE_DATABASE
@@ -70,8 +66,6 @@ should render with external clickhouse with secrets:
   1: |
     - name: CLICKHOUSE_HOST
       value: foo.bar.net
-    - name: CLICKHOUSE_PORT
-      value: "9000"
     - name: CLICKHOUSE_CLUSTER
       value: somecluster
     - name: CLICKHOUSE_DATABASE

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -737,8 +737,6 @@ clickhouse:
 externalClickhouse:
   # -- Host of the external cluster. This is required when clickhouse.enabled is false
   host:
-  # -- Port of the external cluster. 
-  port: 9000
   # -- Name of the external cluster to run DDL queries on. This is required when clickhouse.enabled is false
   cluster:
   # -- Database name for the external cluster


### PR DESCRIPTION
Reverts PostHog/charts-clickhouse#415

Over-eagerly merged the previous one - app side needs work for this to be a thing sadly. We might also need to expose multiple ports and cannot default to only 9000 due to security.