### PR TITLE
values.yaml: add Grafana datasource for alertmanager

### DIFF
--- a/charts/posthog/grafana-dashboards/clickhouse-overview.json
+++ b/charts/posthog/grafana-dashboards/clickhouse-overview.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,23 +25,16 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 2,
-  "iteration": 1647359781915,
+  "id": 32,
+  "iteration": 1659447709036,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
-      "id": 21,
-      "title": "Row title",
-      "type": "row"
-    },
-    {
       "description": "Max node uptime in the cluster.",
       "fieldConfig": {
         "defaults": {
@@ -55,11 +51,11 @@
                 "value": null
               },
               {
-                "color": "dark-orange",
+                "color": "orange",
                 "value": 60
               },
               {
-                "color": "dark-green",
+                "color": "green",
                 "value": 3600
               }
             ]
@@ -72,7 +68,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "id": 4,
       "options": {
@@ -89,7 +85,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -108,6 +104,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of executing queries.",
       "fieldConfig": {
         "defaults": {
@@ -120,7 +120,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-green",
+                "color": "green",
                 "value": null
               }
             ]
@@ -133,7 +133,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 1
+        "y": 0
       },
       "id": 5,
       "options": {
@@ -150,7 +150,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -169,6 +169,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -195,7 +199,7 @@
         "h": 3,
         "w": 2,
         "x": 6,
-        "y": 1
+        "y": 0
       },
       "id": 9,
       "options": {
@@ -212,7 +216,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -231,6 +235,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -257,7 +265,7 @@
         "h": 3,
         "w": 2,
         "x": 8,
-        "y": 1
+        "y": 0
       },
       "id": 11,
       "options": {
@@ -274,7 +282,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -293,6 +301,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -348,7 +360,7 @@
         "h": 3,
         "w": 7,
         "x": 10,
-        "y": 1
+        "y": 0
       },
       "id": 13,
       "options": {
@@ -358,7 +370,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -378,6 +391,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -412,7 +429,6 @@
             }
           },
           "mappings": [],
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -434,7 +450,7 @@
         "h": 3,
         "w": 7,
         "x": 17,
