### PR TITLE
values.yaml: tune not actionable prometheus alerts

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1248,7 +1248,7 @@ prometheus:
 
             - alert: KubernetesDiskPressure
               expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
-              for: 2m
+              for: 10m
               labels:
                 severity: critical
               annotations:
@@ -1356,7 +1356,7 @@ prometheus:
 
             - alert: KubernetesHpaMetricAvailability
               expr: kube_horizontalpodautoscaler_status_condition{status="false", condition="ScalingActive"} == 1
-              for: 0m
+              for: 5m
               labels:
                 severity: warning
               annotations:
@@ -1599,7 +1599,7 @@ prometheus:
 
             - alert: PrometheusTargetMissing
               expr: up == 0
-              for: 0m
+              for: 5m
               labels:
                 severity: critical
               annotations:


### PR DESCRIPTION
## Description
Adjust threshold for 3 alerts. Looking at the telemetry at the last couple of days those would fire during kubernetes nodes autoscaling events without being very actionable. Let's use more sensible values. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
