### PR TITLE
feat(logging): use JSON formatted logs for Django code

### DIFF
--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -22,6 +22,8 @@
   value: {{ .Values.web.internalMetrics.capture | quote }}
 - name: HELM_INSTALL_INFO
   value: {{ template "posthog.helmInstallInfo" . }}
+- name: LOGGING_FORMATTER_NAME
+  value: json
 {{- end }}
 
 {{- define "snippet.posthog-sentry-env" }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1248,6 +1248,18 @@ promtail:
               - timestamp:
                   source: timestamp
                   format: RFC3339
+        - match:
+            selector: '{app="posthog", container=~"posthog-web|posthog-worker|posthog-events"}'
+            stages:
+              - json:
+                  expressions:
+                    timestamp: time
+                    level:
+              - labels:
+                  level:
+              - timestamp:
+                  source: timestamp
+                  format: RFC3339Nano
 
   ## -- Pod annotations.
   podAnnotations: {}


### PR DESCRIPTION
So we can better parse specific data within log messages, e.g. the log
message type, multiline exceptions, we ensure that logs output to JSON
which we then parse as JSON for promtail.

This only works for Django processes at the moment.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
