### PR TITLE
fix(async): pass SITE_URL to plugins-async

### DIFF
--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -20,4 +20,8 @@
   value: {{ .Values.sentryDSN | quote }}
 - name: DEPLOYMENT
   value: {{ template "posthog.deploymentEnv" . }}
+- name: CAPTURE_INTERNAL_METRICS
+  value: {{ .Values.web.internalMetrics.capture| quote }}
+- name: HELM_INSTALL_INFO
+  value: {{ template "posthog.helmInstallInfo" . }}
 {{- end }}

--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -14,4 +14,10 @@
     secretKeyRef:
       name: {{ template "posthog.posthogSecretKey.existingSecret" . }}
       key: {{ .Values.posthogSecretKey.existingSecretKey }}
+- name: SITE_URL
+  value: {{ template "posthog.site.url" . }}
+- name: SENTRY_DSN
+  value: {{ .Values.sentryDSN | quote }}
+- name: DEPLOYMENT
+  value: {{ template "posthog.deploymentEnv" . }}
 {{- end }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -76,12 +76,6 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
 
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
         - name: DISABLE_SECURE_SSL_REDIRECT
           value: '1'
         - name: IS_BEHIND_PROXY

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -91,10 +91,6 @@ spec:
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -51,8 +51,6 @@ spec:
         # Redis env variables
         {{- include "snippet.redis-env" . | indent 8 }}
 
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}
@@ -62,10 +60,6 @@ spec:
 {{- if .Values.hooks.migrate.env }}
 {{ toYaml .Values.hooks.migrate.env | indent 8 }}
 {{- end }}
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
         # PostHog app settings
         {{- include "snippet.posthog-env" . | indent 8 }}
         - name: PRIMARY_DB

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -67,10 +67,6 @@ spec:
         {{- include "snippet.postgresql-migrate-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
         resources:
 {{ toYaml .Values.hooks.migrate.resources | indent 10 }}
       initContainers:

--- a/charts/posthog/templates/plugins-async-deployment.yaml
+++ b/charts/posthog/templates/plugins-async-deployment.yaml
@@ -87,10 +87,6 @@ spec:
         {{- include "snippet.posthog-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- end }}

--- a/charts/posthog/templates/plugins-async-deployment.yaml
+++ b/charts/posthog/templates/plugins-async-deployment.yaml
@@ -84,10 +84,6 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | nindent 8 }}
 
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
         {{- include "snippet.posthog-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -89,10 +89,6 @@ spec:
         {{- include "snippet.posthog-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- end }}

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -86,12 +86,6 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | nindent 8 }}
 
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
         {{- include "snippet.posthog-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -113,10 +113,6 @@ spec:
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -76,12 +76,6 @@ spec:
         # statsd env variables
       {{- include "snippet.statsd-env" . | indent 8 }}
 
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
         - name: DISABLE_SECURE_SSL_REDIRECT
           value: '1'
         - name: IS_BEHIND_PROXY

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -80,12 +80,6 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
 
-        - name: SITE_URL
-          value: {{ template "posthog.site.url" . }}
-        - name: DEPLOYMENT
-          value: {{ template "posthog.deploymentEnv" . }}
-        - name: SENTRY_DSN
-          value: {{ .Values.sentryDSN | quote }}
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.posthog-env" . | indent 8 }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -86,10 +86,6 @@ spec:
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}
-        - name: CAPTURE_INTERNAL_METRICS
-          value: {{ .Values.web.internalMetrics.capture| quote }}
-        - name: HELM_INSTALL_INFO
-          value: {{ template "posthog.helmInstallInfo" . }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Previously it was being passed in individually to each deployment. This
change passes it in, along with SENTRY_DSN and DEPLOYMENT and some others via the
general `snippet.posthog-env` template.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Existing CI 🤞 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
