### PR TITLE
fix(nginx): set service-upstream to "true"

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -513,6 +513,12 @@ ingress-nginx:
       # -- [ingress-nginx documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers)
       use-forwarded-headers: "true"
 
+      # Ensure that we use the service rather than maintaining a list of
+      # upstreams. Without this NGINX will maintain a list which can cause
+      # issues when pods are terminated. See
+      # https://github.com/kubernetes/ingress-nginx/issues/257 for details
+      service-upstream: "true"
+
       # Use JSON format for logs, such that we can easily parse them in e.g. Promtail
       #
       # We also add in:


### PR DESCRIPTION
Instead of having NGINX maintain it's own list of upstreams, we want it
instead to use the service ClusterIP such that k8s can handle e.g. cases
where pods are evicted.

Without this we end up with 5xx errors e.g. on deploys. See
https://github.com/kubernetes/ingress-nginx/issues/257 for more details.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
