### PR TITLE
feat(events): allow event pod resources to be set independently

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -128,7 +128,11 @@ spec:
           successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
+        {{ if not .Values.events.resources }}
 {{ toYaml .Values.web.resources | indent 12 }}
+        {{ else }}
+{{ toYaml .Values.events.resources | indent 12 }}
+        {{ end }}
         {{- if .Values.events.securityContext.enabled }}
         securityContext: {{- omit .Values.events.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -49,7 +49,7 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 2000
-  
+
   - it: should have a container securityContext
     template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -65,8 +65,8 @@ tests:
           value: 1001
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false            
-          
+          value: false
+
   - it: should not have a pod securityContext
     template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -78,7 +78,7 @@ tests:
       - isEmpty:
           path: spec.template.spec.securityContext
           value: 1001
-  
+
   - it: should not have a container securityContext
     template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -88,4 +88,85 @@ tests:
       - hasDocuments:
           count: 1
       - isEmpty:
-          path: spec.template.spec.containers[0].securityContext    
+          path: spec.template.spec.containers[0].securityContext
+
+  # NOTE: historically we have had the events pod use any resources specified
+  # for web. However, we would like to separate the connection and allow them to
+  # be set independently, while maintaining backwards compat. for installs that
+  # are setting the web resources.
+  - it: should set resources when specified
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      events:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: for backwards compat. should use the web resources if specified
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      web:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: should set resources when specified and override web resource settings
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      events:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+      web:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 6Gi
+          requests:
+            cpu: 2000m
+            memory: 6Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi


### PR DESCRIPTION
Previously they just came from the `web.resources` setting. Now you can:

 1. set `events.resources` for use by events pods
 2. update helm chart version, only changing the behaviour if you
    explicitly set the `events.resources` value. Otherwise, you should
    get the existing behaviour of using the `web.resources` value.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
