### PR TITLE
ci: detect restarted pods in kubetest

### DIFF
--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -46,6 +46,7 @@ jobs:
         run: |
           cd ci/kubetest && \
           python -m pytest . -s \
+            --maxfail=1 \
             --splits ${{ matrix.concurrency }} \
             --group ${{ matrix.group }} \
             --splitting-algorithm=least_duration \

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-kubetest:
     runs-on: ubuntu-20.04
@@ -18,11 +22,11 @@ jobs:
     name: e2e - kubetest (${{matrix.group}}/${{ matrix.concurrency }})
 
     strategy:
-        fail-fast: false
-        matrix:
-            # :NOTE: Keep concurrency and group's in sync
-            concurrency: [10]
-            group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      fail-fast: false
+      matrix:
+        # :NOTE: Keep concurrency and group's in sync
+        concurrency: [10]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
       - uses: actions/checkout@v3

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -8,7 +8,12 @@
     - >
         until (python manage.py migrate --check);
         do
-            echo "Waiting for database migrations to be completed"; sleep 1;
+            echo "Waiting for PostgreSQL database migrations to be completed"; sleep 1;
+        done
+
+        until (python manage.py migrate_clickhouse --check);
+        do
+            echo "Waiting for ClickHouse database migrations to be completed"; sleep 1;
         done
   env:
 

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -39,8 +39,12 @@ spec:
           - |
             set -e
             python manage.py notify_helm_install || true
-            python manage.py migrate
+            python manage.py migrate &
+            migrate_pid=$!
             python manage.py migrate_clickhouse
+            migrate_clickhouse_pid=$!
+            wait $migrate_pid
+            wait $migrate_clickhouse_pid
             python manage.py run_async_migrations --check
             python manage.py sync_replicated_schema
 

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -39,9 +39,8 @@ spec:
           - |
             set -e
             python manage.py notify_helm_install || true
-            python manage.py migrate &
-            python manage.py migrate_clickhouse &
-            wait
+            python manage.py migrate
+            python manage.py migrate_clickhouse
             python manage.py run_async_migrations --check
             python manage.py sync_replicated_schema
 

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -39,7 +39,11 @@ spec:
           - |
             set -e
             python manage.py notify_helm_install || true
-            ./bin/migrate
+            python manage.py migrate &
+            python manage.py migrate_clickhouse &
+            wait
+            python manage.py run_async_migrations --check
+            python manage.py sync_replicated_schema
 
         env:
         # Kafka env variables

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -34,7 +34,7 @@ spec:
       - name: migrate-job
         image: {{ template "posthog.image.fullPath" . }}
         command:
-          - /bin/sh
+          - /bin/bash
           - -c
           - |
             set -e

--- a/ci/kubetest/helpers/clickhouse.py
+++ b/ci/kubetest/helpers/clickhouse.py
@@ -6,7 +6,7 @@ def get_clickhouse_statefulset_spec(kube):
         namespace="posthog",
         labels={"clickhouse.altinity.com/namespace": "posthog"},
     )
-    statefulset = next(iter(statefulsets.values()))
+    statefulset = list(statefulsets.values())[0]
     return statefulset.obj.spec
 
 
@@ -18,7 +18,7 @@ def get_clickhouse_cluster_service_spec(kube):
             "clickhouse.altinity.com/Service": "cluster",
         },
     )
-    service = next(iter(services.values()))
+    service = list(services.values())[0]
     return service.obj.spec
 
 
@@ -33,12 +33,12 @@ def get_clickhouse_pods(kube):
 
 
 def get_clickhouse_pod_spec(kube):
-    pod = next(iter(get_clickhouse_pods(kube).values()))
+    pod = list(get_clickhouse_pods(kube).values())[0]
     return pod.obj.spec
 
 
 def run_query_on_clickhouse_nodes(kube, user, password, query):
