### PR TITLE
CI - remove CI run duplication

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -3,11 +3,13 @@ name: e2e - k6 ingestion test
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - ci/**
       - charts/**
       - .github/workflows/test-k6.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   test-chart:
@@ -130,3 +132,8 @@ jobs:
         if: always()
         with:
           namespace: posthog
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -132,8 +132,3 @@ jobs:
         if: always()
         with:
           namespace: posthog
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -52,8 +52,3 @@ jobs:
         if: always()
         with:
           namespace: posthog
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -3,11 +3,13 @@ name: e2e - kubetest
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - ci/**
       - charts/**
       - .github/workflows/test-kubetest.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   test-kubetest:
@@ -50,3 +52,8 @@ jobs:
         if: always()
         with:
           namespace: posthog
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-lint-eslint.yaml
+++ b/.github/workflows/test-lint-eslint.yaml
@@ -22,8 +22,3 @@ jobs:
         run: yarn
       - name: Run ESLint
         run: yarn run eslint . --ext .js,.jsx,.ts,.tsx
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-lint-eslint.yaml
+++ b/.github/workflows/test-lint-eslint.yaml
@@ -3,13 +3,15 @@ name: Lint test
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - '**.js'
       - '**.jsx'
       - '**.ts'
       - '**.tsx'
       - .github/workflows/test-lint-eslint.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   eslint:
@@ -20,3 +22,8 @@ jobs:
         run: yarn
       - name: Run ESLint
         run: yarn run eslint . --ext .js,.jsx,.ts,.tsx
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-lint-github-worklows.yaml
+++ b/.github/workflows/test-lint-github-worklows.yaml
@@ -24,8 +24,3 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color -ignore shellcheck
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-lint-github-worklows.yaml
+++ b/.github/workflows/test-lint-github-worklows.yaml
@@ -3,9 +3,11 @@ name: Lint test
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - .github/workflows/**
+  push:
+    branches:
+      - main
 
 jobs:
   github-workflows-lint:
@@ -22,3 +24,8 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color -ignore shellcheck
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-lint-helm.yaml
+++ b/.github/workflows/test-lint-helm.yaml
@@ -19,8 +19,3 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: helm lint --strict --set "cloud=${{ matrix.cloud }}" charts/posthog
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-lint-helm.yaml
+++ b/.github/workflows/test-lint-helm.yaml
@@ -3,10 +3,12 @@ name: Lint test
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - charts/**
       - .github/workflows/test-lint-helm.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   helm-lint:
@@ -17,3 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: helm lint --strict --set "cloud=${{ matrix.cloud }}" charts/posthog
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-lint-kubetest.yaml
+++ b/.github/workflows/test-lint-kubetest.yaml
@@ -3,10 +3,12 @@ name: Lint test
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - 'ci/kubetest/**'
       - .github/workflows/test-lint-flake8.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   kubetest:
@@ -27,3 +29,8 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 --config ci/kubetest/.flake8 ci/kubetest
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-lint-kubetest.yaml
+++ b/.github/workflows/test-lint-kubetest.yaml
@@ -29,8 +29,3 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 --config ci/kubetest/.flake8 ci/kubetest
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true

--- a/.github/workflows/test-unit-helm.yaml
+++ b/.github/workflows/test-unit-helm.yaml
@@ -3,11 +3,13 @@ name: Unit tests
 on:
   workflow_dispatch:
   pull_request:
-  push:
     paths:
       - charts/**
       - ct.yaml
       - .github/workflows/test-unit-helm.yaml
+  push:
+    branches:
+      - main
 
 jobs:
   helm-unittest:
@@ -24,3 +26,8 @@ jobs:
 
       - name: Run test suite
         run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog
+
+    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/test-unit-helm.yaml
+++ b/.github/workflows/test-unit-helm.yaml
@@ -26,8 +26,3 @@ jobs:
 
       - name: Run test suite
         run: helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog
-
-    # Cancel pending and in-progress runs of this workflow if a newer ref is pushed to CI.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true


### PR DESCRIPTION
## Description
We should run those workflows during PR actions (open, sync, re-open) as well as when they get merged into `main`

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should not have duplicate tests anymore

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
