### PR TITLE
values.yaml: fix Grafana datasource for alertmanager

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1159,6 +1159,8 @@ grafana:
         url: http://posthog-prometheus-alertmanager
         access: proxy
         isDefault: false
+        jsonData:
+          implementation: prometheus
 
 ###
 ###


### PR DESCRIPTION
## Description
There's an undocumented additional config I've missed as part of #508. We need to add it to make Grafana working well with the alertmanager datasource from Prometheus.

See upstream issue https://github.com/grafana/grafana/issues/53263 


## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
