### PR TITLE
fix(hpa): specify behavior as annotation

### DIFF
--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-events
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations:
+    autoscaling.alpha.kubernetes.io/behavior: {{ toJson .Values.events.hpa.behavior | quote }}
 spec:
   scaleTargetRef:
     kind: Deployment
@@ -12,6 +14,4 @@ spec:
   minReplicas: {{ .Values.events.hpa.minpods }}
   maxReplicas: {{ .Values.events.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.events.hpa.cputhreshold }}
-  behavior: 
-    {{ toYaml .Values.events.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-plugins
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations:
+    autoscaling.alpha.kubernetes.io/behavior: {{ toJson .Values.plugins.hpa.behavior | quote }}
 spec:
   scaleTargetRef:
     kind: Deployment
@@ -12,6 +14,4 @@ spec:
   minReplicas: {{ .Values.plugins.hpa.minpods }}
   maxReplicas: {{ .Values.plugins.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.plugins.hpa.cputhreshold }}
-  behavior: 
-    {{ toYaml .Values.plugins.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-web
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations:
+    autoscaling.alpha.kubernetes.io/behavior: {{ toJson .Values.web.hpa.behavior | quote }}
 spec:
   scaleTargetRef:
     kind: Deployment
@@ -12,6 +14,4 @@ spec:
   minReplicas: {{ .Values.web.hpa.minpods }}
   maxReplicas: {{ .Values.web.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
-  behavior: 
-    {{ toYaml .Values.web.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-worker
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations:
+    autoscaling.alpha.kubernetes.io/behavior: {{ toJson .Values.worker.hpa.behavior | quote }}
 spec:
   scaleTargetRef:
     kind: Deployment
@@ -12,6 +14,4 @@ spec:
   minReplicas: {{ .Values.worker.hpa.minpods }}
   maxReplicas: {{ .Values.worker.hpa.maxpods }}
   targetCPUUtilizationPercentage: {{ .Values.worker.hpa.cputhreshold }}
-  behavior: 
-    {{ toYaml .Values.worker.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -70,6 +70,8 @@ tests:
             minReplicas: 2
             maxReplicas: 10
             targetCPUUtilizationPercentage: 70
-            behavior:
-              scaleDown:
-                stabilizationWindowSeconds: 3600
+      - equal:
+          path: metadata.annotations
+          value:
+            autoscaling.alpha.kubernetes.io/behavior: '{"scaleDown":{"stabilizationWindowSeconds":3600}}'
+

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -70,6 +70,8 @@ tests:
             minReplicas: 2
             maxReplicas: 10
             targetCPUUtilizationPercentage: 70
-            behavior:
-              scaleDown:
-                stabilizationWindowSeconds: 3600
+      - equal:
+          path: metadata.annotations
+          value:
+            autoscaling.alpha.kubernetes.io/behavior: '{"scaleDown":{"stabilizationWindowSeconds":3600}}'
+

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -70,6 +70,8 @@ tests:
             minReplicas: 2
             maxReplicas: 10
             targetCPUUtilizationPercentage: 70
-            behavior:
-              scaleDown:
-                stabilizationWindowSeconds: 3600
+      - equal:
+          path: metadata.annotations
+          value:
+            autoscaling.alpha.kubernetes.io/behavior: '{"scaleDown":{"stabilizationWindowSeconds":3600}}'
+

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -70,6 +70,8 @@ tests:
             minReplicas: 2
             maxReplicas: 10
             targetCPUUtilizationPercentage: 70
-            behavior:
-              scaleDown:
-                stabilizationWindowSeconds: 3600
+      - equal:
+          path: metadata.annotations
+          value:
+            autoscaling.alpha.kubernetes.io/behavior: '{"scaleDown":{"stabilizationWindowSeconds":3600}}'
+


### PR DESCRIPTION
The `behavior` is not part of the `autoscaling/v1` spec, but rather part
of `autoscaling/v2beta2` and `autoscaling/v2`. Rather than change to
`autoscaling/v2beta2` for which I need to check the update path, I'm
proposing to add as an annotation.

@guidoiaquinti I'm not entirely sure what "The new fields introduced in autoscaling/v2beta2 are preserved as annotations when working with autoscaling/v1" means in https://v1-21.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/ , perhaps you or @benjackwhite have a better view here.

I'm also happy to update this PR to use `autoscaling/v2beta2` if you think that's a better approach.

For context, [this](https://github.com/PostHog/posthog-cloud-infra/pull/302) is the change I want to be able to make.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
