### PR TITLE
Plugin server split

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -132,3 +132,4 @@ jobs:
         if: always()
         with:
           namespace: posthog
+          important-workloads: deployments/posthog-plugins

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -26,12 +26,16 @@ jobs:
         include:
           - k3s-channel: testing # v1.24 not released yet as channel https://update.k3s.io/v1-release/channels
             test: install
+            values: ci/values/k3s.yaml
           - k3s-channel: v1.23
             test: install
+            values: ci/values/k3s.yaml
           - k3s-channel: v1.22
             test: install
+            values: ci/values/k3s.yaml
           - k3s-channel: v1.21
             test: install
+            values: ci/values/k3s.yaml
 
           # We run an upgrade test where we first install an already released
           # Helm chart version and then upgrade to the version we are now
@@ -41,6 +45,12 @@ jobs:
           # latest dev version.
           - k3s-channel: v1.22
             test: upgrade
+            values: ci/k3s.yaml
+
+          # We run one install test with split plugin-server ingestion
+          - k3s-channel: v1.22
+            test: install
+            values: ci/values/k3s-plugin-server-split.yaml
 
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +70,7 @@ jobs:
       - name: (Upgrade) Install our helm chart from main branch
         if: matrix.test == 'upgrade'
         run: |
-          helm upgrade --install -f ci/values/k3s.yaml --timeout 30m --create-namespace --namespace posthog posthog ./main/charts/posthog --wait --wait-for-jobs --debug
+          helm upgrade --install -f ${{ matrix.values }} --timeout 30m --create-namespace --namespace posthog posthog ./main/charts/posthog --wait --wait-for-jobs --debug
 
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
@@ -70,7 +80,7 @@ jobs:
       - name: "(Upgrade) Helm diff - 'main' branch VS local version"
         if: matrix.test == 'upgrade'
         run: |
-          helm diff upgrade --install -f ci/values/k3s.yaml --namespace posthog posthog ./charts/posthog --debug
+          helm diff upgrade --install -f ${{ matrix.values }} --namespace posthog posthog ./charts/posthog --debug
 
       - name: "(Upgrade) Await chart install"
         if: matrix.test == 'upgrade'
@@ -82,7 +92,7 @@ jobs:
 
       - name: Install our helm chart
         run: |
-          helm upgrade --debug --install -f ci/values/k3s.yaml --timeout 30m --create-namespace --namespace posthog posthog ./charts/posthog --wait --wait-for-jobs --debug
+          helm upgrade --debug --install -f ${{ matrix.values }} --timeout 30m --create-namespace --namespace posthog posthog ./charts/posthog --wait --wait-for-jobs --debug
 
       #
       # Wait for all k8s resources to be ready.

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -45,7 +45,7 @@ jobs:
           # latest dev version.
           - k3s-channel: v1.22
             test: upgrade
-            values: ci/k3s.yaml
+            values: ci/values/k3s.yaml
 
           # We run one install test with split plugin-server ingestion
           - k3s-channel: v1.22

--- a/charts/posthog/templates/_snippet-error-on-invalid-values.tpl
+++ b/charts/posthog/templates/_snippet-error-on-invalid-values.tpl
@@ -4,75 +4,75 @@
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "externalPostgresql.postgresqlHost cannot be set if postgresql.enabled is true" ""
     ) nil -}}
-  
+
   {{- else if and .Values.redis.enabled .Values.externalRedis.host }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "externalRedis.host cannot be set if redis.enabled is true" ""
     ) nil -}}
-  
+
   {{- else if and .Values.kafka.enabled .Values.externalKafka.brokers }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "externalKafka.brokers cannot be set if kafka.enabled is true" ""
     ) nil -}}
-  
+
   {{- else if and .Values.clickhouse.enabled .Values.externalClickhouse.host }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "externalClickhouse.host cannot be set if clickhouse.enabled is true" ""
     ) nil -}}
-  
+
   {{- else if and .Values.clickhouse.enabled .Values.externalClickhouse.cluster }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "externalClickhouse.cluster cannot be set if clickhouse.enabled is true" ""
     ) nil -}}
-  
+
   {{- else if .Values.certManager }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "certManager value has been renamed to cert-manager"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-3xx"
     ) nil -}}
-  
+
   {{- else if .Values.beat }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "beat deployment has been removed"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-7xx"
     ) nil -}}
