### PR TITLE
chore(CI): use official channel for 1.24

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -24,7 +24,7 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
-          - k3s-channel: v1.24.1+k3s1
+          - k3s-channel: v1.24
             test: install
             values: ci/values/k3s.yaml
           - k3s-channel: v1.23


### PR DESCRIPTION
## Description
Now that the official channel for k8s 1.24 is out we should use it without having to pin a specific patch version

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
