### PR TITLE
chore(CI): use k8s version 1.22 as default

### DIFF
--- a/.github/disabled-test-digitalocean-1-click-install.yaml
+++ b/.github/disabled-test-digitalocean-1-click-install.yaml
@@ -26,7 +26,7 @@
 #     steps:
 
 #     - name: Checkout
-#       uses: actions/checkout@v2
+#       uses: actions/checkout@v3
 
 #     - name: Install doctl
 #       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/bump-version-workflow-dispatch.yaml
+++ b/.github/workflows/bump-version-workflow-dispatch.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ jobs:
         )
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Codespell
         uses: codespell-project/actions-codespell@master

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -73,7 +73,7 @@ jobs:
           --zones="us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
           --instance-types="t3a.medium" \
           --tags="provisioned_by=github_action" \
-          --version 1.21 \
+          --version 1.22 \
           --nodes 3
 
         # WORKAROUND: the latest eksctl release (at the time of writing 0.98.0)

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -39,7 +39,7 @@ jobs:
       id: k8s_cluster_creation
       run: |
         # Get the DO K8 version slug
-        DO_K8S_VERSION=$(doctl k8s options versions -ojson | jq --raw-output 'first(.[] | select(.slug | test("^1.21.[0-9]+-do.[0-9]+$")) | .slug)')
+        DO_K8S_VERSION=$(doctl k8s options versions -ojson | jq --raw-output 'first(.[] | select(.slug | test("^1.22.[0-9]+-do.[0-9]+$")) | .slug)')
 
         doctl k8s clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install doctl to manage 'posthog.cc' DNS
       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -69,7 +69,7 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --project ${{ secrets.GCP_PROJECT_ID }} \
           --region us-central1 \
-          --cluster-version 1.21 \
+          --cluster-version 1.22 \
           --labels="provisioned_by=github_action" \
           --machine-type e2-small \
           --num-nodes 2

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -40,7 +40,7 @@ jobs:
             test: upgrade
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: jupyterhub/action-k3s-helm@v2
         with:
@@ -48,7 +48,7 @@ jobs:
           metrics-enabled: false
           traefik-enabled: false
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'
         with:
           ref: main

--- a/.github/workflows/test-kubetest-store-durations.yaml
+++ b/.github/workflows/test-kubetest-store-durations.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 3600
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
 
       - uses: jupyterhub/action-k3s-helm@v2

--- a/.github/workflows/test-kubetest-store-durations.yaml
+++ b/.github/workflows/test-kubetest-store-durations.yaml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout
 
-      - uses: jupyterhub/action-k3s-helm@v1
+      - uses: jupyterhub/action-k3s-helm@v2
         with:
-          k3s-channel: v1.21
+          k3s-channel: v1.22
           metrics-enabled: false
           traefik-enabled: false
 

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -22,7 +22,7 @@ jobs:
             group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
 
       - uses: jupyterhub/action-k3s-helm@v2

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -25,9 +25,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout
 
-      - uses: jupyterhub/action-k3s-helm@v1
+      - uses: jupyterhub/action-k3s-helm@v2
         with:
-          k3s-channel: v1.21
+          k3s-channel: v1.22
           metrics-enabled: false
           traefik-enabled: false
 

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -36,7 +36,6 @@ jobs:
           python -m pip install -r ci/kubetest/requirements.txt
 
       - name: Run kubetest
-        timeout-minutes: 60
         run: |
           cd ci/kubetest && \
           python -m pytest . -s \

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -36,6 +36,7 @@ jobs:
           python -m pip install -r ci/kubetest/requirements.txt
 
       - name: Run kubetest
+        timeout-minutes: 60
         run: |
           cd ci/kubetest && \
           python -m pytest . -s \

--- a/.github/workflows/test-lint-eslint.yaml
+++ b/.github/workflows/test-lint-eslint.yaml
@@ -14,7 +14,7 @@ jobs:
   eslint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install modules
         run: yarn
       - name: Run ESLint

--- a/.github/workflows/test-lint-github-worklows.yaml
+++ b/.github/workflows/test-lint-github-worklows.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download actionlint
         env:

--- a/.github/workflows/test-lint-helm.yaml
+++ b/.github/workflows/test-lint-helm.yaml
@@ -14,5 +14,5 @@ jobs:
       matrix:
         cloud: ["aws", "azure", "do", "gcp", "other"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: helm lint --strict --set "cloud=${{ matrix.cloud }}" charts/posthog

--- a/.github/workflows/test-lint-kubetest.yaml
+++ b/.github/workflows/test-lint-kubetest.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test-unit-helm.yaml
+++ b/.github/workflows/test-unit-helm.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Helm unittest plugin
         run: |

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run helm-docs
         run: |
@@ -22,6 +22,6 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
             author_name: Max Hedgehog
-            author_email: max.hedgehog@posthog.com 
+            author_email: max.hedgehog@posthog.com
             branch: ${{ github.event.pull_request.base.ref }}
             message: 'Regenerate chart ALL_VALUES.md'


### PR DESCRIPTION
## Description
Since we've now added the support for k8s version 1.24, let's bump the Kubernetes version for e2e CI tests to 1.22.

I also took the opportunity to bump some GH action version.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ (with the exception of the upgrade test that is currently under 🔍 by the ingestion team)

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
