### PR TITLE
chore(hpa): update hpa apiVersion to autoscaling/v2beta2

### DIFF
--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.events.enabled .Values.events.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-events

--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -11,7 +11,15 @@ spec:
     name: {{ template "posthog.fullname" . }}-events
   minReplicas: {{ .Values.events.hpa.minpods }}
   maxReplicas: {{ .Values.events.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.events.hpa.cputhreshold }}
+  metrics:
+  {{- with .Values.events.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
   behavior: 
     {{ toYaml .Values.events.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
@@ -11,5 +11,13 @@ spec:
     name: {{ template "posthog.fullname" . }}-pgbouncer
   minReplicas: {{ .Values.pgbouncer.hpa.minpods }}
   maxReplicas: {{ .Values.pgbouncer.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.pgbouncer.hpa.cputhreshold }}
+  metrics:
+  {{- with .Values.pgbouncer.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -11,7 +11,15 @@ spec:
     name: {{ template "posthog.fullname" . }}-plugins
   minReplicas: {{ .Values.plugins.hpa.minpods }}
   maxReplicas: {{ .Values.plugins.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.plugins.hpa.cputhreshold }}
+  metrics:
+  {{- with .Values.plugins.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
   behavior: 
     {{ toYaml .Values.plugins.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.plugins.enabled .Values.plugins.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-plugins

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -11,7 +11,15 @@ spec:
     name: {{ template "posthog.fullname" . }}-web
   minReplicas: {{ .Values.web.hpa.minpods }}
   maxReplicas: {{ .Values.web.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+  metrics:
+  {{- with .Values.web.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
   behavior: 
     {{ toYaml .Values.web.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.web.enabled .Values.web.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-web

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -11,7 +11,15 @@ spec:
     name: {{ template "posthog.fullname" . }}-worker
   minReplicas: {{ .Values.worker.hpa.minpods }}
   maxReplicas: {{ .Values.worker.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.worker.hpa.cputhreshold }}
+  metrics:
+  {{- with .Values.worker.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
   behavior: 
     {{ toYaml .Values.worker.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled .Values.worker.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-worker

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v1
+          of: autoscaling/v2beta2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -69,7 +69,13 @@ tests:
               name: RELEASE-NAME-posthog-events
             minReplicas: 2
             maxReplicas: 10
-            targetCPUUtilizationPercentage: 70
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
             behavior:
               scaleDown:
                 stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/pgbouncer-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v1
+          of: autoscaling/v2beta2
 
   - it: should be the correct kind
     set:
@@ -46,3 +46,30 @@ tests:
           count: 1
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: sets hpa spec
+    set:
+      pgbouncer.enabled: true
+      pgbouncer:
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-pgbouncer
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -69,7 +69,13 @@ tests:
               name: RELEASE-NAME-posthog-plugins
             minReplicas: 2
             maxReplicas: 10
-            targetCPUUtilizationPercentage: 70
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
             behavior:
               scaleDown:
                 stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v1
+          of: autoscaling/v2beta2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v1
+          of: autoscaling/v2beta2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -69,7 +69,13 @@ tests:
               name: RELEASE-NAME-posthog-web
             minReplicas: 2
             maxReplicas: 10
-            targetCPUUtilizationPercentage: 70
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
             behavior:
               scaleDown:
                 stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v1
+          of: autoscaling/v2beta2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -69,7 +69,13 @@ tests:
               name: RELEASE-NAME-posthog-worker
             minReplicas: 2
             maxReplicas: 10
-            targetCPUUtilizationPercentage: 70
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
             behavior:
               scaleDown:
                 stabilizationWindowSeconds: 3600


### PR DESCRIPTION
This is to allow usage of the `behavior` attribute for controlling
scaleUp and scaleDown. This will replace the existing autoscaling/v1
manifests. This is available in Kubernetes 1.21, our oldest supported
version.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