-    pod = next(iter(get_clickhouse_pods(kube).values()))
+    pod = list(get_clickhouse_pods(kube).values())[0]
     response = pod.http_proxy_get(
         "/",
         {

--- a/ci/kubetest/helpers/clickhouse.py
+++ b/ci/kubetest/helpers/clickhouse.py
@@ -1,25 +1,39 @@
-import json
+import time
 
 
 def get_clickhouse_statefulset_spec(kube):
-    statefulsets = kube.get_statefulsets(
-        namespace="posthog",
-        labels={"clickhouse.altinity.com/namespace": "posthog"},
-    )
-    statefulset = list(statefulsets.values())[0]
-    return statefulset.obj.spec
+    start = time.time()
+    while time.time() - start < 120:
+        statefulsets = kube.get_statefulsets(
+            namespace="posthog",
+            labels={"clickhouse.altinity.com/namespace": "posthog"},
+        )
+
+        if len(statefulsets) > 0:
+            return list(statefulsets.values())[0].obj.spec
+
+        time.sleep(5)
+
+    raise Exception("Timed out waiting for resource")
 
 
 def get_clickhouse_cluster_service_spec(kube):
-    services = kube.get_services(
-        namespace="posthog",
-        labels={
-            "clickhouse.altinity.com/namespace": "posthog",
-            "clickhouse.altinity.com/Service": "cluster",
-        },
-    )
-    service = list(services.values())[0]
-    return service.obj.spec
+    start = time.time()
+    while time.time() - start < 120:
+        services = kube.get_services(
+            namespace="posthog",
+            labels={
+                "clickhouse.altinity.com/namespace": "posthog",
+                "clickhouse.altinity.com/Service": "cluster",
+            },
+        )
+
+        if len(services) > 0:
+            return list(services.values())[0].obj.spec
+
+        time.sleep(5)
+
+    raise Exception("Timed out waiting for resource")
 
 
 def get_clickhouse_pods(kube):

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -120,7 +120,7 @@ def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None):
     log.debug("🔄 Waiting for all pods to be ready...")
     labels = labels or {"app": "posthog"}
     start = time.time()
-    timeout = 300
+    timeout = 600
     while time.time() < start + timeout:
         pods = kube.get_pods(namespace="posthog", labels=labels)
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -99,12 +99,12 @@ def install_chart(values, namespace=NAMESPACE):
                 --install \
                 -f {values_file.name} \
                 --set cloud=local \
-                --timeout 30m \
                 --create-namespace \
                 --namespace {namespace} \
                 posthog ../../charts/posthog
         """
         )
+
     log.debug("✅ Done!")
 
 

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -118,7 +118,7 @@ def kubectl_exec(pod, command):
 
 def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None):
     log.debug("🔄 Waiting for all pods to be ready...")
-    labels = labels or {"app": "posthog"}
+    labels = labels or {}
     start = time.time()
     timeout = 600
     while time.time() < start + timeout:
@@ -128,7 +128,9 @@ def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None):
             continue
 
         for pod in pods.values():
-            assert pod.get_restart_count() == 0, f"Detected restart in pod {pod.obj.metadata.name}"
+            if pod.obj.metadata.labels.get('app') == "posthog":
+                # Only ever expect things we have control over to not restart
+                assert pod.get_restart_count() == 0, f"Detected restart in pod {pod.obj.metadata.name}"
 
         if all(pod.is_ready() for pod in pods.values() if "job-name" not in pod.obj.metadata.labels):
             break

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -130,7 +130,7 @@ def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None):
         for pod in pods.values():
             assert pod.get_restart_count() == 0, f"Detected restart in pod {pod.obj.metadata.name}"
 
-        if all(pod.is_ready() for pod in pods.values()):
+        if all(pod.is_ready() for pod in pods.values() if "job-name" not in pod.obj.metadata.labels):
             break
 
         time.sleep(5)

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -128,7 +128,7 @@ def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None):
             continue
 
         for pod in pods.values():
-            if pod.obj.metadata.labels.get('app') == "posthog":
+            if pod.obj.metadata.labels.get("app") == "posthog":
                 # Only ever expect things we have control over to not restart
                 assert pod.get_restart_count() == 0, f"Detected restart in pod {pod.obj.metadata.name}"
 

--- a/ci/kubetest/test_clickhouse_backup.py
+++ b/ci/kubetest/test_clickhouse_backup.py
@@ -61,7 +61,10 @@ clickhouse:
 
 
 def test_backup(kube):
-    create_namespace_if_not_exists(),
+    cleanup_k8s([NAMESPACE, "posthog"])
+    cleanup_helm([NAMESPACE, "posthog"])
+
+    create_namespace_if_not_exists()
     install_custom_resources("./custom_k8s_resources/s3_minio.yaml")
     install_chart(VALUES_WITH_BACKUP)
     wait_for_pods_to_be_ready(kube)
@@ -90,8 +93,3 @@ def verify_backup(kube):
     else:
         pytest.fail("Backup is not succeeded for pod {pod.name}")
 
-
-@pytest.fixture(autouse=True)
-def before_each_cleanup():
-    cleanup_k8s([NAMESPACE, "posthog"])
-    cleanup_helm([NAMESPACE, "posthog"])

--- a/ci/kubetest/test_clickhouse_backup.py
+++ b/ci/kubetest/test_clickhouse_backup.py
@@ -92,4 +92,3 @@ def verify_backup(kube):
             break
     else:
         pytest.fail("Backup is not succeeded for pod {pod.name}")
-

--- a/ci/kubetest/test_clickhouse_backup.py
+++ b/ci/kubetest/test_clickhouse_backup.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import pytest
 
-from helpers.clickhouse import get_clickhouse_cluster_service_spec
 from helpers.utils import (
     NAMESPACE,
     cleanup_helm,

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -114,4 +114,3 @@ def test_can_connect_external_clickhouse_via_secret(kube):
 def setup_external_clickhouse():
     # :TRICKY: We can't use a single docker image since posthog relies on clickhouse being installed in a cluster
     install_chart(VALUES_EXTERNAL_CLICKHOUSE, namespace="clickhouse")
-

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -85,17 +85,26 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET = merge_yaml(
 
 
 def test_can_connect_from_web_pod(kube):
+    cleanup_k8s([NAMESPACE, "clickhouse"])
+    cleanup_helm([NAMESPACE, "clickhouse"])
+
     install_chart(VALUES_ACCESS_CLICKHOUSE)
     wait_for_pods_to_be_ready(kube)
 
 
 def test_can_connect_external_clickhouse_via_password(kube):
+    cleanup_k8s([NAMESPACE, "clickhouse"])
+    cleanup_helm([NAMESPACE, "clickhouse"])
+
     setup_external_clickhouse()
     install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD)
     wait_for_pods_to_be_ready(kube)
 
 
 def test_can_connect_external_clickhouse_via_secret(kube):
+    cleanup_k8s([NAMESPACE, "clickhouse"])
+    cleanup_helm([NAMESPACE, "clickhouse"])
+
     install_custom_resources("./custom_k8s_resources/clickhouse_external_secret.yaml")
     setup_external_clickhouse()
     install_chart(VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_SECRET)
@@ -106,8 +115,3 @@ def setup_external_clickhouse():
     # :TRICKY: We can't use a single docker image since posthog relies on clickhouse being installed in a cluster
     install_chart(VALUES_EXTERNAL_CLICKHOUSE, namespace="clickhouse")
 
-
-@pytest.fixture(autouse=True)
-def before_each_cleanup():
-    cleanup_k8s([NAMESPACE, "clickhouse"])
-    cleanup_helm([NAMESPACE, "clickhouse"])

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -14,11 +14,11 @@ cloud: "local"
 
 clickhouse:
   image:
-    tag: 22.3.6.5-alpine 
+    tag: 22.3.6.5-alpine
 """
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def setup(kube):
     cleanup_k8s()
     cleanup_helm()
@@ -26,7 +26,7 @@ def setup(kube):
     wait_for_pods_to_be_ready(kube)
 
 
-def test_posthog_healthy(kube):
+def test_posthog_healthy(setup, kube):
     is_posthog_healthy(kube)
 
 

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -18,18 +18,12 @@ clickhouse:
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_clickhouse_pod_image(kube):
     cleanup_k8s()
     cleanup_helm()
     install_chart(VALUES_WITH_DIFFERENT_CLICKHOUSE_IMAGE)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_posthog_healthy(setup, kube):
     is_posthog_healthy(kube)
-
-
-def test_clickhouse_pod_image(kube):
     pod_spec = get_clickhouse_pod_spec(kube)
     assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.6.5-alpine"

--- a/ci/kubetest/test_clickhouse_persistence_disabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_disabled.py
@@ -10,9 +10,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_clickhouse_persistence_disabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_disabled.py
@@ -7,7 +7,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_clickhouse_persistence_disabled.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_clickhouse_persistence_enabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled.py
@@ -11,9 +11,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_clickhouse_persistence_enabled.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled.py
@@ -8,7 +8,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_clickhouse_persistence_enabled.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -13,7 +13,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_clickhouse_persistence_enabled_existing_claim.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -1,6 +1,6 @@
 import logging
+import time
 
-import pytest
 from kubernetes import client
 
 from helpers.clickhouse import get_clickhouse_statefulset_spec
@@ -26,15 +26,12 @@ def create_custom_pvc():
     log.debug("✅ Done!")
 
 
-@pytest.fixture
-def setup(kube):
+def test_volume_claim(kube):
     cleanup_k8s()
     create_custom_pvc()
     helm_install(HELM_INSTALL_CMD)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_volume_claim(setup, kube):
     statefulset_spec = get_clickhouse_statefulset_spec(kube)
 
     # Verify the spec.volumes configuration

--- a/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
+++ b/ci/kubetest/test_clickhouse_persistence_enabled_existing_claim.py
@@ -16,9 +16,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_clickhouse_service_loadbalancer.py
+++ b/ci/kubetest/test_clickhouse_service_loadbalancer.py
@@ -10,9 +10,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_clickhouse_service_loadbalancer.py
+++ b/ci/kubetest/test_clickhouse_service_loadbalancer.py
@@ -7,7 +7,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_clickhouse_service_loadbalancer.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_clickhouse_service_loadbalancer.py
+++ b/ci/kubetest/test_clickhouse_service_loadbalancer.py
@@ -13,17 +13,9 @@ helm upgrade \
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_cluster_service(setup, kube):
     cleanup_k8s()
     helm_install(HELM_INSTALL_CMD)
     wait_for_pods_to_be_ready(kube)
-
-
-def test_helm_install(setup, kube):
-    pass
-
-
-def test_cluster_service(kube):
     cluster_service = get_clickhouse_cluster_service_spec(kube)
     assert cluster_service.type == "LoadBalancer", "ClickHouse cluster service type is {}".format(cluster_service.type)

--- a/ci/kubetest/test_clickhouse_service_loadbalancer.py
+++ b/ci/kubetest/test_clickhouse_service_loadbalancer.py
@@ -1,5 +1,3 @@
-import pytest
-
 from helpers.clickhouse import get_clickhouse_cluster_service_spec
 from helpers.utils import cleanup_k8s, helm_install, wait_for_pods_to_be_ready
 
@@ -13,7 +11,7 @@ helm upgrade \
 """
 
 
-def test_cluster_service(setup, kube):
+def test_cluster_service(kube):
     cleanup_k8s()
     helm_install(HELM_INSTALL_CMD)
     wait_for_pods_to_be_ready(kube)

--- a/ci/kubetest/test_clickhouse_service_nodeport.py
+++ b/ci/kubetest/test_clickhouse_service_nodeport.py
@@ -10,9 +10,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_clickhouse_service_nodeport.py
+++ b/ci/kubetest/test_clickhouse_service_nodeport.py
@@ -7,7 +7,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_clickhouse_service_nodeport.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_clickhouse_service_nodeport.py
+++ b/ci/kubetest/test_clickhouse_service_nodeport.py
@@ -13,17 +13,10 @@ helm upgrade \
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_cluster_service(kube):
     cleanup_k8s()
     helm_install(HELM_INSTALL_CMD)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_helm_install(setup, kube):
-    pass
-
-
-def test_cluster_service(kube):
     cluster_service = get_clickhouse_cluster_service_spec(kube)
     assert cluster_service.type == "NodePort", "ClickHouse cluster service type is {}".format(cluster_service.type)

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -32,7 +32,7 @@ clickhouse:
 # I don't think this ever worked, but this was being masked by the issue that
 # there was a fixture that was being initialized for each test_ hence we were
 # just testing that we could perform the initial install with more shards.
-@pytest.skip("Broken, clickhouse-operator fails to replicate tables to new shards")
+@pytest.mark.skip("Broken, clickhouse-operator fails to replicate tables to new shards")
 def test_upgrading_to_more_shards(kube):
     cleanup_k8s()
     cleanup_helm()

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from helpers.clickhouse import get_clickhouse_table_counts_on_all_nodes
-from helpers.utils import cleanup_helm, cleanup_k8s, install_chart, is_posthog_healthy, wait_for_pods_to_be_ready
+from helpers.utils import cleanup_helm, cleanup_k8s, install_chart, wait_for_pods_to_be_ready
 
 VALUES_WITH_SHARDING = """
 cloud: "local"
@@ -22,6 +22,17 @@ clickhouse:
 """
 
 
+# I've disabled this for now, on bringing up the 5th clickhouse node it appears
+# we get:
+#
+# │ E0630 09:54:06.695617       1 connection.go:184] Exec():FAILED Exec(http://***:***@chi-posthog-posthog-2-0.posthog.svc.clust │
+# │  for SQL: CREATE TABLE IF NOT EXISTS posthog.sharded_session_recording_events (`uuid` UUID, `timestamp` DateTime64(6, 'UTC') │
+# │ I0630 09:54:06.695646       1 retry.go:48] exec():chi-posthog-posthog-2-0.posthog.svc.cluster.local:FAILED attempt 2 of 10,  │
+#
+# I don't think this ever worked, but this was being masked by the issue that
+# there was a fixture that was being initialized for each test_ hence we were
+# just testing that we could perform the initial install with more shards.
+@pytest.skip("Broken, clickhouse-operator fails to replicate tables to new shards")
 def test_upgrading_to_more_shards(kube):
     cleanup_k8s()
     cleanup_helm()

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -22,7 +22,7 @@ clickhouse:
 """
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def setup(kube):
     cleanup_k8s()
     cleanup_helm()
@@ -30,7 +30,7 @@ def setup(kube):
     wait_for_pods_to_be_ready(kube)
 
 
-def test_posthog_healthy(kube):
+def test_posthog_healthy(setup, kube):
     is_posthog_healthy(kube)
 
 

--- a/ci/kubetest/test_clickhouse_sharding.py
+++ b/ci/kubetest/test_clickhouse_sharding.py
@@ -22,19 +22,12 @@ clickhouse:
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_upgrading_to_more_shards(kube):
     cleanup_k8s()
     cleanup_helm()
     install_chart(VALUES_WITH_SHARDING)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_posthog_healthy(setup, kube):
-    is_posthog_healthy(kube)
-
-
-def test_shards_are_properly_set_up(kube):
     number_of_hosts, table_counts = get_clickhouse_table_counts_on_all_nodes(kube)
 
     assert number_of_hosts == 4
@@ -43,8 +36,6 @@ def test_shards_are_properly_set_up(kube):
     # table count as of 2022.02.24
     assert table_counts[0] >= 31
 
-
-def test_upgrading_to_more_shards(kube):
     # Upgrade to 6 nodes in total (3 * 2)
     new_values = yaml.safe_load(VALUES_WITH_SHARDING)
     new_values["clickhouse"]["layout"]["shardsCount"] = 3

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -6,6 +6,9 @@ from helpers.utils import apply_manifest, cleanup_k8s, create_namespace_if_not_e
 
 
 def test_can_use_external_object_storage_with_secret_specified():
+    cleanup_k8s()
+    create_namespace_if_not_exists()
+
     # MinIO credentials
     username = "some-user"
     password = "some-password"
@@ -54,8 +57,3 @@ def test_can_use_external_object_storage_with_secret_specified():
         """
     )
 
-
-@pytest.fixture(autouse=True)
-def before_each_cleanup():
-    cleanup_k8s()
-    create_namespace_if_not_exists()

--- a/ci/kubetest/test_external_object_storage.py
+++ b/ci/kubetest/test_external_object_storage.py
@@ -56,4 +56,3 @@ def test_can_use_external_object_storage_with_secret_specified():
                 existingSecret: object-storage-config
         """
     )
