### PR TITLE
Fix an issue that checks for connectivity in the init container even when pgbouncer is disabled

### DIFF
--- a/charts/posthog/templates/_postgresql.tpl
+++ b/charts/posthog/templates/_postgresql.tpl
@@ -2,10 +2,18 @@
 
 {{/* ENV used by posthog deployments for connecting to postgresql */}}
 {{- define "snippet.postgresql-env" }}
+  {{ if .Values.pgbouncer.enabled }}
 - name: POSTHOG_POSTGRES_HOST
   value: {{ template "posthog.pgbouncer.host" . }}
 - name: POSTHOG_POSTGRES_PORT
   value: {{ include "posthog.pgbouncer.port" . | quote }}
+  {{ else }}
+- name: POSTHOG_POSTGRES_HOST
+  value: {{ template "posthog.postgresql.host" . }}
+- name: POSTHOG_POSTGRES_PORT
+  value: {{ include "posthog.postgresql.port" . | quote }}
+  {{- end }}
+
 - name: POSTHOG_DB_USER
   value: {{ include "posthog.postgresql.username" . }}
 - name: POSTHOG_DB_NAME

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -22,10 +22,12 @@
         done
         {{ end }}
 
+        {{ if .Values.pgbouncer.enabled }}
         until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.pgbouncer.port" . }});
         do
             echo "waiting for PgBouncer"; sleep 1;
         done
+        {{ end }}
 
         {{ if .Values.postgresql.enabled }}
         until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.postgresql.port" . }});


### PR DESCRIPTION
## Description
Fix an issue that checks for connectivity in the init container even when pgbouncer is disabled, Also in snippet.postgresql-env always use the address of pgbouncer.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?


## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
