### PR TITLE
chore(web): remove trailing forwardslash from probes

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -99,7 +99,7 @@ spec:
 {{- end }}
         livenessProbe:
           httpGet:
-            path: /_livez/
+            path: /_livez
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
@@ -111,7 +111,7 @@ spec:
           httpGet:
             # For readiness, we want to use the checks specific to the events
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz/?role=events
+            path: /_readyz?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
@@ -124,7 +124,7 @@ spec:
             # For startup, we want to make sure that everything is in place,
             # including postgres. This does however mean we would not be able to
             # deploy new releases when we have a postgres outage
-            path: /_readyz/
+            path: /_readyz
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -121,7 +121,7 @@ spec:
 {{- end }}
         livenessProbe:
           httpGet:
-            path: /_livez/
+            path: /_livez
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
@@ -133,7 +133,7 @@ spec:
           httpGet:
             # For readiness, we want to use the checks specific to the web
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz/?role=web
+            path: /_readyz?role=web
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
@@ -146,7 +146,7 @@ spec:
             # For startup, we want to make sure that everything is in place,
             # including postgres. This does however mean we would not be able to
             # deploy new releases when we have a postgres outage
-            path: /_readyz/
+            path: /_readyz
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}

--- a/ci/kubetest/test_clickhouse_connectivity.py
+++ b/ci/kubetest/test_clickhouse_connectivity.py
@@ -23,6 +23,8 @@ VALUES_ACCESS_CLICKHOUSE = merge_yaml(
       enabled: true
     pgbouncer:
       enabled: true
+    kafka:
+      enabled: true
     """,
 )
 

--- a/ci/kubetest/test_clickhouse_external_password.py
+++ b/ci/kubetest/test_clickhouse_external_password.py
@@ -34,6 +34,10 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = merge_yaml(
       enabled: true
     pgbouncer:
       enabled: true
+    kafka:
+      enabled: true
+    zookeeper:
+      enabled: true
 
     clickhouse:
       enabled: false

--- a/ci/kubetest/test_clickhouse_external_via_secret.py
+++ b/ci/kubetest/test_clickhouse_external_via_secret.py
@@ -36,6 +36,10 @@ VALUES_ACCESS_EXTERNAL_CLICKHOUSE_VIA_PASSWORD = merge_yaml(
       enabled: true
     pgbouncer:
       enabled: true
+    kafka:
+      enabled: true
+    zookeeper:
+      enabled: true
 
     clickhouse:
       enabled: false


### PR DESCRIPTION
With the forward slash we end up hitting the login page instead.
Ideally I would want to not follow 302 redirects but I couldn't see how
to do this.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
