### PR TITLE
CI - upgrade test to bitnami/kafka v14.9.3

### DIFF
--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -212,7 +212,7 @@ def install_external_kafka(namespace="posthog"):
           helm upgrade --install \
             --namespace {namespace} \
             kafka bitnami/kafka \
-            --version "12.6.0" \
+            --version "14.9.3" \
             --set zookeeper.enabled=true \
             --set replicaCount=2
         """.format(


### PR DESCRIPTION
## Description
This PR upgrades the `bitnami/kafka` used by the `kubetest` test `test_kafka_external.py::test_helm_install` from version `12.6.0` to `14.9.3`. We are doing this to align the Kafka version in use as in the future we might enforce a min version in PostHog. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ (with the exception of the upgrade test, that is broken also on `main`)

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
