### PR TITLE
ClickHouse - switch default service to ClusterIP

### DIFF
--- a/charts/posthog/templates/NOTES.txt
+++ b/charts/posthog/templates/NOTES.txt
@@ -1,4 +1,23 @@
 
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+{{- if (not contains .Values.clickhouse.serviceType "ClusterIP") }}
+-------------------------------------------------------------------------------
+ WARNING
+
+    By specifying "clickhouse.serviceType={{ .Values.clickhouse.serviceType }}"
+    you are exposing the ClickHouse service externally to the cluster.
+
+    For security reasons, we strongly suggest you to switch back to "ClusterIP"
+    if you don't need any direct external access. Otherwise, please keep in
+    mind to review the service security posture (example: use unique credentials,
+    restrict network access to a range of IPs, use TLS, etc...)
+
+-------------------------------------------------------------------------------
+{{- end }}
+
 ** Please be patient while the chart is being deployed **
 
 To access your PostHog site from outside the cluster follow the steps below:

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -7,7 +7,11 @@ spec:
   configuration:
     users:
       {{ .Values.clickhouse.user }}/password: {{ .Values.clickhouse.password }}
-      {{ .Values.clickhouse.user }}/networks/ip: "0.0.0.0/0"
+      {{ .Values.clickhouse.user }}/networks/host_regexp: ([a-zA-Z-]+)\.{{ .Release.Namespace }}\.svc\.cluster\.local$
+      {{ .Values.clickhouse.user }}/networks/ip:
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
       {{ .Values.clickhouse.user }}/profile: default
       {{ .Values.clickhouse.user }}/quota: default
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -676,8 +676,8 @@ clickhouse:
     runAsGroup: 101
     fsGroup: 101
 
-  # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
-  serviceType: NodePort
+  # -- Kubernetes Service type.
+  serviceType: ClusterIP
 
   persistence:
     # -- Enable data persistence using PVC.


### PR DESCRIPTION
## Description
This PR switch the default ClickHouse service type from `NodePort` to `ClusterIP`. This is to remove the possibility of exposing the service in environments where k8s nodes are not deployed in private subnets (or in public subnets but without network restriction in place).

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI should be ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
