### PR TITLE
Revert "fix(nginx): set service-upstream to "true""

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -513,12 +513,6 @@ ingress-nginx:
       # -- [ingress-nginx documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers)
       use-forwarded-headers: "true"
 
-      # Ensure that we use the service rather than maintaining a list of
-      # upstreams. Without this NGINX will maintain a list which can cause
-      # issues when pods are terminated. See
-      # https://github.com/kubernetes/ingress-nginx/issues/257 for details
-      service-upstream: "true"
-
       # Use JSON format for logs, such that we can easily parse them in e.g. Promtail
       #
       # We also add in:


### PR DESCRIPTION
I believe this doesn't play so well with e.g. http keepalive. Rather we want NGINX to know that a pod port has been removed from a Service Endpoint thereby being able to handle reaping these connections. As a result of using the Service, on ingress-nginx creating a connection, it is first iptable routed to a pod. After this, the connection will be maintained for [120 seconds](https://github.com/PostHog/posthog/blob/master/gunicorn.config.py#L9) which I think is fine as a setting fwiw.

ingress-nginx will still be sending requests down this connection, even after the pod port has been removed from the Endpoint, and getting 502 which isn't what we want.

I'm yet to test this however.

For reading material: https://learnk8s.io/kubernetes-long-lived-connections

Reverts PostHog/charts-clickhouse#532