### PR TITLE
refactor(alerts): make clear what replicamismatch alerts mean

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1488,7 +1488,8 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes ReplicasSet mismatch (instance {{ $labels.instance }})
-                description: "Deployment Replicas mismatch"
+                description: "The number of ready pods in the Deployment's replicaset does
+                  not match the desired number"
 
             - alert: KubernetesDeploymentReplicasMismatch
               expr: kube_deployment_spec_replicas != kube_deployment_status_replicas_available
@@ -1497,7 +1498,8 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes Deployment replicas mismatch (instance {{ $labels.instance }})
-                description: "Deployment Replicas mismatch"
+                description: "The number of ready pods in the Deployment does
+                  not match the desired number"
 
             - alert: KubernetesStatefulsetReplicasMismatch
               expr: kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas
@@ -1506,7 +1508,8 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes StatefulSet replicas mismatch (instance {{ $labels.instance }})
-                description: "A StatefulSet does not match the expected number of replicas."
+                description: "The number of ready pods in the StatefulSet does
+                  not match the desired number"
 
             - alert: KubernetesDeploymentGenerationMismatch
               expr: kube_deployment_status_observed_generation != kube_deployment_metadata_generation

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1488,8 +1488,9 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes ReplicasSet mismatch (instance {{ $labels.instance }})
-                description: "The number of ready pods in the Deployment's replicaset does
-                  not match the desired number"
+                description: >
+                  The number of ready pods in the Deployment's replicaset does
+                  not match the desired number.
 
             - alert: KubernetesDeploymentReplicasMismatch
               expr: kube_deployment_spec_replicas != kube_deployment_status_replicas_available
@@ -1498,8 +1499,9 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes Deployment replicas mismatch (instance {{ $labels.instance }})
-                description: "The number of ready pods in the Deployment does
-                  not match the desired number"
+                description: >
+                  The number of ready pods in the Deployment does not match the
+                  desired number.
 
             - alert: KubernetesStatefulsetReplicasMismatch
               expr: kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas
@@ -1508,8 +1510,9 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Kubernetes StatefulSet replicas mismatch (instance {{ $labels.instance }})
-                description: "The number of ready pods in the StatefulSet does
-                  not match the desired number"
+                description: >
+                  The number of ready pods in the StatefulSet does not match the
+                  desired number.
 
             - alert: KubernetesDeploymentGenerationMismatch
               expr: kube_deployment_status_observed_generation != kube_deployment_metadata_generation


### PR DESCRIPTION
Specifically mentioning that it is around the number of ready pods not
being what the desired count is should make it more clear, atleast to
me!

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
