### PR TITLE
chore(k8s): remove 1.20 support, add 1.24

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -21,13 +21,13 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
+          - k3s-channel: testing # v1.24 not released yet as channel https://update.k3s.io/v1-release/channels
+            test: install
           - k3s-channel: v1.23
             test: install
           - k3s-channel: v1.22
             test: install
           - k3s-channel: v1.21
-            test: install
-          - k3s-channel: v1.20
             test: install
 
           # We run an upgrade test where we first install an already released
@@ -36,17 +36,13 @@ jobs:
           #
           # It can be very useful to see the "Helm diff" step's output from the
           # latest dev version.
-          - k3s-channel: v1.21
+          - k3s-channel: v1.22
             test: upgrade
 
     steps:
       - uses: actions/checkout@v2
 
-      # Starts a k8s cluster with NetworkPolicy enforcement and installs both
-      # kubectl and helm
-      #
-      # ref: https://github.com/jupyterhub/action-k3s-helm/
-      - uses: jupyterhub/action-k3s-helm@v1
+      - uses: jupyterhub/action-k3s-helm@v2
         with:
           k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">= 1.20-0 <= 1.23-0"
+kubeVersion: ">= 1.21-0 <= 1.24-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -20,7 +20,7 @@ This Helm chart bootstraps a [PostHog](https://posthog.com/) installation on a [
 
 
 ## Prerequisites
-- Kubernetes >=1.20 <= 1.23
+- Kubernetes >=1.21 <= 1.24
 - Helm >= 3.7.0
 
 ## Installation


### PR DESCRIPTION
## Description

* bump GH action `jupyterhub/action-k3s-helm`
* remove support for k8s version 1.20
* add support for k8s version 1.24

Similar to https://github.com/PostHog/charts-clickhouse/pull/399 and https://github.com/PostHog/charts-clickhouse/pull/406. Closes #407.

Website changes are available at: https://github.com/PostHog/posthog.com/pull/3542

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ (with the exception of the k3s upgrade test that is also broken on `main` and currently under investigation by the PostHog ingestion team). 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
