### PR TITLE
PgBouncer - use pkill instead of killall

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -108,7 +108,7 @@ spec:
               #
               # See https://www.pgbouncer.org/usage.html
               #
-              command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 60"]
+              command: ["/bin/sh", "-c", "pkill -INT pgbouncer && sleep 60"]
 
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}


### PR DESCRIPTION
## Description
Small but big detail (introduced via #473), the `bitnami/pgbouncer` container image doesn't contain the `killall` binary, let's use `pkill` instead:

```
I have no name!@posthog-pgbouncer-556c59c447-vxxpk:/$ killall -INT pgbouncer
bash: killall: command not found
```

```
I have no name!@posthog-pgbouncer-556c59c447-vxxpk:/$ /usr/bin/pkill --version
pkill from procps-ng 3.3.17
```

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ + manual tests of the command

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