-        "y": 1
+        "y": 0
       },
       "id": 26,
       "options": {
@@ -444,7 +460,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -464,6 +481,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of executing queries.",
       "fieldConfig": {
         "defaults": {
@@ -537,7 +558,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 3
       },
       "id": 15,
       "options": {
@@ -547,7 +568,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -579,6 +601,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of failed queries.",
       "fieldConfig": {
         "defaults": {
@@ -652,7 +678,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 4
+        "y": 3
       },
       "id": 19,
       "options": {
@@ -662,7 +688,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -694,6 +721,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of reads from a file that were slow. This indicate system overload.",
       "fieldConfig": {
         "defaults": {
@@ -757,7 +788,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 8
       },
       "id": 17,
       "options": {
@@ -767,7 +798,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -787,6 +819,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of times the number of query processing threads was lowered due to slow reads.",
       "fieldConfig": {
         "defaults": {
@@ -850,7 +886,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 8
       },
       "id": 18,
       "options": {
@@ -860,7 +896,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -880,6 +917,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Total amount of memory (bytes) allocated by the server.",
       "fieldConfig": {
         "defaults": {
@@ -936,7 +977,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 7,
       "options": {
@@ -946,7 +987,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -966,6 +1008,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of connections to TCP server (clients with native interface), also included server-server distributed query connections & number of connections to HTTP server",
       "fieldConfig": {
         "defaults": {
@@ -1021,7 +1067,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 13
       },
       "id": 2,
       "options": {
@@ -1031,7 +1077,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1063,6 +1110,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1118,7 +1169,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 18
       },
       "id": 29,
       "options": {
@@ -1128,7 +1179,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1161,18 +1213,35 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 23
       },
       "id": 23,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "SELECT",
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of executing SELECT ueries.",
       "fieldConfig": {
         "defaults": {
@@ -1246,7 +1315,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 24
       },
       "id": 24,
       "options": {
@@ -1256,7 +1325,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1288,6 +1358,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Number of failed SELECT queries.",
       "fieldConfig": {
         "defaults": {
@@ -1361,7 +1435,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 25
+        "y": 24
       },
       "id": 25,
       "options": {
@@ -1371,7 +1445,8 @@
           "placement": "right"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1404,7 +1479,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 34,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [
     "PostHog",

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1153,6 +1153,12 @@ grafana:
         access: proxy
         isDefault: false
 
+      # Comment the snippet below if you are running with `prometheus.alertmanager.enabled: false`
+      - name: Alertmanager
+        type: alertmanager
+        url: http://posthog-prometheus-alertmanager
+        access: proxy
+        isDefault: false
 
 ###
 ###
@@ -1619,50 +1625,50 @@ prometheus:
                 summary: Prometheus too many restarts (instance {{ $labels.instance }})
                 description: "Prometheus has restarted more than twice in the last 15 minutes. It might be crashlooping.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusAlertmanagerJobMissing
-            #   expr: absent(up{job="alertmanager"})
-            #   for: 0m
-            #   labels:
-            #     severity: warning
-            #   annotations:
-            #     summary: Prometheus AlertManager job missing (instance {{ $labels.instance }})
-            #     description: "A Prometheus AlertManager job has disappeared\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusAlertmanagerJobMissing
+              expr: absent(up{job="alertmanager"})
+              for: 0m
+              labels:
+                severity: warning
+              annotations:
+                summary: Prometheus AlertManager job missing (instance {{ $labels.instance }})
+                description: "A Prometheus AlertManager job has disappeared\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusAlertmanagerConfigurationReloadFailure
-            #   expr: alertmanager_config_last_reload_successful != 1
-            #   for: 0m
-            #   labels:
-            #     severity: warning
-            #   annotations:
-            #     summary: Prometheus AlertManager configuration reload failure (instance {{ $labels.instance }})
-            #     description: "AlertManager configuration reload error\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusAlertmanagerConfigurationReloadFailure
+              expr: alertmanager_config_last_reload_successful != 1
+              for: 0m
+              labels:
+                severity: warning
+              annotations:
+                summary: Prometheus AlertManager configuration reload failure (instance {{ $labels.instance }})
+                description: "AlertManager configuration reload error\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusAlertmanagerConfigNotSynced
-            #   expr: count(count_values("config_hash", alertmanager_config_hash)) > 1
-            #   for: 0m
-            #   labels:
-            #     severity: warning
-            #   annotations:
-            #     summary: Prometheus AlertManager config not synced (instance {{ $labels.instance }})
-            #     description: "Configurations of AlertManager cluster instances are out of sync\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusAlertmanagerConfigNotSynced
+              expr: count(count_values("config_hash", alertmanager_config_hash)) > 1
+              for: 0m
+              labels:
+                severity: warning
+              annotations:
+                summary: Prometheus AlertManager config not synced (instance {{ $labels.instance }})
+                description: "Configurations of AlertManager cluster instances are out of sync\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusAlertmanagerE2eDeadManSwitch
-            #   expr: vector(1)
-            #   for: 0m
-            #   labels:
-            #     severity: critical
-            #   annotations:
-            #     summary: Prometheus AlertManager E2E dead man switch (instance {{ $labels.instance }})
-            #     description: "Prometheus DeadManSwitch is an always-firing alert. It's used as an end-to-end test of Prometheus through the Alertmanager.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusAlertmanagerE2eDeadManSwitch
+              expr: vector(1)
+              for: 0m
+              labels:
+                severity: critical
+              annotations:
+                summary: Prometheus AlertManager E2E dead man switch (instance {{ $labels.instance }})
+                description: "Prometheus DeadManSwitch is an always-firing alert. It's used as an end-to-end test of Prometheus through the Alertmanager.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusNotConnectedToAlertmanager
-            #   expr: prometheus_notifications_alertmanagers_discovered < 1
-            #   for: 0m
-            #   labels:
-            #     severity: critical
-            #   annotations:
-            #     summary: Prometheus not connected to alertmanager (instance {{ $labels.instance }})
-            #     description: "Prometheus cannot connect the alertmanager\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusNotConnectedToAlertmanager
+              expr: prometheus_notifications_alertmanagers_discovered < 1
+              for: 0m
+              labels:
+                severity: critical
+              annotations:
+                summary: Prometheus not connected to alertmanager (instance {{ $labels.instance }})
+                description: "Prometheus cannot connect the alertmanager\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
             - alert: PrometheusRuleEvaluationFailures
               expr: increase(prometheus_rule_evaluation_failures_total[3m]) > 0
@@ -1700,14 +1706,14 @@ prometheus:
                 summary: Prometheus notifications backlog (instance {{ $labels.instance }})
                 description: "The Prometheus notification queue has not been empty for 10 minutes\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-            # - alert: PrometheusAlertmanagerNotificationFailing
-            #   expr: rate(alertmanager_notifications_failed_total[1m]) > 0
-            #   for: 0m
-            #   labels:
-            #     severity: critical
-            #   annotations:
-            #     summary: Prometheus AlertManager notification failing (instance {{ $labels.instance }})
-            #     description: "Alertmanager is failing sending notifications\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            - alert: PrometheusAlertmanagerNotificationFailing
+              expr: rate(alertmanager_notifications_failed_total[1m]) > 0
+              for: 0m
+              labels:
+                severity: critical
+              annotations:
+                summary: Prometheus AlertManager notification failing (instance {{ $labels.instance }})
+                description: "Alertmanager is failing sending notifications\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
             - alert: PrometheusTargetEmpty
               expr: prometheus_sd_discovered_targets == 0


### PR DESCRIPTION
## Description
1. add Grafana datasource for Prometheus Alertmanager in the `values.yaml` defaults. I didn't realise we were running already with `prometheus.alertmanager.enabled: true` as default so I think this change make sense
2. as `prometheus.alertmanager.enabled: true` is true by default, let's also add some basic alerting rules for Alertmanager
3. not strictly part of my PR (I had it in my checkout) but there's also a minor fix of the ClickHouse Grafana dashboard 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
