### PR TITLE
fix: wait for clickhouse migrations before starting new pods

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -8,7 +8,12 @@
     - >
         until (python manage.py migrate --check);
         do
-            echo "Waiting for database migrations to be completed"; sleep 1;
+            echo "Waiting for PostgreSQL database migrations to be completed"; sleep 1;
+        done
+
+        until (python manage.py migrate_clickhouse --check);
+        do
+            echo "Waiting for ClickHouse database migrations to be completed"; sleep 1;
         done
   env:
 


### PR DESCRIPTION
Previously we were just waiting on PostgreSQL migrations. As a result,
pods would end up getting into a crash loop.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
