### PR TITLE
initContainer - wait for migrations: add env

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-migrations.tpl
@@ -31,4 +31,9 @@
   # PostHog app settings
   {{- include "snippet.posthog-env" . | nindent 2 }}
 
+  # Global ENV variables
+  {{- if .Values.env }}
+  {{ toYaml .Values.env | nindent 2 }}
+  {{- end }}
+
 {{- end }}

--- a/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
+++ b/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
@@ -1,0 +1,29 @@
+suite: _initContainers-wait-for-migrations
+templates:
+  - templates/events-deployment.yaml
+  - templates/plugins-deployment.yaml
+  - templates/web-deployment.yaml
+  - templates/worker-deployment.yaml
+  # NOTE: we need to include this as it is required by the other templates
+  - templates/secrets.yaml
+
+tests:
+  - it: spec.template.spec.initContainers[1].env override via 'env' should work
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/events-deployment.yaml
+      - templates/plugins-deployment.yaml
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+        - name: this-is-a-custom-variable
+          value: this-is-a-custom-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: this-is-a-custom-variable
+            value: this-is-a-custom-value


### PR DESCRIPTION
## Description
Make sure we add the "global" env variables also to the wait for migrations initContainer. Fixes #496

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
