### PR TITLE
PgBouncer - upgrade to 1.17.0

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -3,8 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
-  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +18,9 @@ spec:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.pgbouncer.podAnnotations }}
+{{ toYaml .Values.pgbouncer.podAnnotations | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
@@ -44,51 +47,55 @@ spec:
       {{- end }}
       {{- if .Values.pgbouncer.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.pgbouncer.podSecurityContext "enabled" | toYaml | nindent 8 }}
-      {{- end }}     
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-pgbouncer
-      {{- if .Values.pgbouncer.image }}
-        image: "{{ default "edoburu/pgbouncer" .Values.pgbouncer.image.repository }}:{{ default "1.12.0" .Values.pgbouncer.image.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.pgbouncer.image.pullPolicy }}
-      {{- else }}
-        image: "edoburu/pgbouncer:1.12.0"
-        imagePullPolicy: "IfNotPresent"
-      {{- end }}
+        image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy }}
         ports:
         - containerPort: 6543
         env:
-        - name: DB_USER
+        - name: POSTGRESQL_USERNAME
           value: {{ include "posthog.postgresql.username" . }}
-        - name: DB_PASSWORD
+        - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "posthog.postgresql.secretName" . }}
               key: {{ include "posthog.postgresql.secretPasswordKey" . }}
-        - name: DB_HOST
+        - name: POSTGRESQL_HOST
           value: {{ include "posthog.postgresql.host" . }}
-        - name: DB_PORT
+        - name: POSTGRESQL_PORT
           value: {{ include "posthog.postgresql.port" . | quote }}
-        - name: DB_NAME
+        - name: POSTGRESQL_DATABASE
           value: {{ include "posthog.postgresql.database" . }}
-        - name: LISTEN_PORT
-          value: "6543"
-        - name: MAX_CLIENT_CONN
-          value: "1000"
-        - name: POOL_MODE
-          value: "transaction"
+        - name: PGBOUNCER_DATABASE
+          value: {{ include "posthog.postgresql.database" . }}
 {{- if .Values.pgbouncer.env }}
 {{ toYaml .Values.pgbouncer.env | indent 8 }}
 {{- end }}
         readinessProbe:
           tcpSocket:
             port: 6543
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          failureThreshold: {{ .Values.pgbouncer.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncer.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncer.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncer.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncer.readinessProbe.timeoutSeconds }}
+
         livenessProbe:
           tcpSocket:
             port: 6543
-          initialDelaySeconds: 15
-          periodSeconds: 20
+          failureThreshold: {{ .Values.pgbouncer.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncer.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncer.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncer.livenessProbe.timeoutSeconds }}
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 60"]
+
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}
       {{- end }}
@@ -98,7 +105,7 @@ spec:
 {{- end }}
         {{- if .Values.pgbouncer.securityContext.enabled }}
         securityContext: {{- omit .Values.pgbouncer.securityContext "enabled" | toYaml | nindent 12 }}
-        {{- end }}     
+        {{- end }}
     {{- if .Values.pgbouncer.extraVolumes }}
       volumes: {{- toYaml .Values.pgbouncer.extraVolumes | nindent 6 }}
     {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -29,6 +29,11 @@ spec:
 {{ toYaml .Values.pgbouncer.podLabels | indent 8 }}
         {{- end }}
     spec:
+      # Time to wait before hard killing the container. Note: if the container
+      # shuts down and exits before the terminationGracePeriod is done, we
+      # moves to the next step immediately.
+      terminationGracePeriodSeconds: 70
+
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.pgbouncer.affinity }}
       affinity:
@@ -104,10 +109,6 @@ spec:
               # See https://www.pgbouncer.org/usage.html
               #
               command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 60"]
-
-      terminationGracePeriodSeconds: 70 # Time to wait before hard killing
-      # the container. Note: if the container shuts down and exits before the
-      # terminationGracePeriod is done, k8s moves to the next step immediately.
 
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.pgbouncer.podAnnotations }}
 {{ toYaml .Values.pgbouncer.podAnnotations | indent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       - name: {{ .Chart.Name }}-pgbouncer
         image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"
         imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy }}
+
         ports:
         - containerPort: 6543
         env:
@@ -94,7 +95,19 @@ spec:
         lifecycle:
           preStop:
             exec:
+              #
+              # Before killing the container, let'send a SIGINT to the pgbouncer
+              # process for a safe shutdown. Let's then wait 60s that is the double
+              # of the max connection timeout we have in our app to make sure
+              # connections are drained before we terminate the container.
+              #
+              # See https://www.pgbouncer.org/usage.html
+              #
               command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 60"]
