### PR TITLE
Grafana: add Helm deploy annotations to dashboards

### DIFF
--- a/charts/posthog/grafana-dashboards/application-endpoints-overview.json
+++ b/charts/posthog/grafana-dashboards/application-endpoints-overview.json
@@ -4,8 +4,8 @@
       {
         "builtIn": 1,
         "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
+          "type": "datasource",
+          "uid": "grafana"
         },
         "enable": true,
         "hide": true,
@@ -18,6 +18,20 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+        "hide": false,
+        "iconColor": "dark-blue",
+        "name": "Deploy / Rollback",
+        "tagKeys": "container",
+        "target": {},
+        "titleFormat": ""
       }
     ]
   },

--- a/charts/posthog/grafana-dashboards/clickhouse-overview.json
+++ b/charts/posthog/grafana-dashboards/clickhouse-overview.json
@@ -18,6 +18,20 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+        "hide": false,
+        "iconColor": "dark-blue",
+        "name": "Deploy / Rollback",
+        "tagKeys": "container",
+        "target": {},
+        "titleFormat": ""
       }
     ]
   },

--- a/charts/posthog/grafana-dashboards/kafka-overview.json
+++ b/charts/posthog/grafana-dashboards/kafka-overview.json
@@ -18,6 +18,20 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+        "hide": false,
+        "iconColor": "dark-blue",
+        "name": "Deploy / Rollback",
+        "tagKeys": "container",
+        "target": {},
+        "titleFormat": ""
       }
     ]
   },

--- a/charts/posthog/grafana-dashboards/kubernetes-deployment.json
+++ b/charts/posthog/grafana-dashboards/kubernetes-deployment.json
@@ -4,8 +4,8 @@
             {
                 "builtIn": 1,
                 "datasource": {
-                    "type": "grafana",
-                    "uid": "-- Grafana --"
+                    "type": "datasource",
+                    "uid": "grafana"
                 },
                 "enable": true,
                 "hide": true,
@@ -18,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },

--- a/charts/posthog/grafana-dashboards/kubernetes-overview.json
+++ b/charts/posthog/grafana-dashboards/kubernetes-overview.json
@@ -18,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },
@@ -26,8 +40,8 @@
     "fiscalYearStartMonth": 0,
     "gnetId": 7249,
     "graphTooltip": 1,
-    "id": 16,
-    "iteration": 1658328126986,
+    "id": 82,
+    "iteration": 1660647316429,
     "links": [],
     "liveNow": false,
     "panels": [

--- a/charts/posthog/grafana-dashboards/kubernetes-pvc.json
+++ b/charts/posthog/grafana-dashboards/kubernetes-pvc.json
@@ -10,9 +10,7 @@
                 "enable": true,
                 "hide": true,
                 "iconColor": "rgba(0, 211, 255, 1)",
-                "limit": 100,
                 "name": "Annotations & Alerts",
-                "showIn": 0,
                 "target": {
                     "limit": 100,
                     "matchAny": false,
@@ -20,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },

--- a/charts/posthog/grafana-dashboards/minio.json
+++ b/charts/posthog/grafana-dashboards/minio.json
@@ -3,7 +3,10 @@
         "list": [
             {
                 "builtIn": 1,
-                "datasource": "-- Grafana --",
+                "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                },
                 "enable": true,
                 "hide": true,
                 "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },

--- a/charts/posthog/grafana-dashboards/nginx.json
+++ b/charts/posthog/grafana-dashboards/nginx.json
@@ -18,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },

--- a/charts/posthog/grafana-dashboards/pgbouncer.json
+++ b/charts/posthog/grafana-dashboards/pgbouncer.json
@@ -3,7 +3,10 @@
         "list": [
             {
                 "builtIn": 1,
-                "datasource": "-- Grafana --",
+                "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                },
                 "enable": true,
                 "hide": true,
                 "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },

--- a/charts/posthog/grafana-dashboards/postgresql.json
+++ b/charts/posthog/grafana-dashboards/postgresql.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,6 +18,20 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+        "hide": false,
+        "iconColor": "dark-blue",
+        "name": "Deploy / Rollback",
+        "tagKeys": "container",
+        "target": {},
+        "titleFormat": ""
       }
     ]
   },

--- a/charts/posthog/grafana-dashboards/redis.json
+++ b/charts/posthog/grafana-dashboards/redis.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:1820",
         "builtIn": 1,
         "datasource": {
           "type": "datasource",
@@ -19,6 +18,20 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+        "hide": false,
+        "iconColor": "dark-blue",
+        "name": "Deploy / Rollback",
+        "tagKeys": "container",
+        "target": {},
+        "titleFormat": ""
       }
     ]
   },

--- a/charts/posthog/grafana-dashboards/zookeeper.json
+++ b/charts/posthog/grafana-dashboards/zookeeper.json
@@ -3,7 +3,10 @@
         "list": [
             {
                 "builtIn": 1,
-                "datasource": "-- Grafana --",
+                "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                },
                 "enable": true,
                 "hide": true,
                 "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,6 +18,20 @@
                     "type": "dashboard"
                 },
                 "type": "dashboard"
+            },
+            {
+                "datasource": {
+                    "type": "loki",
+                    "uid": "P8E80F9AEF21F6940"
+                },
+                "enable": true,
+                "expr": "{namespace=\"posthog\", container=~\"grafana-annotation-job-.*\"}",
+                "hide": false,
+                "iconColor": "dark-blue",
+                "name": "Deploy / Rollback",
+                "tagKeys": "container",
+                "target": {},
+                "titleFormat": ""
             }
         ]
     },


### PR DESCRIPTION
## Description
Now that we have Helm deploys generating log lines that we can use as annotations, let's add those annotations to all our dashboards. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