-

--- a/ci/kubetest/test_postgresql_connectivity.py
+++ b/ci/kubetest/test_postgresql_connectivity.py
@@ -82,4 +82,3 @@ def test_can_connect_from_web_pod(values, resources_to_install, kube):
 
     install_chart(values)
     wait_for_pods_to_be_ready(kube)
-

--- a/ci/kubetest/test_postgresql_connectivity.py
+++ b/ci/kubetest/test_postgresql_connectivity.py
@@ -73,15 +73,13 @@ externalPostgresql:
     ],
 )
 def test_can_connect_from_web_pod(values, resources_to_install, kube):
+    cleanup_k8s()
+    exec_subprocess("kubectl delete pvc --all --all-namespaces")
+    create_namespace_if_not_exists()
+
     for resource in resources_to_install:
         install_custom_resources(resource)
 
     install_chart(values)
     wait_for_pods_to_be_ready(kube)
 
-
-@pytest.fixture(autouse=True)
-def before_each_cleanup():
-    cleanup_k8s()
-    exec_subprocess("kubectl delete pvc --all --all-namespaces")
-    create_namespace_if_not_exists()

--- a/ci/kubetest/test_posthog_hpa_enabled.py
+++ b/ci/kubetest/test_posthog_hpa_enabled.py
@@ -6,7 +6,6 @@ HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
     -f ../../ci/values/kubetest/test_posthog_hpa_enabled.yaml \
