### PR TITLE
dev(codespaces): use k3s instead of kind

### DIFF
--- a/.devcontainer/supervisord.conf
+++ b/.devcontainer/supervisord.conf
@@ -1,0 +1,4 @@
+[supervisord]
+
+[program:k3s]
+command=k3s server


### PR DESCRIPTION
The experience with k3s is much nicer given that ports will be available
to the client machine (rather than on a separate docker network) and
also includes a load balancer by default by way of Klipper-lb

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