-  
+
   {{- else if .Values.clickhouseOperator }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "clickhouseOperator values are no longer valid"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-9xx"
     ) nil -}}
-  
+
   {{- else if or .Values.redis.port .Values.redis.host .Values.redis.password }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "redis.port, redis.host and redis.password are no longer valid"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-11xx"
     ) nil -}}
-  
+
   {{- else if .Values.clickhouse.host }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "clickhouse.host has been moved to externalClickhouse.host"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
     ) nil -}}
-  
+
   {{- else if .Values.clickhouse.replication }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "clickhouse.replication has been removed"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-12xx"
     ) nil -}}
-  
+
   {{- else if .Values.postgresql.postgresqlHost }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "postgresql.postgresqlHost has been moved to externalPostgresql.postgresqlHost"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
     ) nil -}}
-  
+
   {{- else if .Values.postgresql.postgresqlPort }}
     {{- required (printf (include "snippet.error-on-invalid-values-template" .)
       "postgresql.postgresqlPort has been moved to externalPostgresql.postgresqlPort"
       "https://posthog.com/docs/self-host/deploy/upgrade-notes#upgrading-from-13xx"
     ) nil -}}
-  
+
   {{- else if .Values.postgresql.postgresqlUsername }}
     {{- if ne .Values.postgresql.postgresqlUsername "postgres" }}
       {{- required (printf (include "snippet.error-on-invalid-values-template" .)
@@ -85,6 +85,12 @@
       {{- required (printf (include "snippet.error-on-invalid-values-template" .)
         "clickhouse.useNodeSelector has been removed"
         "please use the clickhouse.nodeSelector variable instead"
+      ) nil -}}
+    {{- end -}}
+
+    {{- if and .Values.pluginsAsync.enabled (not .Values.plugins.enabled) }}
+      {{- required (printf (include "snippet.error-on-invalid-values-template" .)
+        "pluginsAsync.enabled cannot be set if plugins.enabled is false" ""
       ) nil -}}
     {{- end -}}
   {{- end -}}

--- a/charts/posthog/templates/plugins-async-deployment.yaml
+++ b/charts/posthog/templates/plugins-async-deployment.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.plugins.enabled -}}
-# Keep this in sync with `pluginsAsync-deployment.yaml`
+{{- if .Values.pluginsAsync.enabled -}}
+# Keep this in sync with `plugins-deployment.yaml`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "posthog.fullname" . }}-plugins
+  name: {{ template "posthog.fullname" . }}-pluginsAsync
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
@@ -11,56 +11,56 @@ spec:
     matchLabels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: plugins
-  {{- if not .Values.plugins.hpa.enabled }}
-  replicas: {{ .Values.plugins.replicacount }}
+        role: pluginsAsync
+  {{- if not .Values.pluginsAsync.hpa.enabled }}
+  replicas: {{ .Values.pluginsAsync.replicacount }}
   {{- end }}
   template:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- if .Values.plugins.podAnnotations }}
