### PR TITLE
fix(web): wait 10 seconds for k8s endpoints to be updated on term

### DIFF
--- a/charts/posthog/templates/_snippet-web-deployments.tpl
+++ b/charts/posthog/templates/_snippet-web-deployments.tpl
@@ -1,0 +1,39 @@
+{{/*
+
+    Defines a lifecycle command to be used by web traffic serving deployments.
+    This will delay the sending of the TERM signal
+
+    To achieve zero downtime deploys, we introduce a delay between Pod
+    delete request and sending the TERM signal to Gunicorn. Gunicorn
+    will gracefully complete in-flight requests with a TERM signal,
+    but removal from Kubernetes endpoints will not be instant, so
+    there will be some requests reaching Gunicorn after shutdown has
+    been initiated. Gunicorn will reject any requests that come in
+    after shutdown is initiated resulting in 502s reported by the
+    ingress controller.
+
+    The delay here will be proceeded by kubelet sending a TERM signal
+    to process 1.
+
+*/}}
+{{- define "snippet.web-deployments.lifecycle" -}}
+lifecycle:
+    preStop:
+        exec:
+            command: [
+                "sh", "-c",
+                "sleep 10"
+            ]
+{{- end -}}
+
+
+{{/*
+
+    Set a grace period that is 10 seconds delay (from
+    lifecycle.exec.preStop) + 30 seconds for Gunicorn to gracefully shutdown
+    + 5 seconds leeway
+
+*/}}
+{{- define "snippet.web-deployments.terminationGracePeriodSeconds" -}}
+45
+{{- end -}}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -32,6 +32,7 @@ spec:
 {{ toYaml .Values.web.podLabels | indent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.web.affinity }}
       affinity:
@@ -100,6 +101,9 @@ spec:
 {{- if .Values.web.env }}
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}
+
+        {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
+
         livenessProbe:
           httpGet:
             path: /_livez

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -32,6 +32,7 @@ spec:
 {{ toYaml .Values.web.podLabels | indent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
       {{- if .Values.web.affinity }}
       affinity:
@@ -122,6 +123,9 @@ spec:
 {{- if .Values.web.env }}
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}
+
+        {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
+
         livenessProbe:
           httpGet:
             path: /_livez

--- a/charts/posthog/tests/web-deployments.yaml
+++ b/charts/posthog/tests/web-deployments.yaml
@@ -1,0 +1,19 @@
+suite: PostHog web and events deployment definitions
+templates:
+  - templates/web-deployment.yaml
+  - templates/events-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: has grace period and lifecycle set, to ensure zero downtime deployments
+    templates:
+      - templates/web-deployment.yaml
+      - templates/events-deployment.yaml
+    set:
+      cloud: local
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 45
+      - isNotNull:
+          path: spec.template.spec.containers[0].lifecycle


### PR DESCRIPTION
To ensure that we initiate Gunicorn shutdown after the last web requests
come in via the Service endpoint, we wait 10 seconds thereby giving time
to have the Pod removed from the Endpoint.

We are seeing 502s on deploys. Gunicorn is successfully waiting to
complete in flight requests now, but will reject any new ones that come
in after shutdown has started.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
