### PR TITLE
CI: disable Let's Encrypt

### DIFF
--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -166,8 +166,8 @@ jobs:
 
     - name: Set PostHog endpoints to use for the ingestion test
       run: |
-        echo "POSTHOG_API_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
-        echo "POSTHOG_EVENT_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+        echo "POSTHOG_API_ENDPOINT=http://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+        echo "POSTHOG_EVENT_ENDPOINT=http://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
 
     - name: Run ingestion test using k6
       uses: k6io/action@v0.2.0

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -161,16 +161,6 @@ jobs:
           --record-name "${{ steps.vars.outputs.dns_record }}" \
           --record-data "${load_balancer_external_hostname}."
 
-    - name: Wait for the Let's Encrypt certificate to be issued and deployed
-      id: tls_certificate_creation
-      run: |
-        echo "Wait for the Let's Encrypt certificate to be issued and deployed..."
-        while ! kubectl wait --for=condition=Ready --timeout=60s certificaterequest --all -n posthog > /dev/null 2>&1
-        do
-          echo "  certificate hasn't been yet issued and deployed"
-        done
-        echo "The certificate has been issued and it has been deployed!"
-
     - name: Setup PostHog for the ingestion test
       run: ./ci/setup_ingestion_test.sh
 

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -120,17 +120,6 @@ jobs:
           --record-name "${{ steps.vars.outputs.dns_record }}" \
           --record-data "${load_balancer_external_ip}"
 
-    - name: Wait for the Let's Encrypt certificate to be issued and deployed
-      id: tls_certificate_creation
-      timeout-minutes: 60
-      run: |
-        echo "Wait for the Let's Encrypt certificate to be issued and deployed..."
-        while ! kubectl wait --for=condition=Ready --timeout=60s certificaterequest --all -n posthog > /dev/null 2>&1
-        do
-          echo "  certificate hasn't been yet issued and deployed"
-        done
-        echo "The certificate has been issued and it has been deployed!"
-
     - name: Setup PostHog for the ingestion test
       run: ./ci/setup_ingestion_test.sh
 

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -125,8 +125,8 @@ jobs:
 
     - name: Set PostHog endpoints to use for the ingestion test
       run: |
-        echo "POSTHOG_API_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
-        echo "POSTHOG_EVENT_ENDPOINT=https://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+        echo "POSTHOG_API_ENDPOINT=http://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
+        echo "POSTHOG_EVENT_ENDPOINT=http://${{ steps.vars.outputs.fqdn_record }}" | tee -a "$GITHUB_ENV"
 
     - name: Run ingestion test using k6
       uses: k6io/action@v0.2.0

--- a/ci/values/amazon_web_services.yaml
+++ b/ci/values/amazon_web_services.yaml
@@ -1,10 +1,13 @@
 cloud: "aws"
 ingress:
-  hostname: <your-hostname>
   nginx:
     enabled: true
-cert-manager:
-  enabled: true
+    redirectToTLS: false
+
+# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+web:
+  secureCookies: false
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/digital_ocean.yaml
+++ b/ci/values/digital_ocean.yaml
@@ -1,10 +1,13 @@
 cloud: "do"
 ingress:
-  hostname: <your-hostname>
   nginx:
     enabled: true
-cert-manager:
-  enabled: true
+    redirectToTLS: false
+
+# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+web:
+  secureCookies: false
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/google_cloud_platform.yaml
+++ b/ci/values/google_cloud_platform.yaml
@@ -1,13 +1,7 @@
 cloud: "gcp"
-ingress:
-  nginx:
-    enabled: true
-    redirectToTLS: false
 
-# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
-# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
-web:
-  secureCookies: false
+# We configure GCP ingress pretty differently than anything else
+# and TLS is currently hardcoded/built-in.
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/google_cloud_platform.yaml
+++ b/ci/values/google_cloud_platform.yaml
@@ -1,6 +1,13 @@
 cloud: "gcp"
 ingress:
-  hostname: <your-hostname>
+  nginx:
+    enabled: true
+    redirectToTLS: false
+
+# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+web:
+  secureCookies: false
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -4,6 +4,11 @@ ingress:
     enabled: true
     redirectToTLS: false
 
+# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+web:
+  secureCookies: false
+
 # Use small PVC in CI
 clickhouse:
   persistence:

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -1,18 +1,8 @@
 cloud: k3s
-
-pluginsAsync:
-  enabled: true
-
 ingress:
   nginx:
     enabled: true
     redirectToTLS: false
-  letsencrypt: false
-
-web:
-  secureCookies: false
-  internalMetrics:
-    capture: false
 
 # Use small PVC in CI
 clickhouse:
@@ -31,3 +21,7 @@ redis:
 zookeeper:
   persistence:
     size: 1Gi
+
+# Enable pluginsAsync for this test
+pluginsAsync:
+  enabled: true

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -1,15 +1,8 @@
 cloud: k3s
-
 ingress:
   nginx:
     enabled: true
     redirectToTLS: false
-  letsencrypt: false
-
-web:
-  secureCookies: false
-  internalMetrics:
-    capture: false
 
 # Use small PVC in CI
 clickhouse:

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -4,6 +4,11 @@ ingress:
     enabled: true
     redirectToTLS: false
 
+# Disable `SESSION_COOKIE_SECURE` as we don't use TLS
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+web:
+  secureCookies: false
+
 # Use small PVC in CI
 clickhouse:
   persistence:


### PR DESCRIPTION
## Description
As discussed on Slack, this PR disable the Let'sEncrypt TLS certificate flow from all the Helm chart tests. It's a validation that is quite complex (relies on DNS propagations) and requires interactions with a provider we do not control. This is making the overall tests pretty flaky. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is green for 

- k6/k3 (see below)
- AWS (see [here](https://github.com/PostHog/charts-clickhouse/actions/runs/2926873440))
- DO (see [here](https://github.com/PostHog/charts-clickhouse/actions/runs/2926871318))
- GCP (see [here](https://github.com/PostHog/charts-clickhouse/actions/runs/2926987703))

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
