### PR TITLE
PgBouncer - conn draining tuning

### DIFF
--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       # Time to wait before hard killing the container. Note: if the container
       # shuts down and exits before the terminationGracePeriod is done, we
       # moves to the next step immediately.
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 65
 
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.pgbouncer.affinity }}
@@ -126,7 +126,7 @@ spec:
                 # removed. Unfortunately we will also get an ugly 'FailedPreStopHook'
                 # warning in the k8s event logs but I'm not sure how we can avoid it.
                 #
-                "sleep 10 && kill -INT 1 && sleep 31"
+                "sleep 30 && kill -INT 1 && sleep 31"
               ]
 
         {{- if .Values.pgbouncer.extraVolumeMounts }}


### PR DESCRIPTION
## Description
The new connection draining logic seems to work fine but we still gets some sporadic client connection errors that we would like to avoid. I'm bumping the first `sleep` (to let the termination event propagate to the service) as I have the feeling (but unfortunately not evidence yet!) it might be the problem.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
