### PR TITLE
chore: avoid setting SENTRY_DSN if .Values.sentryDSN not set

### DIFF
--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -16,8 +16,10 @@
       key: {{ .Values.posthogSecretKey.existingSecretKey }}
 - name: SITE_URL
   value: {{ template "posthog.site.url" . }}
+{{ if .Values.sentryDSN }}
 - name: SENTRY_DSN
   value: {{ .Values.sentryDSN | quote }}
+{{ end }}
 - name: DEPLOYMENT
   value: {{ template "posthog.deploymentEnv" . }}
 - name: CAPTURE_INTERNAL_METRICS


### PR DESCRIPTION
This is such that we can not use the Helm Chart value for setting this,
but rather use the `env` on individual deployments, such that we can
specify a different one per deployment. (e.g. a separate one for the
plugin-server).

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