+
+      terminationGracePeriodSeconds: 70 # Time to wait before hard killing
+      # the container. Note: if the container shuts down and exits before the
+      # terminationGracePeriod is done, k8s moves to the next step immediately.
 
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -20,4 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
+  behavior:
+    {{ toYaml .Values.pgbouncer.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-service.yaml
+++ b/charts/posthog/templates/pgbouncer-service.yaml
@@ -3,14 +3,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+   {{- range $key, $value := .Values.pgbouncer.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
-  type: "ClusterIP"
+  type: {{ .Values.pgbouncer.service.type }}
   ports:
-  - port: 6543
+  - name: {{ template "posthog.fullname" . }}-pgbouncer
+    port: 6543
     targetPort: 6543
-    protocol: TCP
-    name: {{ template "posthog.fullname" . }}-pgbouncer
   selector:
     app: {{ template "posthog.fullname" . }}
     role: pgbouncer

--- a/charts/posthog/templates/plugins-hpa.yaml
+++ b/charts/posthog/templates/plugins-hpa.yaml
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.plugins.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/tests/pgbouncer-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-hpa.yaml
@@ -56,6 +56,9 @@ tests:
           minpods: 2
           maxpods: 10
           cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
     asserts:
       - equal:
           path: spec
@@ -73,3 +76,6 @@ tests:
                 target:
                   type: Utilization
                   averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -556,31 +556,89 @@ externalPostgresql:
 pgbouncer:
   # -- Whether to deploy a PgBouncer service to satisfy the applications requirements.
   enabled: true
-  hpa:
-    # -- Boolean to create a HorizontalPodAutoscaler for pgbouncer
-    # -- This experimental and set up based on cpu utilization
-    # -- Adding pgbouncers can cause running out of connections for Postgres
-    enabled: false
-    # -- CPU threshold percent for pgbouncer
-    cputhreshold: 60
-    # -- Min pods for pgbouncer
-    minpods: 1
-    # -- Max pods for pgbouncer
-    maxpods: 10
-  # -- How many replicas of pgbouncer to run. Ignored if hpa is used
+
+  # -- Count of pgbouncer pods to run. This setting is ignored if `pgbouncer.hpa.enabled` is set to `true`.
   replicacount: 1
-  # -- Additional env vars to be added to the pgbouncer deployment
-  env: []
-  # -- Additional volumeMounts to be added to the pgbouncer deployment
-  extraVolumeMounts: []
-  # -- Additional volumes to be added to the pgbouncer deployment
-  extraVolumes: []
-  # -- Container security context for the pgbouncer deployment
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the pgbouncer stack.
+    enabled: false
+    # -- CPU threshold percent for the pgbouncer stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the pgbouncer stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the pgbouncer stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  # -- Additional env variables to inject into the pgbouncer stack deployment.
+  env:
+    - name: PGBOUNCER_PORT
+      value: "6543"
+    - name: PGBOUNCER_MAX_CLIENT_CONN
+      value: "1000"
+    - name: PGBOUNCER_POOL_MODE
+      value: "transaction"
+
+  # -- Resource limits for the pgbouncer stack deployment.
+  resources: {}
+
+  # -- Node labels for the pgbouncer stack deployment.
+  nodeSelector: {}
+
+  # -- Toleration labels for the pgbouncer stack deployment.
+  tolerations: []
+
+  # -- Affinity settings for the pgbouncer stack deployment.
+  affinity: {}
+
+  # -- Container security context for the pgbouncer stack deployment.
   securityContext:
     enabled: false
-  # -- Pod security context for the pgbouncer deployment
+
+  # -- Pod security context for the pgbouncer stack deployment.
   podSecurityContext:
     enabled: false
+
+  readinessProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 3
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 10
+    # -- The readiness probe period seconds
+    periodSeconds: 5
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 2
+
+  livenessProbe:
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 60
+    # -- The liveness probe period seconds
+    periodSeconds: 10
+    # -- The liveness probe success threshold
+    successThreshold: 1
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 2
+
+  image:
+    repository: bitnami/pgbouncer
+    tag: 1.17.0
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  ## -- PgBouncer pod(s) annotation.
+  podAnnotations: {}
+
 
 ###
 ###

--- a/ci/kubetest/helpers/clickhouse.py
+++ b/ci/kubetest/helpers/clickhouse.py
@@ -3,7 +3,7 @@ import time
 
 def get_clickhouse_statefulset_spec(kube):
     start = time.time()
-    while time.time() - start < 300:
+    while (time.time() - start) < 300:
         statefulsets = kube.get_statefulsets(
             namespace="posthog",
             labels={"clickhouse.altinity.com/namespace": "posthog"},

--- a/ci/kubetest/helpers/clickhouse.py
+++ b/ci/kubetest/helpers/clickhouse.py
@@ -3,7 +3,7 @@ import time
 
 def get_clickhouse_statefulset_spec(kube):
     start = time.time()
-    while time.time() - start < 120:
+    while time.time() - start < 300:
         statefulsets = kube.get_statefulsets(
             namespace="posthog",
             labels={"clickhouse.altinity.com/namespace": "posthog"},
@@ -19,7 +19,7 @@ def get_clickhouse_statefulset_spec(kube):
 
 def get_clickhouse_cluster_service_spec(kube):
     start = time.time()
-    while time.time() - start < 120:
+    while time.time() - start < 300:
         services = kube.get_services(
             namespace="posthog",
             labels={

--- a/ci/kubetest/helpers/clickhouse.py
+++ b/ci/kubetest/helpers/clickhouse.py
@@ -19,7 +19,7 @@ def get_clickhouse_statefulset_spec(kube):
 
 def get_clickhouse_cluster_service_spec(kube):
     start = time.time()
-    while time.time() - start < 300:
+    while (time.time() - start) < 300:
         services = kube.get_services(
             namespace="posthog",
             labels={


### PR DESCRIPTION
## Description
- upgrade PgBouncer from 1.12.0 to 1.17.0 (see changelog [here](https://www.pgbouncer.org/changelog.html#pgbouncer-112x)). We are doing that by upgrading the default image to an official bitnami one. From the changelog I don't see any major breaking change.   
- add more fine grain readiness/liveness checks + lifecycle config
- various other fixes to align this deployment and service more close to the others we already have 

Release notes are available at: https://github.com/PostHog/posthog.com/pull/3717

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
