### PR TITLE
chore(prestop): log to pid 1 stdout prestop events

### DIFF
--- a/charts/posthog/templates/_snippet-web-deployments.tpl
+++ b/charts/posthog/templates/_snippet-web-deployments.tpl
@@ -22,7 +22,7 @@ lifecycle:
         exec:
             command: [
                 "sh", "-c",
-                "sleep 10"
+                '(echo \'{"event": "preStop_started"}\'; sleep 10; echo \'{"event": "preStop_ended"}\') > /proc/1/fd/1'
             ]
 {{- end -}}
 


### PR DESCRIPTION
This is so we can see when the prestop is called, and correlate these
with e.g. request_started events.

The order of events looks something like:

1. pod termination request
2. prestop start
3. pod port removed from k8s endpoint, no new connections made
4. prestop completes
5. term signal sent to process 1
6. process gracefully completes inflight requests and stops
7. pod deleted

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
