### PR TITLE
feat(logging): log Kubernetes with eventrouter

### DIFF
--- a/.devcontainer/values.yml
+++ b/.devcontainer/values.yml
@@ -49,6 +49,9 @@ prometheus:
 loki:
   enabled: true
 
+eventrouter:
+  enabled: true
+
 promtail:
   enabled: true
 

--- a/charts/posthog/templates/eventrouter.yaml
+++ b/charts/posthog/templates/eventrouter.yaml
@@ -1,0 +1,81 @@
+#
+# If enabled, we add a Deployment for
+# https://github.com/vmware-archive/eventrouter as per
+# https://grafana.com/blog/2020/07/21/loki-tutorial-how-to-send-logs-from-eks-with-promtail-to-get-full-visibility-in-grafana/
+#
+# It looks like a dead project which is unfortunate but appears to work. There
+# is a Grafana Agent integration to pull Kubernetes events but this appears to
+# be experimental at the time of writing:
+# https://grafana.com/docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/
+#
+{{- if .Values.eventrouter.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-eventrouter
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-eventrouter
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-eventrouter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-eventrouter
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-eventrouter
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "sink": "stdout"
+    }
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-eventrouter-cm
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-eventrouter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: eventrouter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: eventrouter
+  template:
+    metadata:
+      labels:
+        app: eventrouter
+        tier: control-plane-addons
+    spec:
+      containers:
+        - name: kube-eventrouter
+          image: {{ .Values.eventrouter.image.repository }}:{{ .Values.eventrouter.image.tag }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/eventrouter
+      serviceAccount: {{ .Release.Name }}-eventrouter
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Release.Name }}-eventrouter-cm
+{{- end }}

--- a/charts/posthog/templates/eventrouter.yaml
+++ b/charts/posthog/templates/eventrouter.yaml
@@ -69,7 +69,7 @@ spec:
       containers:
         - name: kube-eventrouter
           image: {{ .Values.eventrouter.image.repository }}:{{ .Values.eventrouter.image.tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.eventrouter.image.pullPolicy }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/eventrouter

--- a/charts/posthog/tests/eventrouter.yaml
+++ b/charts/posthog/tests/eventrouter.yaml
@@ -1,0 +1,35 @@
+suite: Event router
+templates:
+  - templates/eventrouter.yaml
+
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be able to enable
+    set:
+      eventrouter:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        not: true
+
+  - it: should allow setting different images/tag ad pull policy
+    set:
+      eventrouter:
+        enabled: true
+        image:
+          repository: repository
+          tag: tag
+          pullPolicy: pullPolicy
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: repository:tag
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: pullPolicy

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1214,6 +1214,18 @@ loki:
   # -- Whether to install Loki or not.
   enabled: false
 
+###
+###
+### ---- EventRouter: https://github.com/vmware-archive/eventrouter
+###
+###
+eventrouter:
+  # -- Whether to install eventrouter.
+  enabled: false
+  image:
+    repository: gcr.io/heptio-images/eventrouter
+    tag: v0.3
+    pullPolicy: IfNotPresent
 
 ###
 ###


### PR DESCRIPTION
We currently can only view events via `kubectl get events` which isn't
great for correlating with logs. At the moment I'm trying to understand
why some requests hit 502 on deploys, which appears to be due to the
pods being killed without grace, but it's difficult to see exactly what
is going on at the moment.

I followed the instructions on
https://grafana.com/blog/2020/07/21/loki-tutorial-how-to-send-logs-from-eks-with-promtail-to-get-full-visibility-in-grafana/

There is also
https://grafana.com/docs/agent/latest/configuration/integrations/integrations-next/eventhandler-config/
which we should perhaps move to but for now, this should do the trick.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
