### PR TITLE
CI - bump wait time for 'wait_for_pods_to_be_ready'

### DIFF
--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -3,13 +3,13 @@ import { check } from 'k6'
 import { Counter } from 'k6/metrics'
 import { URL } from './lib/url_1_0_0.js'
 import { describe } from './lib/expect_0_0_5.js';
-import { isPrivateIP }  from './utils.js'
+import { isPrivateIP } from './utils.js'
 import {
-    POSTHOG_API_ENDPOINT,
-    POSTHOG_EVENT_ENDPOINT,
-    SKIP_SOURCE_IP_ADDRESS_CHECK,
-    checkPrerequisites
-  } from './common.js';
+  POSTHOG_API_ENDPOINT,
+  POSTHOG_EVENT_ENDPOINT,
+  SKIP_SOURCE_IP_ADDRESS_CHECK,
+  checkPrerequisites
+} from './common.js';
 
 
 checkPrerequisites();
@@ -30,7 +30,7 @@ export let options = {
       executor: 'per-vu-iterations',
       vus: 1,           // Number of VUs to run concurrently.
       iterations: 1,    // only run a single iteration after generateEvents() completes
-      startTime: '40s',  // duration + gracefulStop of the above
+      startTime: '100s',  // duration + gracefulStop of the above + 1m
     },
   },
   thresholds: {
@@ -92,9 +92,9 @@ export function checkEvents() {
       var random_event = res.json()["results"].pop()
       var source_ip = random_event["properties"]["$ip"]
 
-      t.expect(! isPrivateIP(source_ip))
-      .as(`The source IP address of a random ingested event (${source_ip}) is not part of a private range`)
-      .toEqual(true)
+      t.expect(!isPrivateIP(source_ip))
+        .as(`The source IP address of a random ingested event (${source_ip}) is not part of a private range`)
+        .toEqual(true)
     })
     failedTestCases.add(success === false);
   }

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -122,7 +122,7 @@ def wait_for_pods_to_be_ready(kube, labels={}, expected_count=None):
     log.debug("🔄 Waiting for all pods to be ready...")
     time.sleep(30)
     start = time.time()
-    timeout = 60
+    timeout = 300
     while time.time() < start + timeout:
         pods = kube.get_pods(namespace="posthog", labels=labels)
 

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -88,15 +88,11 @@ def test_can_connect_from_web_pod(kube):
     install_chart(VALUES_ACCESS_CLICKHOUSE)
     wait_for_pods_to_be_ready(kube)
 
-    verify_can_connect_to_clickhouse(kube)
-
 
 def test_can_connect_external_clickhouse_via_password(kube):
     setup_external_clickhouse()
     install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD)
     wait_for_pods_to_be_ready(kube)
-
-    verify_can_connect_to_clickhouse(kube)
 
 
 def test_can_connect_external_clickhouse_via_secret(kube):
@@ -105,30 +101,10 @@ def test_can_connect_external_clickhouse_via_secret(kube):
     install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET)
     wait_for_pods_to_be_ready(kube)
 
-    verify_can_connect_to_clickhouse(kube)
-
 
 def setup_external_clickhouse():
     # :TRICKY: We can't use a single docker image since posthog relies on clickhouse being installed in a cluster
     install_chart(VALUES_EXTERNAL_CLICKHOUSE, namespace="clickhouse")
-
-
-def verify_can_connect_to_clickhouse(kube):
-    "Checks whether clickhouse is connectable from the web pod"
-    pods = kube.get_pods(namespace=NAMESPACE, labels={"role": "web"})
-    pod = list(pods.values())[0]
-
-    command = " ".join(
-        [
-            f"kubectl exec --stdin --tty {pod.name} -n posthog",
-            "--",
-            "python manage.py shell_plus -c",
-            "\"print('connection check success', sync_execute('select count() from events')[0][0])\"",
-        ]
-    )
-
-    # This command will exit with an error code if clickhouse is not connectable
-    exec_subprocess(command)
 
 
 @pytest.fixture(autouse=True)

--- a/ci/kubetest/test_postgresql_connectivity.py
+++ b/ci/kubetest/test_postgresql_connectivity.py
@@ -79,17 +79,6 @@ def test_can_connect_from_web_pod(values, resources_to_install, kube):
     install_chart(values)
     wait_for_pods_to_be_ready(kube)
 
-    verify_can_connect_to_postgresql(kube)
-
-
-def verify_can_connect_to_postgresql(kube):
-    pods = kube.get_pods(namespace=NAMESPACE, labels={"role": "web"})
-    pod = list(pods.values())[0]
-    # _preflight endpoint returns the status of most of our services
-    preflight_response = pod.http_proxy_get("/_preflight").json()
-
-    assert preflight_response["db"], f"Web pod couldn't connect to postgresql, preflight response: {preflight_response}"
-
 
 @pytest.fixture(autouse=True)
 def before_each_cleanup():


### PR DESCRIPTION
## Description
1️⃣ `wait_for_pods_to_be_ready`: we currently wait for a minute while due to suboptimal readiness and liveness check config, we might have to wait more. 

2️⃣ This PR also removes the manual ClickHouse and PostgreSQL checks (done via executing a query from the web pod & by inspecting the output of a specific PostHog HTTP endpoint). We can remove those checks as we can directly rely on the application health checks already exposed to Kubernetes. This removes a layer of complexity and possible issues.

3️⃣ I'm also extending the `ci/k6/ingestion-test.js` wait time between sending and counting the number of events as it seems from CI that the overall processing of events got slower in the new release and we might need to account for that.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
