### PR TITLE
chore(metrics): hide /_metrics endpoint

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -53,6 +53,18 @@ spec:
         paths:
           {{- if (ne (include "ingress.type" .) "clb") }}
           - pathType: Prefix
+            path: "/_metrics"
+          {{- else }}
+          - pathType: ImplementationSpecific
+            path: "/_metrics"
+          {{- end }}
+            backend:
+              service:
+                name: nonexistent-service-name
+                port:
+                  number: {{ .Values.service.externalPort }}
+          {{- if (ne (include "ingress.type" .) "clb") }}
+          - pathType: Prefix
             path: "/"
           {{- else }}
           - pathType: ImplementationSpecific


### PR DESCRIPTION
To ensure we do not leak data on private paths, we direct these paths to
a non-existent backend. There is almost certainly a better way to do
this, but this is my straw man.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
