### PR TITLE
Helm: add Grafana annotations

### DIFF
--- a/charts/posthog/templates/grafana-annotation-post.job.yaml
+++ b/charts/posthog/templates/grafana-annotation-post.job.yaml
@@ -1,3 +1,4 @@
+#
 # This job gets installed only if Grafana, Loki and Promtail are enabled.
 #
 # It's an ephemeral container running at the start and end of each Helm

--- a/charts/posthog/templates/grafana-annotation-post.job.yaml
+++ b/charts/posthog/templates/grafana-annotation-post.job.yaml
@@ -1,0 +1,29 @@
+# This job gets installed only if Grafana, Loki and Promtail are enabled.
+#
+# It's an ephemeral container running at the start and end of each Helm
+# deploy and it's used to log at stdout the Helm revision we are
+# installing / we finished installing.
+#
+# This datapoint is useful and can be very helpful as annotation
+# in Grafana dashboard.
+#
+{{- if and .Values.grafana.enabled (and .Values.loki.enabled .Values.promtail.enabled) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-grafana-annotation-job-post" .Release.Name }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade,post-rollback"
+spec:
+  template:
+    spec:
+      containers:
+      - name: grafana-annotation-job-post
+        image: {{ .Values.busybox.image }}
+        imagePullPolicy: {{ .Values.busybox.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo '{"operation_stage": "end", "helm_revision": "{{ .Release.Revision }}"}'
+{{- end }}

--- a/charts/posthog/templates/grafana-annotation-pre.job.yaml
+++ b/charts/posthog/templates/grafana-annotation-pre.job.yaml
@@ -1,3 +1,4 @@
+#
 # This job gets installed only if Grafana, Loki and Promtail are enabled.
 #
 # It's an ephemeral container running at the start and end of each Helm

--- a/charts/posthog/templates/grafana-annotation-pre.job.yaml
+++ b/charts/posthog/templates/grafana-annotation-pre.job.yaml
@@ -1,0 +1,29 @@
+# This job gets installed only if Grafana, Loki and Promtail are enabled.
+#
+# It's an ephemeral container running at the start and end of each Helm
+# deploy and it's used to log at stdout the Helm revision we are
+# installing / we finished installing.
+#
+# This datapoint is useful and can be very helpful as annotation
+# in Grafana dashboard.
+#
+{{- if and .Values.grafana.enabled (and .Values.loki.enabled .Values.promtail.enabled) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-grafana-annotation-job-pre" .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
+spec:
+  template:
+    spec:
+      containers:
+      - name: grafana-annotation-job-pre
+        image: {{ .Values.busybox.image }}
+        imagePullPolicy: {{ .Values.busybox.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo '{"operation_stage": "start", "helm_revision": "{{ .Release.Revision }}"}'
+{{- end }}


### PR DESCRIPTION
## Description
Adds two new ephemeral jobs to keep track of Helm execution stage. This can be useful for basic release monitoring.

Afaik there's no way to get the value of execution stage in the pod/job (see [StackOverflow](https://stackoverflow.com/questions/63493461/helm-hook-is-there-a-way-to-get-the-value-of-execution-stage-in-the-pod-job)) so I'm creating two templates. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
Partially but we are in Cambridge with a terrible internet connection so it was even difficult open this PR 😺 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