-    --timeout 30m \
     --create-namespace \
     --namespace posthog \
     posthog ../../charts/posthog

--- a/ci/kubetest/test_posthog_hpa_enabled.py
+++ b/ci/kubetest/test_posthog_hpa_enabled.py
@@ -9,9 +9,7 @@ helm upgrade \
     --timeout 30m \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_prometheus_postgres_exporter.py
+++ b/ci/kubetest/test_prometheus_postgres_exporter.py
@@ -11,20 +11,11 @@ prometheus-postgres-exporter:
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_prometheus_postgres_exporter(kube):
     cleanup_k8s()
     install_chart(VALUES_YAML)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_helm_install(setup, kube):
-    pass
-
-
-def test_posthog_healthy(kube):
     is_posthog_healthy(kube)
 
-
-def test_prometheus_postgres_exporter(kube):
     is_prometheus_exporter_healthy(kube, "prometheus-postgres-exporter", "pg_up 1")

--- a/ci/kubetest/test_prometheus_redis_exporter.py
+++ b/ci/kubetest/test_prometheus_redis_exporter.py
@@ -11,20 +11,10 @@ prometheus-redis-exporter:
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_prometheus_redis_exporter(kube):
     cleanup_k8s()
     install_chart(VALUES_YAML)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_helm_install(setup, kube):
