### PR TITLE
Include site url in plugins deployment

### DIFF
--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -81,6 +81,8 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | nindent 8 }}
 
+        - name: SITE_URL
+          value: {{ template "posthog.site.url" . }}
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: DEPLOYMENT


### PR DESCRIPTION
## Description

In a random [github thread I noticed](https://github.com/PostHog/posthog/pull/10197#discussion_r894427126) that SITE_URL is not set for plugins deployment. This fixes it. cc @benjackwhite 

Note SITE_URL is set in other deployments (events, web, worker).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Nope.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
