### PR TITLE
feat(hpa): add non-abstracted hpa config values

### DIFF
--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -9,7 +9,11 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-events
+  {{ if .Values.events.autoscaling }}
+  {{ .Values.events.autoscaling | nindent 2 }}
+  {{ else }}
   minReplicas: {{ .Values.events.hpa.minpods }}
   maxReplicas: {{ .Values.events.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.events.hpa.cputhreshold }}
+  {{ end }}
 {{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -9,7 +9,11 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-plugins
+  {{ if .Values.plugins.autoscaling }}
+  {{ .Values.plugins.autoscaling | nindent 2 }}
+  {{ else }}
   minReplicas: {{ .Values.plugins.hpa.minpods }}
   maxReplicas: {{ .Values.plugins.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.plugins.hpa.cputhreshold }}
+  {{ end }}
 {{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -9,7 +9,11 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-web
+  {{ if .Values.web.autoscaling }}
+  {{ .Values.web.autoscaling | nindent 2 }}
+  {{ else }}
   minReplicas: {{ .Values.web.hpa.minpods }}
   maxReplicas: {{ .Values.web.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+  {{ end }}
 {{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -9,7 +9,11 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-worker
+  {{ if .Values.worker.autoscaling }}
+  {{ .Values.worker.autoscaling | nindent 2 }}
+  {{ else }}
   minReplicas: {{ .Values.worker.hpa.minpods }}
   maxReplicas: {{ .Values.worker.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.worker.hpa.cputhreshold }}
+  {{ end }}
 {{- end }}

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -46,3 +46,13 @@ tests:
           count: 1
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: uses the `autoscaling` settings if set
+    set:
+      events.enabled: true
+      events.autoscaling:
+        minReplicas: 1
+        maxReplicas: 5
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -46,3 +46,13 @@ tests:
           count: 1
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: uses the `autoscaling` settings if set
+    set:
+      plugins.enabled: true
+      plugins.autoscaling:
+        minReplicas: 1
+        maxReplicas: 5
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -46,3 +46,13 @@ tests:
           count: 1
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: uses the `autoscaling` settings if set
+    set:
+      web.enabled: true
+      web.autoscaling:
+        minReplicas: 1
+        maxReplicas: 5
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -46,3 +46,13 @@ tests:
           count: 1
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: uses the `autoscaling` settings if set
+    set:
+      worker.enabled: true
+      worker.autoscaling:
+        minReplicas: 1
+        maxReplicas: 5
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 3600

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -48,6 +48,13 @@ events:
   # -- Count of events pods to run. This setting is ignored if `events.hpa.enabled` is set to `true`.
   replicacount: 1
 
+  # -- HPA spec to be used for autoscaling the events pods. See
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  # for configuration options
+  autoscaling:
+
+  # -- Deprecated: settings to be used for hpa. Use `autoscaling` instead, which
+  # does not try to abstract the HPA interface.
   hpa:
     # -- Whether to create a HorizontalPodAutoscaler for the events stack.
     enabled: false
@@ -57,6 +64,7 @@ events:
     minpods: 1
     # -- Max pods for the events stack HorizontalPodAutoscaler.
     maxpods: 10
+
   # -- Container security context for the events stack HorizontalPodAutoscaler.
   securityContext:
     enabled: false
@@ -71,6 +79,13 @@ web:
   # -- Count of web pods to run. This setting is ignored if `web.hpa.enabled` is set to `true`.
   replicacount: 1
 
+  # -- HPA spec to be used for autoscaling the web pods. See
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  # for configuration options
+  autoscaling:
+
+  # -- Deprecated: settings to be used for hpa. Use `autoscaling` instead, which
+  # does not try to abstract the HPA interface.
   hpa:
     # -- Whether to create a HorizontalPodAutoscaler for the web stack.
     enabled: false
@@ -147,6 +162,13 @@ worker:
   # -- Count of worker pods to run. This setting is ignored if `worker.hpa.enabled` is set to `true`.
   replicacount: 1
 
+  # -- HPA spec to be used for autoscaling the worker pods. See
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  # for configuration options
+  autoscaling:
+
+  # -- Deprecated: settings to be used for hpa. Use `autoscaling` instead, which
+  # does not try to abstract the HPA interface.
   hpa:
     # -- Whether to create a HorizontalPodAutoscaler for the worker stack.
     enabled: false
@@ -187,6 +209,13 @@ plugins:
   # -- Count of plugin-server pods to run. This setting is ignored if `plugins.hpa.enabled` is set to `true`.
   replicacount: 1
 
+  # -- HPA spec to be used for autoscaling the plugin pods. See
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  # for configuration options
+  autoscaling:
+
+  # -- Deprecated: settings to be used for hpa. Use `autoscaling` instead, which
+  # does not try to abstract the HPA interface.
   hpa:
     # -- Whether to create a HorizontalPodAutoscaler for the plugin stack.
     enabled: false


### PR DESCRIPTION
Previously we had a thin abstraction over a subset of the hpa config.
Rather than maintain this abstraction I have simply exposed the
underlying spec for hpa manifests. This was we can use the full range of
hpa without needing to make chart interface changes.

I've added this as the existing configuration can exhibit a lot of
flapping, where we might go from 10 pods, down to 5, only to then
request another 5 pods directly after. I would like to set the
`behavior.scaleDown.stabilizationWindowSeconds` setting to a higher
value than the default.

Note that this does not include the pluginsAsync values addition at the
moment. This is because we do not have an HPA manifest for pluginsAsync,
I'll handle this separately.

The reason for not reusing e.g. `web.hpa` is to avoid any unexpected
behaviour with existing values people may have. I chose `autoscaling`
bsaed on a similarly structured value in the `ingress-nginx` helm chart.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
