### PR TITLE
chore: remove unique-name secret

### DIFF
--- a/charts/posthog/templates/secrets.yaml
+++ b/charts/posthog/templates/secrets.yaml
@@ -17,16 +17,3 @@ data:
   {{- if not .Values.email.existingSecret }}
   smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
   {{- end }}
-
-  {{- if $previous }}
-  # :TRICKY: Raise an error if trying to apply the incorrect values file for clients we manage under client_values/
-  {{- $prevUniqueName := b64dec (default "" (index $previous.data "unique-name")) }}
-  {{- $uniqueName := default "" .Values.uniqueName }}
-  {{- if and (ne $uniqueName $prevUniqueName) (ne $prevUniqueName "") }}
-  {{ fail "uniqueName does not match expected! Are you using the wrong values.yaml?" }}
-  {{- end }}
-  {{- end }}
-
-  {{- if .Values.uniqueName }}
-  unique-name: {{ .Values.uniqueName | b64enc | quote }}
-  {{- end }}


### PR DESCRIPTION
It doesn't appear to be being used.

As a result of adding the ability to specify your own `SECRET_KEY` via
`posthogSecretKey.existingKey` it is now the case that if you also set
`email.existingKey` your'll end up with `data == null` within the
`posthog` secret. This causes issues with the evaluation of `index
$previous.data 'unique-name'`

Rather than resolving this, I've opted for removal due to it not being
used.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
