### PR TITLE
Prometheus: alert KubernetesPodNotHealthy reporting incorrect alerts

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1333,8 +1333,8 @@ prometheus:
                 description: "The maximum number of desired Pods has been hit\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
             - alert: KubernetesPodNotHealthy
-              expr: min_over_time(sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"})[15m:1m]) > 0
-              for: 0m
+              expr: sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"}) > 0
+              for: 15m
               labels:
                 severity: critical
               annotations:


### PR DESCRIPTION
## Description
See https://github.com/samber/awesome-prometheus-alerts/pull/263. I'm importing the same fix that is currently in pending review upstream.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