-        {{- toYaml .Values.plugins.podAnnotations | nindent 8 }}
+        {{- if .Values.pluginsAsync.podAnnotations }}
+        {{- toYaml .Values.pluginsAsync.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: plugins
+        role: pluginsAsync
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
-        {{- if .Values.plugins.podLabels }}
-        {{- toYaml .Values.plugins.podLabels | nindent 8 }}
+        {{- if .Values.pluginsAsync.podLabels }}
+        {{- toYaml .Values.pluginsAsync.podLabels | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
-      {{- if .Values.plugins.affinity }}
+      {{- if .Values.pluginsAsync.affinity }}
       affinity:
-        {{- toYaml .Values.plugins.affinity | nindent 8 }}
+        {{- toYaml .Values.pluginsAsync.affinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.plugins.nodeSelector }}
+      {{- if .Values.pluginsAsync.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.plugins.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.pluginsAsync.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.plugins.tolerations }}
+      {{- if .Values.pluginsAsync.tolerations }}
       tolerations:
-        {{- toYaml .Values.plugins.tolerations | nindent 8 }}
+        {{- toYaml .Values.pluginsAsync.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.plugins.schedulerName }}
-      schedulerName: "{{ .Values.plugins.schedulerName }}"
+      {{- if .Values.pluginsAsync.schedulerName }}
+      schedulerName: "{{ .Values.pluginsAsync.schedulerName }}"
       {{- end }}
-      {{- if .Values.plugins.priorityClassName }}
-      priorityClassName: "{{ .Values.plugins.priorityClassName }}"
+      {{- if .Values.pluginsAsync.priorityClassName }}
+      priorityClassName: "{{ .Values.pluginsAsync.priorityClassName }}"
       {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- if .Values.plugins.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.plugins.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.pluginsAsync.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.pluginsAsync.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-plugins
+      - name: {{ .Chart.Name }}-pluginsAsync
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
@@ -70,10 +70,8 @@ spec:
         # Expose the port on which the healtchheck endpoint listens
         - containerPort: 6738
         env:
-        {{- if .Values.pluginsAsync.enabled }}
         - name: PLUGIN_SERVER_MODE
-          value: "ingestion"
-        {{- end }}
+          value: "async"
         # Kafka env variables
         {{- include "snippet.kafka-env" . | nindent 8 }}
 
@@ -86,8 +84,6 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | nindent 8 }}
 
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
         - name: SENTRY_DSN
           value: {{ .Values.sentryDSN | quote }}
         - name: DEPLOYMENT
@@ -102,34 +98,34 @@ spec:
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- end }}
-        {{- if .Values.plugins.env }}
-        {{- toYaml .Values.plugins.env | nindent 8 }}
+        {{- if .Values.pluginsAsync.env }}
+        {{- toYaml .Values.pluginsAsync.env | nindent 8 }}
         {{- end }}
         livenessProbe:
           exec:
             command:
               # Just check that we can at least exec to the container
               - "true"
-          failureThreshold: {{ .Values.plugins.livenessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.plugins.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.plugins.livenessProbe.periodSeconds }}
-          successThreshold: {{ .Values.plugins.livenessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.plugins.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.pluginsAsync.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pluginsAsync.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pluginsAsync.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pluginsAsync.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pluginsAsync.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          failureThreshold: {{ .Values.plugins.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.pluginsAsync.readinessProbe.failureThreshold }}
           httpGet:
             path: /_health
             port: 6738
             scheme: HTTP
-          initialDelaySeconds: {{ .Values.plugins.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.plugins.readinessProbe.periodSeconds }}
-          successThreshold: {{ .Values.plugins.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.plugins.readinessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.pluginsAsync.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pluginsAsync.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pluginsAsync.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pluginsAsync.readinessProbe.timeoutSeconds }}
         resources:
-          {{- toYaml .Values.plugins.resources | nindent 12 }}
-        {{- if .Values.plugins.securityContext.enabled }}
+          {{- toYaml .Values.pluginsAsync.resources | nindent 12 }}
+        {{- if .Values.pluginsAsync.securityContext.enabled }}
         securityContext:
-          {{- omit .Values.plugins.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- omit .Values.pluginsAsync.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}

--- a/charts/posthog/templates/plugins-async-deployment.yaml
+++ b/charts/posthog/templates/plugins-async-deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "posthog.fullname" . }}-pluginsAsync
+  name: {{ template "posthog.fullname" . }}-plugins-async
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
@@ -11,7 +11,7 @@ spec:
     matchLabels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: pluginsAsync
+        role: plugins-async
   {{- if not .Values.pluginsAsync.hpa.enabled }}
   replicas: {{ .Values.pluginsAsync.replicacount }}
   {{- end }}
@@ -25,7 +25,7 @@ spec:
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: pluginsAsync
+        role: plugins-async
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
@@ -60,7 +60,7 @@ spec:
       securityContext: {{- omit .Values.pluginsAsync.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-pluginsAsync
+      - name: {{ .Chart.Name }}-plugins-async
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.plugins.enabled -}}
-# Keep this in sync with `pluginsAsync-deployment.yaml`
+# Keep this in sync with `plugins-async-deployment.yaml`
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/posthog/tests/plugins-async-deployment.yaml
+++ b/charts/posthog/tests/plugins-async-deployment.yaml
@@ -1,22 +1,23 @@
-suite: PostHog plugins deployment definition
+suite: PostHog plugins async deployment definition
 templates:
-  - templates/plugins-deployment.yaml
+  - templates/plugins-async-deployment.yaml
   - templates/secrets.yaml
 
 tests:
-  - it: should be empty if plugins.enabled is set to false
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+  - it: should be empty if pluginsAsync.enabled is set to false
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      plugins.enabled: false
+      pluginsAsync.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should have the correct apiVersion
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAsync.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -24,9 +25,10 @@ tests:
           of: apps/v1
 
   - it: should be the correct kind
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAsync.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -34,12 +36,13 @@ tests:
           of: Deployment
 
   - it: should have a pod securityContext
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      plugins.podSecurityContext.enabled: true
-      plugins.podSecurityContext.runAsUser: 1001
-      plugins.podSecurityContext.fsGroup: 2000
+      pluginsAsync.enabled: true
+      pluginsAsync.podSecurityContext.enabled: true
+      pluginsAsync.podSecurityContext.runAsUser: 1001
+      pluginsAsync.podSecurityContext.fsGroup: 2000
     asserts:
       - hasDocuments:
           count: 1
@@ -51,12 +54,13 @@ tests:
           value: 2000
 
   - it: should have a container securityContext
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      plugins.securityContext.enabled: true
-      plugins.securityContext.runAsUser: 1001
-      plugins.securityContext.allowPrivilegeEscalation: false
+      pluginsAsync.enabled: true
+      pluginsAsync.securityContext.enabled: true
+      pluginsAsync.securityContext.runAsUser: 1001
+      pluginsAsync.securityContext.allowPrivilegeEscalation: false
     asserts:
       - hasDocuments:
           count: 1
@@ -68,10 +72,11 @@ tests:
           value: false
 
   - it: should not have a pod securityContext
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      plugins.podSecurityContext.enabled: false
+      pluginsAsync.enabled: true
+      pluginsAsync.podSecurityContext.enabled: false
     asserts:
       - hasDocuments:
           count: 1
@@ -80,29 +85,19 @@ tests:
           value: 1001
 
   - it: should not have a container securityContext
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      plugins.securityContext.enabled: false
+      pluginsAsync.enabled: true
+      pluginsAsync.securityContext.enabled: false
     asserts:
       - hasDocuments:
           count: 1
       - isEmpty:
           path: spec.template.spec.containers[0].securityContext
 
-  - it: does not set PLUGIN_SERVER_MODE by default
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
-    set:
-      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: PLUGIN_SERVER_MODE
-            value: ingestion
-
-  - it: sets PLUGIN_SERVER_MODE if pluginsAsync is enabled
-    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+  - it: sets PLUGIN_SERVER_MODE
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
       pluginsAsync.enabled: true
@@ -111,4 +106,4 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: PLUGIN_SERVER_MODE
-            value: ingestion
+            value: async

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -180,7 +180,7 @@ worker:
 
 plugins:
   # -- Whether to install the PostHog plugin-server stack or not.
-  # This service handles data ingestion into clickhouse, running apps and async jobs.
+  # This service handles data ingestion into ClickHouse, running apps and async jobs.
   # See `pluginsAsync` to scale this separately.
   enabled: true
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -179,10 +179,12 @@ worker:
     enabled: false
 
 plugins:
-   # -- Whether to install the PostHog plugin-server stack or not.
+  # -- Whether to install the PostHog plugin-server stack or not.
+  # This service handles data ingestion into clickhouse, running apps and async jobs.
+  # See `pluginsAsync` to scale this separately.
   enabled: true
 
-  # -- Count of plugin-server pods to run. This setting is ignored if `plugin-server.hpa.enabled` is set to `true`.
+  # -- Count of plugin-server pods to run. This setting is ignored if `plugins.hpa.enabled` is set to `true`.
   replicacount: 1
 
   hpa:
@@ -239,6 +241,48 @@ plugins:
     successThreshold: 1
     # -- The readiness probe timeout seconds
     timeoutSeconds: 5
+
+
+pluginsAsync:
+  # -- Whether to install the PostHog plugin-server async stack or not.
+  # If disabled (default), plugins service handles both ingestion and running of async tasks.
+  # Allows for separate scaling of this service.
+  enabled: false
+
+  # -- Count of plugin-server-async pods to run. This setting is ignored if `pluginsAsync.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the plugin stack.
+    enabled: false
+    # -- CPU threshold percent for the plugin-server stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the plugin-server stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the plugin-server stack HorizontalPodAutoscaler.
+    maxpods: 10
+
+  # -- Additional env variables to inject into the plugin-server stack deployment.
+  env: []
+
+  # -- Resource limits for the plugin-server stack deployment.
+  resources:
+    {}
+
+  # -- Node labels for the plugin-server stack deployment.
+  nodeSelector: {}
+  # -- Toleration labels for the plugin-server stack deployment.
+  tolerations: []
+  # -- Affinity settings for the plugin-server stack deployment.
+  affinity: {}
+
+  # -- Container security context for the plugin-server stack deployment.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the plugin-server stack deployment.
+  podSecurityContext:
+    enabled: false
+
 
 email:
   # -- SMTP service host.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -283,6 +283,31 @@ pluginsAsync:
   podSecurityContext:
     enabled: false
 
+  livenessProbe:
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 10
+    # -- The liveness probe period seconds
+    periodSeconds: 10
+    # -- The liveness probe success threshold
+    successThreshold: 1
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 2
+
+  readinessProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 3
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 50
+    # -- The readiness probe period seconds
+    periodSeconds: 30
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 5
+
+
 
 email:
   # -- SMTP service host.

--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -60,7 +60,7 @@ export function checkEvents() {
 
   success = describe('Check the count of events ingested', (t) => {
 
-    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/2/insights/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`)
+    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/insights/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`)
     const res = http.get(URI.toString(), {
       headers: {
         Authorization: `Bearer e2e_demo_api_key`
@@ -78,7 +78,7 @@ export function checkEvents() {
   success = describe('Check onEvent called enough times', (t) => {
 
     // :TRICKY: We generate there being a plugin generating $pluginEvent events, see setup_ingestion_test.sh
-    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/2/events/?event=$pluginEvent`)
+    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/events/?event=$pluginEvent`)
     const res = http.get(URI.toString(), {
       headers: {
         Authorization: `Bearer e2e_demo_api_key`
@@ -97,7 +97,7 @@ export function checkEvents() {
   if (!SKIP_SOURCE_IP_ADDRESS_CHECK) {
     success = describe('Check if the source IP address of a random ingested event is not part of a private range', (t) => {
 
-      const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/2/events/?event=k6s_custom_event`)
+      const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/events/?event=k6s_custom_event`)
       const res = http.get(URI.toString(), {
         headers: {
           Authorization: `Bearer e2e_demo_api_key`

--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -90,6 +90,7 @@ export function checkEvents() {
 
     t.expect(res.json()['results'].length).as('Count of $pluginEvents').toBeGreaterThan(0)
   })
+  failedTestCases.add(success === false);
 
   // This test case doesn't work in all the environments (e.g. k3s) so we made it optional
   if (!SKIP_SOURCE_IP_ADDRESS_CHECK) {

--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -60,7 +60,7 @@ export function checkEvents() {
 
   success = describe('Check the count of events ingested', (t) => {
 
-    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/insights/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`)
+    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/@current/insights/trend/?events=[{"id":"k6s_custom_event","type":"events"}]&refresh=true`)
     const res = http.get(URI.toString(), {
       headers: {
         Authorization: `Bearer e2e_demo_api_key`
@@ -78,7 +78,7 @@ export function checkEvents() {
   success = describe('Check onEvent called enough times', (t) => {
 
     // :TRICKY: We generate there being a plugin generating $pluginEvent events, see setup_ingestion_test.sh
-    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/events/?event=$pluginEvent`)
+    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/@current/events/?event=$pluginEvent`)
     const res = http.get(URI.toString(), {
       headers: {
         Authorization: `Bearer e2e_demo_api_key`
@@ -97,7 +97,7 @@ export function checkEvents() {
   if (!SKIP_SOURCE_IP_ADDRESS_CHECK) {
     success = describe('Check if the source IP address of a random ingested event is not part of a private range', (t) => {
 
-      const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/1/events/?event=k6s_custom_event`)
+      const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/@current/events/?event=k6s_custom_event`)
       const res = http.get(URI.toString(), {
         headers: {
           Authorization: `Bearer e2e_demo_api_key`

--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -70,8 +70,8 @@ export function checkEvents() {
     t.expect(res.status).as('HTTP response status').toEqual(200)
     t.expect(res).toHaveValidJson()
 
-    var event_count = res.json()["result"][0]["count"]
-    t.expect(event_count).as(`Count of ingested events (${event_count})`).toBeGreaterThan(100)
+    const eventCount = res.json()["result"][0]["count"]
+    t.expect(eventCount).as(`Count of ingested events (${eventCount})`).toBeGreaterThan(100)
   })
   failedTestCases.add(success === false);
 
@@ -88,7 +88,8 @@ export function checkEvents() {
     t.expect(res.status).as('HTTP response status').toEqual(200)
     t.expect(res).toHaveValidJson()
 
-    t.expect(res.json()['results'].length).as('Count of $pluginEvents').toBeGreaterThan(0)
+    const eventCount = res.json()['results'].length
+    t.expect(eventCount).as(`Count of $pluginEvents (${eventCount})`).toBeGreaterThan(0)
   })
   failedTestCases.add(success === false);
 

--- a/ci/k6/ingestion-test.js
+++ b/ci/k6/ingestion-test.js
@@ -75,6 +75,22 @@ export function checkEvents() {
   })
   failedTestCases.add(success === false);
 
+  success = describe('Check onEvent called enough times', (t) => {
+
+    // :TRICKY: We generate there being a plugin generating $pluginEvent events, see setup_ingestion_test.sh
+    const URI = new URL(`${POSTHOG_API_ENDPOINT}/api/projects/2/events/?event=$pluginEvent`)
+    const res = http.get(URI.toString(), {
+      headers: {
+        Authorization: `Bearer e2e_demo_api_key`
+      }
+    })
+
+    t.expect(res.status).as('HTTP response status').toEqual(200)
+    t.expect(res).toHaveValidJson()
+
+    t.expect(res.json()['results'].length).as('Count of $pluginEvents').toBeGreaterThan(0)
+  })
+
   // This test case doesn't work in all the environments (e.g. k3s) so we made it optional
   if (!SKIP_SOURCE_IP_ADDRESS_CHECK) {
     success = describe('Check if the source IP address of a random ingested event is not part of a private range', (t) => {

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -24,6 +24,7 @@ PluginSourceFile.objects.update_or_create(
     plugin=plugin, filename="index.ts", source="""
         export async function onEvent(event, meta) {
             const ratelimit = await meta.cache.get('ratelimit')
+            console.log('e2e log', { event, ratelimit })
             if (!ratelimit && event.event !== '$pluginEvent') {
                 posthog.capture('$pluginEvent', { event: event.event })
                 await meta.cache.set('ratelimit', 1)
@@ -35,3 +36,9 @@ PluginSourceFile.objects.update_or_create(
 
 plugin_config.enabled = True
 plugin_config.save()
+
+for team in Team.objects.all():
+    print(team.__dict__)
+
+for plugin in Plugin.objects.all():
+    print(plugin.__dict__)

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -1,3 +1,17 @@
+import os
+import sys
+
+from os.path import dirname
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "posthog.settings"
+sys.path.append(dirname(__file__))
+
+import django
+
+django.setup()
+
+from posthog.models import Organization, Plugin, PluginConfig, PluginSourceFile
+
 organization = Organization.objects.last()
 team = organization.teams.last()
 plugin = Plugin.objects.create(organization=organization, name="e2e test plugin", plugin_type="source")

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -1,5 +1,5 @@
-organization = Organization.objects.first()
-team = organization.teams.first()
+organization = Organization.objects.last()
+team = organization.teams.last()
 plugin = Plugin.objects.create(organization=organization, name="e2e test plugin", plugin_type="source")
 plugin_config = PluginConfig.objects.create(plugin=plugin, team=team, order=1, config={})
 

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -10,7 +10,7 @@ import django
 
 django.setup()
 
-from posthog.models import Organization, Plugin, PluginConfig, PluginSourceFile, Team
+from posthog.models import Organization, Plugin, PluginConfig, PluginSourceFile
 
 organization = Organization.objects.last()
 team = organization.teams.last()
@@ -36,9 +36,3 @@ PluginSourceFile.objects.update_or_create(
 
 plugin_config.enabled = True
 plugin_config.save()
-
-for team in Team.objects.all():
-    print(team.__dict__)
-
-for plugin in Plugin.objects.all():
-    print(plugin.__dict__)

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -1,0 +1,23 @@
+organization = Organization.objects.first()
+team = organization.teams.first()
+plugin = Plugin.objects.create(organization=organization, name="e2e test plugin", plugin_type="source")
+plugin_config = PluginConfig.objects.create(plugin=plugin, team=team, order=1, config={})
+
+PluginSourceFile.objects.update_or_create(
+    plugin=plugin, filename="plugin.json", source='{ "name": "e2e test plugin", "config": [] }',
+)
+PluginSourceFile.objects.update_or_create(
+    plugin=plugin, filename="index.ts", source="""
+        export async function onEvent(event, meta) {
+            const ratelimit = await meta.cache.get('ratelimit')
+            if (!ratelimit && event.event !== '$pluginEvent') {
+                posthog.capture('$pluginEvent', { event: event.event })
+                await meta.cache.set('ratelimit', 1)
+                await meta.cache.expire('ratelimit', 60)
+            }
+        }
+    """,
+)
+
+plugin_config.enabled = True
+plugin_config.save()

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -10,7 +10,7 @@ import django
 
 django.setup()
 
-from posthog.models import Organization, Plugin, PluginConfig, PluginSourceFile
+from posthog.models import Organization, Plugin, PluginConfig, PluginSourceFile, Team
 
 organization = Organization.objects.last()
 team = organization.teams.last()

--- a/ci/setup-plugin.py
+++ b/ci/setup-plugin.py
@@ -24,7 +24,6 @@ PluginSourceFile.objects.update_or_create(
     plugin=plugin, filename="index.ts", source="""
         export async function onEvent(event, meta) {
             const ratelimit = await meta.cache.get('ratelimit')
-            console.log('e2e log', { event, ratelimit })
             if (!ratelimit && event.event !== '$pluginEvent') {
                 posthog.capture('$pluginEvent', { event: event.event })
                 await meta.cache.set('ratelimit', 1)

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+set -ex
+
 #
 # This script setup PostHog in DEV mode to do ingestion testing
 #
@@ -10,30 +12,5 @@ WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadat
 kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data # --create-e2e-test-plugin
 
 # :KLUDGE: Inline this setup script until 1.37.0 is out and `setup_dev --create-e2e-test-plugin` does something.
-echo << EOF
-from django.utils.timezone import now
-
-organization = Organization.objects.first()
-team = organization.teams.first()
-plugin = Plugin.objects.create(organization=organization, name="e2e test plugin", plugin_type="source")
-plugin_config = PluginConfig.objects.create(plugin=plugin, team=team, order=1, config={})
-
-PluginSourceFile.objects.update_or_create(
-    plugin=plugin, filename="plugin.json", source='{ "name": "e2e test plugin", "config": [] }',
-)
-PluginSourceFile.objects.update_or_create(
-    plugin=plugin, filename="index.ts", source="""
-        export async function onEvent(event, meta) {
-            const ratelimit = await meta.cache.get('ratelimit')
-            if (!ratelimit && event.event !== '$pluginEvent') {
-                posthog.capture('$pluginEvent', { event: event.event })
-                await meta.cache.set('ratelimit', 1)
-                await meta.cache.expire('ratelimit', 60)
-            }
-        }
-    """,
-)
-
-plugin_config.enabled = True
-plugin_config.save()
-EOF | kubectl exec "$WEB_POD" -n posthog -- python manage.py shell
+cat ci/setup-plugin.py | kubectl exec "$WEB_POD" -n posthog -- python manage.py shell_plus
+echo 'Setup done'

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -14,4 +14,3 @@ kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data # --c
 # :KLUDGE: Inline this setup script until 1.37.0 is out and `setup_dev --create-e2e-test-plugin` does something.
 kubectl cp ci/setup-plugin.py "$WEB_POD:." -n posthog
 kubectl exec "$WEB_POD" -n posthog -- python setup-plugin.py
-echo 'Setup done'

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -7,9 +7,9 @@ sleep 10 # TODO: remove this. It was added as the command below often errors wit
 
 WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadata.name}")
 
-kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data --create-e2e-test-plugin
+kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data # --create-e2e-test-plugin
 
-# :KLUDGE: Inline this setup script until 1.37.0 is out and `--create-e2e-test-plugin` does something.
+# :KLUDGE: Inline this setup script until 1.37.0 is out and `setup_dev --create-e2e-test-plugin` does something.
 echo << EOF
 from django.utils.timezone import now
 

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -12,5 +12,6 @@ WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadat
 kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data # --create-e2e-test-plugin
 
 # :KLUDGE: Inline this setup script until 1.37.0 is out and `setup_dev --create-e2e-test-plugin` does something.
-cat ci/setup-plugin.py | kubectl exec "$WEB_POD" -n posthog -- python manage.py shell_plus
+kubectl cp ci/setup-plugin.py "$WEB_POD:." -n posthog
+kubectl exec "$WEB_POD" -n posthog -- python setup-plugin.py
 echo 'Setup done'

--- a/ci/setup_ingestion_test.sh
+++ b/ci/setup_ingestion_test.sh
@@ -7,4 +7,33 @@ sleep 10 # TODO: remove this. It was added as the command below often errors wit
 
 WEB_POD=$(kubectl get pods -n posthog -l role=web -o jsonpath="{.items[].metadata.name}")
 
-kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data
+kubectl exec "$WEB_POD" -n posthog -- python manage.py setup_dev --no-data --create-e2e-test-plugin
+
+# :KLUDGE: Inline this setup script until 1.37.0 is out and `--create-e2e-test-plugin` does something.
+echo << EOF
+from django.utils.timezone import now
+
+organization = Organization.objects.first()
+team = organization.teams.first()
+plugin = Plugin.objects.create(organization=organization, name="e2e test plugin", plugin_type="source")
+plugin_config = PluginConfig.objects.create(plugin=plugin, team=team, order=1, config={})
+
+PluginSourceFile.objects.update_or_create(
+    plugin=plugin, filename="plugin.json", source='{ "name": "e2e test plugin", "config": [] }',
+)
+PluginSourceFile.objects.update_or_create(
+    plugin=plugin, filename="index.ts", source="""
+        export async function onEvent(event, meta) {
+            const ratelimit = await meta.cache.get('ratelimit')
+            if (!ratelimit && event.event !== '$pluginEvent') {
+                posthog.capture('$pluginEvent', { event: event.event })
+                await meta.cache.set('ratelimit', 1)
+                await meta.cache.expire('ratelimit', 60)
+            }
+        }
+    """,
+)
+
+plugin_config.enabled = True
+plugin_config.save()
+EOF | kubectl exec "$WEB_POD" -n posthog -- python manage.py shell

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -1,0 +1,38 @@
+cloud: k3s
+
+image:
+  # :TODO: Remove this once 1.37.0 is out
+  tag: latest
+
+pluginsAsync:
+  enabled: true
+
+ingress:
+  nginx:
+    enabled: true
+    redirectToTLS: false
+  letsencrypt: false
+
+web:
+  secureCookies: false
+
+internalMetrics:
+  capture: false
+
+# Use small PVC in CI
+clickhouse:
+  persistence:
+    size: 1Gi
+kafka:
+  persistence:
+    size: 1Gi
+postgresql:
+  persistence:
+    size: 1Gi
+redis:
+  master:
+    persistence:
+      size: 1Gi
+zookeeper:
+  persistence:
+    size: 1Gi

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -2,7 +2,7 @@ cloud: k3s
 
 image:
   # :TODO: Remove this once 1.37.0 is out
-  tag: latest
+  sha: "sha256:c16d6dbd0c2bb13a22cc48114092c9741ee51c5318517c15ef5b12428b5f5c31"
 
 pluginsAsync:
   enabled: true
@@ -15,9 +15,8 @@ ingress:
 
 web:
   secureCookies: false
-
-internalMetrics:
-  capture: false
+  internalMetrics:
+    capture: false
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -9,6 +9,9 @@ ingress:
 web:
   secureCookies: false
 
+internalMetrics:
+  capture: false
+
 # Use small PVC in CI
 clickhouse:
   persistence:

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -8,9 +8,8 @@ ingress:
 
 web:
   secureCookies: false
-
-internalMetrics:
-  capture: false
+  internalMetrics:
+    capture: false
 
 # Use small PVC in CI
 clickhouse:


### PR DESCRIPTION
## Description

This PR introduces `pluginsAsync` - a separate plugin server process that allows scaling non-ingestion pieces of plugin-server separately from everything else. 

Note that this isn't turned on by default as it's:
- Experimental - the exact service boundaries are bound to change over time (as the number of these split processes)
- We'll handle running only the main process gracefully in the chart and generally

Note I also added an E2E test for measuring `onEvent` plugin calls - in a split plugin server, these are handled separately.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- Test deploy
- Unit tests
- E2E ingestion test.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
