### PR TITLE
PgBouncer: fix resource regression

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   selector:
     matchLabels:
-        app: {{ template "posthog.fullname" . }}
-        release: "{{ .Release.Name }}"
-        role: pgbouncer
+      app: {{ template "posthog.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: pgbouncer
   {{- if not .Values.pgbouncer.hpa.enabled }}
   replicas: {{ .Values.pgbouncer.replicacount }}
   {{- end }}
@@ -134,7 +134,7 @@ spec:
         {{- end }}
 
         {{- if .Values.pgbouncer.resources }}
-        resources: {{ toYaml .Values.pgbouncer.resources | indent 12 }}
+        resources: {{ toYaml .Values.pgbouncer.resources | nindent 10 }}
         {{- end }}
 
         {{- if .Values.pgbouncer.securityContext.enabled }}
@@ -163,7 +163,7 @@ spec:
           - >
               until (nc -vz 127.0.0.1 6543);
               do
-                  echo "waiting for PgBouncer"; sleep 1;
+                echo "waiting for PgBouncer"; sleep 1;
               done
 
               pgbouncer_exporter \
@@ -177,7 +177,7 @@ spec:
             containerPort: {{ .Values.pgbouncer.exporter.port }}
 
         {{- if .Values.pgbouncer.exporter.resources }}
-        resources: {{ toYaml .Values.pgbouncer.exporter.resources | nindent 12 }}
+        resources: {{ toYaml .Values.pgbouncer.exporter.resources | nindent 10 }}
         {{- end }}
 
         {{- if .Values.pgbouncer.exporter.securityContext.enabled }}

--- a/charts/posthog/tests/__snapshot__/pgbouncer-deployment.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/pgbouncer-deployment.yaml.snap
@@ -1,0 +1,58 @@
+should match snapshot data:
+  1: |
+    containers:
+    - env:
+      - name: POSTGRESQL_USERNAME
+        value: postgres
+      - name: POSTGRESQL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgresql-password
+            name: RELEASE-NAME-posthog-postgresql
+      - name: POSTGRESQL_DATABASE
+        value: posthog
+      - name: POSTGRESQL_HOST
+        value: RELEASE-NAME-posthog-postgresql
+      - name: POSTGRESQL_PORT
+        value: "5432"
+      - name: PGBOUNCER_DATABASE
+        value: posthog
+      - name: PGBOUNCER_PORT
+        value: "6543"
+      - name: PGBOUNCER_MAX_CLIENT_CONN
+        value: "1000"
+      - name: PGBOUNCER_POOL_MODE
+        value: transaction
+      - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
+        value: extra_float_digits
+      image: bitnami/pgbouncer:1.17.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - sh
+            - -c
+            - sleep 10 && kill -INT 1 && sleep 31
+      livenessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        successThreshold: 1
+        tcpSocket:
+          port: 6543
+        timeoutSeconds: 2
+      name: posthog-pgbouncer
+      ports:
+      - containerPort: 6543
+        name: pgbouncer
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        successThreshold: 1
+        tcpSocket:
+          port: 6543
+        timeoutSeconds: 2
+    serviceAccountName: RELEASE-NAME-posthog
+    terminationGracePeriodSeconds: 60

--- a/charts/posthog/tests/pgbouncer-deployment.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment.yaml
@@ -13,15 +13,15 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have the correct apiVersion
+  - it: should match snapshot data
     template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
     asserts:
       - hasDocuments:
           count: 1
-      - isAPIVersion:
-          of: apps/v1
+      - matchSnapshot:
+          path: spec.template.spec
 
   - it: should be the correct kind
     template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
@@ -49,7 +49,7 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 2000
-    
+
   - it: should have a container securityContext
     template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -65,8 +65,8 @@ tests:
           value: 1001
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false            
-          
+          value: false
+
   - it: should not have a pod securityContext
     template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -78,7 +78,7 @@ tests:
       - isEmpty:
           path: spec.template.spec.securityContext
           value: 1001
-  
+
   - it: should not have a container securityContext
     template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -88,4 +88,54 @@ tests:
       - hasDocuments:
           count: 1
       - isEmpty:
-          path: spec.template.spec.containers[0].securityContext  
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: pgbouncer should have the correct resources if set
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.resources:
+        requests:
+          cpu: 100m
+          memory: 50M
+        limits:
+          cpu: 512m
+          memory: 100M
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 50M
+            limits:
+              cpu: 512m
+              memory: 100M
+
+  - it: pgbouncer metrics exporter should have the correct resources if set
+    template: templates/pgbouncer-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer.exporter:
+        enabled: true
+        resources:
+          requests:
+            cpu: 125m
+            memory: 100M
+          limits:
+            cpu: 250m
+            memory: 200M
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[1].resources
+          value:
+            requests:
+              cpu: 125m
+              memory: 100M
+            limits:
+              cpu: 250m
+              memory: 200M


### PR DESCRIPTION
## Description
Fix regression introduced via #479. The regression is only triggered in deployments where `pgbouncer.resources` is set. Unfortunately we didn't have a test to catch this but I've added it as part of this PR.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
