### PR TITLE
PgBouncer - changes to preStop

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -100,15 +100,23 @@ spec:
         lifecycle:
           preStop:
             exec:
-              #
-              # Before killing the container, let'send a SIGINT to the pgbouncer
-              # process for a safe shutdown. Let's then wait 60s that is the double
-              # of the max connection timeout we have in our app to make sure
-              # connections are drained before we terminate the container.
-              #
-              # See https://www.pgbouncer.org/usage.html
-              #
-              command: ["/bin/sh", "-c", "pkill -INT pgbouncer && sleep 60"]
+              command: [
+                "sh", "-c",
+                #
+                # Introduce a delay to the shutdown sequence to wait for the
+                # pod eviction event to propagate into the cluster.
+                #
+                # See: https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
+                #
+                "sleep 10",
+                #
+                # Then, gracefully shutdown pgbouncer by sending a SIGINT
+                # to the process.
+                #
+                # See https://www.pgbouncer.org/usage.html
+                #
+                "kill -INT 1",
+              ]
 
       {{- if .Values.pgbouncer.extraVolumeMounts }}
         volumeMounts: {{- toYaml .Values.pgbouncer.extraVolumeMounts | nindent 8 }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI ✅ + manual testing by scaling down pgbouncer:

Timeline:

1️⃣ Termination request is logged (`kubectl get events -n posthog --watch --field-selector involvedObject.name=posthog-pgbouncer-7cdfdf8b-6tktf`)
```
0s          Normal    Killing     pod/posthog-pgbouncer-7cdfdf8b-6tktf   Stopping container posthog-pgbouncer
```

2️⃣ `preStop` is executed, 10 seconds after the process gets the INIT signal 

```
2022-07-07 14:36:46.039 UTC [1] LOG got SIGTERM, fast exit
```
3️⃣ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