-    pass
-
-
-def test_posthog_healthy(kube):
     is_posthog_healthy(kube)
-
-
-def test_prometheus_redis_exporter(kube):
     is_prometheus_exporter_healthy(kube, "prometheus-redis-exporter", "redis_up 1")

--- a/ci/kubetest/test_redis_external.py
+++ b/ci/kubetest/test_redis_external.py
@@ -21,9 +21,7 @@ helm upgrade \
     -f ../../ci/values/kubetest/test_redis_external.yaml \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_redis_external.py
+++ b/ci/kubetest/test_redis_external.py
@@ -17,7 +17,6 @@ log = logging.getLogger()
 HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
-    --timeout 30m \
     -f ../../ci/values/kubetest/test_redis_external.yaml \
     --create-namespace \
     --namespace posthog \

--- a/ci/kubetest/test_redis_external_with_existing_secret.py
+++ b/ci/kubetest/test_redis_external_with_existing_secret.py
@@ -17,7 +17,6 @@ log = logging.getLogger()
 HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
-    --timeout 30m \
     -f ../../ci/values/kubetest/test_redis_external_with_existing_secret.yaml \
     --create-namespace \
     --namespace posthog \

--- a/ci/kubetest/test_redis_external_with_existing_secret.py
+++ b/ci/kubetest/test_redis_external_with_existing_secret.py
@@ -24,24 +24,15 @@ helm upgrade \
 """
 
 
-@pytest.fixture
-def setup(kube):
+def test_redis_secret(kube):
     cleanup_k8s()
     create_namespace_if_not_exists()
     install_custom_resources("./custom_k8s_resources/redis_external_with_existing_secret.yaml")
     helm_install(HELM_INSTALL_CMD)
     wait_for_pods_to_be_ready(kube)
 
-
-def test_helm_install(setup, kube):
-    pass
-
-
-def test_posthog_healthy(kube):
     is_posthog_healthy(kube)
 
-
-def test_redis_secret(kube):
     secrets = kube.get_secrets(namespace="posthog", fields={"type": "Opaque"})
 
     default_redis_secret_name = "posthog-posthog-redis-external"

--- a/ci/kubetest/test_redis_external_with_existing_secret.py
+++ b/ci/kubetest/test_redis_external_with_existing_secret.py
@@ -21,9 +21,7 @@ helm upgrade \
     -f ../../ci/values/kubetest/test_redis_external_with_existing_secret.yaml \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_redis_external_with_password.py
+++ b/ci/kubetest/test_redis_external_with_password.py
@@ -22,9 +22,7 @@ helm upgrade \
     -f ../../ci/values/kubetest/test_redis_external_with_password.yaml \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_redis_external_with_password.py
+++ b/ci/kubetest/test_redis_external_with_password.py
@@ -18,7 +18,6 @@ log = logging.getLogger()
 HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
-    --timeout 30m \
     -f ../../ci/values/kubetest/test_redis_external_with_password.yaml \
     --create-namespace \
     --namespace posthog \

--- a/ci/kubetest/test_redis_internal_with_existing_secret.py
+++ b/ci/kubetest/test_redis_internal_with_existing_secret.py
@@ -21,9 +21,7 @@ helm upgrade \
     -f ../../ci/values/kubetest/test_redis_internal_with_existing_secret.yaml \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 

--- a/ci/kubetest/test_redis_internal_with_existing_secret.py
+++ b/ci/kubetest/test_redis_internal_with_existing_secret.py
@@ -17,7 +17,6 @@ log = logging.getLogger()
 HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
-    --timeout 30m \
     -f ../../ci/values/kubetest/test_redis_internal_with_existing_secret.yaml \
     --create-namespace \
     --namespace posthog \

--- a/ci/kubetest/test_redis_internal_with_password.py
+++ b/ci/kubetest/test_redis_internal_with_password.py
@@ -11,7 +11,6 @@ log = logging.getLogger()
 HELM_INSTALL_CMD = """
 helm upgrade \
     --install \
-    --timeout 30m \
     -f ../../ci/values/kubetest/test_redis_internal_with_password.yaml \
     --create-namespace \
     --namespace posthog \

--- a/ci/kubetest/test_redis_internal_with_password.py
+++ b/ci/kubetest/test_redis_internal_with_password.py
@@ -15,9 +15,7 @@ helm upgrade \
     -f ../../ci/values/kubetest/test_redis_internal_with_password.yaml \
     --create-namespace \
     --namespace posthog \
-    posthog ../../charts/posthog \
-    --wait-for-jobs \
-    --wait
+    posthog ../../charts/posthog
 """
 
 


### PR DESCRIPTION
Before https://github.com/PostHog/charts-clickhouse/pull/457/checks we
were having pods getting into crash loops. To ensure we catch these
cases in the future, and to enable some faster failing tests we abort as
soon as we see something has restarted.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
