### PR TITLE
CH: externalZookeeper - fix indent

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -48,7 +48,7 @@ spec:
     zookeeper:
       nodes:
       {{- if .Values.clickhouse.externalZookeeper }}
-      {{ toYaml .Values.clickhouse.externalZookeeper.servers | indent 4 }}
+{{ toYaml .Values.clickhouse.externalZookeeper.servers | indent 8 }}
       {{- else }}
         - host: {{ template "posthog.zookeeper.host" . }}
           port: {{ template "posthog.zookeeper.port" . }}

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -285,7 +285,7 @@ tests:
           path: spec.configuration.users
           value:
             someuser/password: somepass
-            someuser/networks/ip: 
+            someuser/networks/ip:
               - "10.0.0.0/8"
               - "172.16.0.0/12"
               - "192.168.0.0/16"
@@ -379,7 +379,7 @@ tests:
 
   - it: by default only allows access from in-cluster and with the namespace
     asserts:
-      - equal: 
+      - equal:
           path: spec.configuration.users.admin/networks/ip
           value:
             - "10.0.0.0/8"
@@ -397,3 +397,24 @@ tests:
           value:
             - "192.168.0.1"
             - "172.31.0.0/16"
+
+  - it: externalZookeeper override should work
+    set:
+      clickhouse.externalZookeeper.servers:
+        - host: host1
+          port: 2181
+        - host: host2
+          port: 2181
+        - host: host3
+          port: 2181
+    asserts:
+      - equal:
+          path: spec.configuration.zookeeper
+          value:
+            nodes:
+              - host: host1
+                port: 2181
+              - host: host2
+                port: 2181
+              - host: host3
+                port: 2181

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -715,11 +715,15 @@ clickhouse:
   secure: false
   # -- Whether to verify TLS certificate on connection to ClickHouse
   verify: false
+  # -- List of external Zookeeper servers to use.
   # externalZookeeper:
-  # -- URL for zookeeper.
-  # servers:
-  # - host: posthog-posthog-zookeeper
-  #   port: 2181
+  #   servers:
+  #     - host: host1
+  #       port: 2181
+  #     - host: host2
+  #       port: 2181
+  #     - host: host3
+  #       port: 2181
 
   image:
     # -- ClickHouse image repository.
@@ -752,7 +756,7 @@ clickhouse:
   # allowed to access from. By default anything within a private network will be
   # allowed. This should suffice for most use case although to expose to other
   # networks you will need to update this setting.
-  # 
+  #
   # For more details on usage, see https://posthog.com/docs/self-host/deploy/configuration#securing-clickhouse
   allowedNetworkIps:
     - "10.0.0.0/8"


### PR DESCRIPTION
## Description
We got a user report that `clickhouse.externalZookeeper` override wasn't working due to an indentation issue. Despite it is an option not fully supported, I'm pushing a fix that should make it work. 

Once we'll have more bandwidth we should also add an e2e test for this case. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
