### PR TITLE
Quote STATSD_PORT, as it is expected to be a string

### DIFF
--- a/charts/posthog/templates/_statsd.tpl
+++ b/charts/posthog/templates/_statsd.tpl
@@ -24,6 +24,6 @@
 - name: STATSD_HOST
   value: "{{ include "posthog.statsd.host" . }}"
 - name: STATSD_PORT
-  value: "{{ include "posthog.statsd.port" . }}"
+  value: "{{ include "posthog.statsd.port" . | quote }}"
 {{- end }}
 {{- end }}

--- a/charts/posthog/tests/_statsd.yaml
+++ b/charts/posthog/tests/_statsd.yaml
@@ -27,7 +27,7 @@ tests:
             - name: STATSD_HOST
               value: RELEASE-NAME-posthog-prometheus-statsd-exporter
             - name: STATSD_PORT
-              value: "9125"
+              value: 9125
 
   - it: should render env variables pointing to prometheus-statsd-exporter when it is enabled and custom values are used
     set:
@@ -43,7 +43,7 @@ tests:
             - name: STATSD_HOST
               value: RELEASE-NAME-posthog-prometheus-statsd-exporter
             - name: STATSD_PORT
-              value: "1234"
+              value: 1234
 
   - it: should render env variables pointing to externalStatsd when is enabled
     set:
@@ -60,7 +60,7 @@ tests:
             - name: STATSD_HOST
               value: statsd.example.com
             - name: STATSD_PORT
-              value: "5678"
+              value: 5678
 
   - it: should render env variables pointing to prometheus-statsd-exporter when both internal and external statsd are enabled
     set:
@@ -79,4 +79,4 @@ tests:
             - name: STATSD_HOST
               value: RELEASE-NAME-posthog-prometheus-statsd-exporter
             - name: STATSD_PORT
-              value: "1234"
+              value: 1234


### PR DESCRIPTION
Users of the chart are likely to set the port value to an int, but in order to be used it needs to be quoted as a string. 

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
