### PR TITLE
clickhouse-backup: bump default image from 1.4.0 to 1.5.0

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -966,14 +966,14 @@ clickhouse:
       # -- Clickhouse backup image repository.
       repository: altinity/clickhouse-backup
       # -- ClickHouse backup image tag.
-      tag: "1.4.0"
+      tag: "1.5.0"
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
     backup_user: backup
     # password in plain text because it's using in cronjob
     backup_password: backup_password
-    backup_schedule: "0 0 * * *" #backup every day at 0:00
+    backup_schedule: "0 0 * * *" # backup every day at 0:00
     clickhouse_services: "chi-posthog-posthog-0-0" # use first replica in each shard, use `kubectl get svc | grep chi-posthog-posthog`
 
     # All options: https://github.com/AlexAkulov/clickhouse-backup#default-config


### PR DESCRIPTION
## Description
Bump the default image of `clickhouse-backup` from 1.4.0 to 1.5.0. Fixes #503.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
