### PR TITLE
Make sentryDSN configurable for plugin server

### DIFF
--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -16,12 +16,15 @@
       key: {{ .Values.posthogSecretKey.existingSecretKey }}
 - name: SITE_URL
   value: {{ template "posthog.site.url" . }}
-- name: SENTRY_DSN
-  value: {{ .Values.sentryDSN | quote }}
 - name: DEPLOYMENT
   value: {{ template "posthog.deploymentEnv" . }}
 - name: CAPTURE_INTERNAL_METRICS
-  value: {{ .Values.web.internalMetrics.capture| quote }}
+  value: {{ .Values.web.internalMetrics.capture | quote }}
 - name: HELM_INSTALL_INFO
   value: {{ template "posthog.helmInstallInfo" . }}
+{{- end }}
+
+{{- define "snippet.posthog-sentry-env" }}
+- name: SENTRY_DSN
+  value: {{ .Values.sentryDSN | quote }}
 {{- end }}

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -30,5 +30,6 @@
 
   # PostHog app settings
   {{- include "snippet.posthog-env" . | nindent 2 }}
+  {{- include "snippet.posthog-sentry-env" . | nindent 2 }}
 
 {{- end }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -86,6 +86,7 @@ spec:
       {{- end }}
         # PostHog app settings
         {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.postgresql-env" . | nindent 8 }}

--- a/charts/posthog/templates/migrate.job.yaml
+++ b/charts/posthog/templates/migrate.job.yaml
@@ -63,6 +63,7 @@ spec:
 {{- end }}
         # PostHog app settings
         {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.postgresql-migrate-env" . | nindent 8 }}

--- a/charts/posthog/templates/plugins-async-deployment.yaml
+++ b/charts/posthog/templates/plugins-async-deployment.yaml
@@ -72,6 +72,10 @@ spec:
         env:
         - name: PLUGIN_SERVER_MODE
           value: "async"
+
+        - name: SENTRY_DSN
+          value: {{ .Values.pluginsAsync.sentryDSN | default .Values.sentryDSN }}
+
         # Kafka env variables
         {{- include "snippet.kafka-env" . | nindent 8 }}
 

--- a/charts/posthog/templates/plugins-deployment.yaml
+++ b/charts/posthog/templates/plugins-deployment.yaml
@@ -74,6 +74,10 @@ spec:
         - name: PLUGIN_SERVER_MODE
           value: "ingestion"
         {{- end }}
+
+        - name: SENTRY_DSN
+          value: {{ .Values.plugins.sentryDSN | default .Values.sentryDSN }}
+
         # Kafka env variables
         {{- include "snippet.kafka-env" . | nindent 8 }}
 

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -86,6 +86,7 @@ spec:
       {{- end }}
         # PostHog app settings
         {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         - name: SAML_ENTITY_ID
           value: {{ default "" .Values.saml.entity_id | quote }}
         - name: SAML_ACS_URL

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -170,3 +170,15 @@ tests:
             requests:
               cpu: 4000m
               memory: 16Gi
+
+  - it: sets SENTRY_DSN env var
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint

--- a/charts/posthog/tests/migrate-job.yaml
+++ b/charts/posthog/tests/migrate-job.yaml
@@ -32,3 +32,15 @@ tests:
           count: 1
       - isKind:
           of: Job
+
+  - it: sets SENTRY_DSN env var
+    template: templates/migrate.job.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint

--- a/charts/posthog/tests/plugins-async-deployment.yaml
+++ b/charts/posthog/tests/plugins-async-deployment.yaml
@@ -107,3 +107,30 @@ tests:
           content:
             name: PLUGIN_SERVER_MODE
             value: async
+
+  - it: sets SENTRY_DSN env var
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAsync.enabled: true
+      sentryDSN: main.endpoint
+      pluginsAsync.sentryDSN: pluginsAsync.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: pluginsAsync.endpoint
+
+  - it: sets SENTRY_DSN env var with default
+    template: templates/plugins-async-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAsync.enabled: true
+      sentryDSN: main.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: main.endpoint

--- a/charts/posthog/tests/plugins-deployment.yaml
+++ b/charts/posthog/tests/plugins-deployment.yaml
@@ -112,3 +112,28 @@ tests:
           content:
             name: PLUGIN_SERVER_MODE
             value: ingestion
+
+  - it: sets SENTRY_DSN env var
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: main.endpoint
+      plugins.sentryDSN: plugins.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: plugins.endpoint
+
+  - it: sets SENTRY_DSN env var with default
+    template: templates/plugins-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: main.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: main.endpoint

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -69,7 +69,7 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 2000
-  
+
   - it: should have a container securityContext
     template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -85,8 +85,8 @@ tests:
           value: 1001
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false            
-          
+          value: false
+
   - it: should not have a pod securityContext
     template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -98,7 +98,7 @@ tests:
       - isEmpty:
           path: spec.template.spec.securityContext
           value: 1001
-  
+
   - it: should not have a container securityContext
     template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -109,6 +109,15 @@ tests:
           count: 1
       - isEmpty:
           path: spec.template.spec.containers[0].securityContext
-         
-  
-  
+
+  - it: sets SENTRY_DSN env var
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint

--- a/charts/posthog/tests/worker-deployment.yaml
+++ b/charts/posthog/tests/worker-deployment.yaml
@@ -49,7 +49,7 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 2000
-  
+
   - it: should have a container securityContext
     template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -65,8 +65,8 @@ tests:
           value: 1001
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
-          value: false            
-          
+          value: false
+
   - it: should not have a pod securityContext
     template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -78,7 +78,7 @@ tests:
       - isEmpty:
           path: spec.template.spec.securityContext
           value: 1001
-  
+
   - it: should not have a container securityContext
     template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
@@ -89,6 +89,15 @@ tests:
           count: 1
       - isEmpty:
           path: spec.template.spec.containers[0].securityContext
-         
-  
-  
+
+  - it: sets SENTRY_DSN env var
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -272,6 +272,9 @@ plugins:
     # -- The readiness probe timeout seconds
     timeoutSeconds: 5
 
+  # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
+  sentryDSN:
+
 
 pluginsAsync:
   # -- Whether to install the PostHog plugin-server async stack or not.
@@ -341,6 +344,8 @@ pluginsAsync:
     # -- The readiness probe timeout seconds
     timeoutSeconds: 5
 
+  # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
+  sentryDSN:
 
 
 email:


### PR DESCRIPTION
## Description

After this change, sentryDSN is changable for plugin server.  This matches how we want to do tracking on cloud.

Opted for this route (over env vars) so new deployments always receive _a_ SentryDSN.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

See tests.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
