### PR TITLE
ci(k3s): just use the install script, not the github action

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
 
           until (kubectl version)
           do

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -59,7 +59,7 @@ jobs:
           until (kubectl version)
           do
             echo "Waiting for k3s to be ready"
-            ((c++)) && ((c==60)) && exit 1
+            ((c++)) && ((c==120)) && exit 1
             sleep 1
           done
 

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -55,14 +55,16 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
-          mkdir ~/.kube
-          kubectl config view > ~/.kube/config
+
           until (kubectl version)
           do
             echo "Waiting for k3s to be ready"
-            ((c++)) && ((c==10)) && exit 1
+            ((c++)) && ((c==60)) && exit 1
             sleep 1
           done
+
+          mkdir ~/.kube
+          kubectl config view > ~/.kube/config
 
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -55,6 +55,8 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
+          mkdir ~/.kube
+          k3s kubectl config view > ~/.kube/config
 
           until (kubectl version)
           do
@@ -62,9 +64,6 @@ jobs:
             ((c++)) && ((c==120)) && exit 1
             sleep 1
           done
-
-          mkdir ~/.kube
-          kubectl config view > ~/.kube/config
 
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -52,11 +52,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: jupyterhub/action-k3s-helm@v3
-        with:
-          k3s-channel: ${{ matrix.k3s-channel }}
-          metrics-enabled: false
-          traefik-enabled: false
+      - name: Setup k3s
+        run: |
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
+          export HUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+      - name: Install Helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -56,6 +56,12 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
           export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+          until (kubectl version)
+          do
+            echo "Waiting for k3s to be ready"
+            ((c++)) && ((c==10)) && exit 1
+            sleep 1
+          done
 
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
           mkdir ~/.kube
-          sudo k3s kubectl config view > ~/.kube/config
+          sudo k3s kubectl config view --raw > ~/.kube/config
 
           until (kubectl version)
           do

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -55,10 +55,7 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
-          export HUBECONFIG=/etc/rancher/k3s/k3s.yaml
-
-      - name: Install Helm
-        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
+          mkdir ~/.kube
           kubectl config view > ~/.kube/config
           until (kubectl version)
           do

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -58,13 +58,6 @@ jobs:
           mkdir ~/.kube
           sudo k3s kubectl config view --raw > ~/.kube/config
 
-          until (kubectl version)
-          do
-            echo "Waiting for k3s to be ready"
-            ((c++)) && ((c==120)) && exit 1
-            sleep 1
-          done
-
       - uses: actions/checkout@v3
         if: matrix.test == 'upgrade'
         with:

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
-          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+          kubectl config view > ~/.kube/config
           until (kubectl version)
           do
             echo "Waiting for k3s to be ready"

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
           mkdir ~/.kube
-          k3s kubectl config view > ~/.kube/config
+          sudo k3s kubectl config view > ~/.kube/config
 
           until (kubectl version)
           do

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -50,8 +50,9 @@ jobs:
 
       - name: Setup k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
-          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
+          mkdir ~/.kube
+          sudo k3s kubectl config view --raw > ~/.kube/config
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.22 INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
           mkdir ~/.kube
           sudo k3s kubectl config view --raw > ~/.kube/config
 

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -48,11 +48,13 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout
 
-      - uses: jupyterhub/action-k3s-helm@v3
-        with:
-          k3s-channel: v1.22
-          metrics-enabled: false
-          traefik-enabled: false
+      - name: Setup k3s
+        run: |
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
+          export HUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+      - name: Install Helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -51,10 +51,7 @@ jobs:
       - name: Setup k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=${{ matrix.k3s-channel }} sh -
-          export HUBECONFIG=/etc/rancher/k3s/k3s.yaml
-
-      - name: Install Helm
-        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
The previous action does things that I don't _think_ we need. For instance it installs Calico, but I think we can do without this. The Calico manifest it references is a 404 atm. It will probably be fixed soon, but I'd rather remove as many deps as possible.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
