### PR TITLE
K8s - drop support for v1.21

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -33,9 +33,6 @@ jobs:
           - k3s-channel: v1.22
             test: install
             values: ci/values/k3s.yaml
-          - k3s-channel: v1.21
-            test: install
-            values: ci/values/k3s.yaml
 
           # We run an upgrade test where we first install an already released
           # Helm chart version and then upgrade to the version we are now

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">= 1.21-0 <= 1.24-0"
+kubeVersion: ">= 1.22-0 <= 1.24-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -20,7 +20,7 @@ This Helm chart bootstraps a [PostHog](https://posthog.com/) installation on a [
 
 
 ## Prerequisites
-- Kubernetes >=1.21 <= 1.24
+- Kubernetes >=1.22 <= 1.24
 - Helm >= 3.7.0
 
 ## Installation


### PR DESCRIPTION
## Description
This PR drops the support for Kubernetes v1.21 as EOL since 2022-06-28.

Accompanying release notes are available at: 

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
