### PR TITLE
feat(ingress): allow setting ingress.hostname to empty

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -160,10 +160,7 @@ reverse proxy is in front of the app listening on a different DNS name.
 {{- define "posthog.site.url" -}}
     {{- if .Values.siteUrl -}}
         {{- .Values.siteUrl -}}
-    {{- else if .Values.ingress.enabled -}}
-        {{- if not .Values.ingress.hostname -}}
-            {{- required "When ingress is enabled you must either set ingress.hostname or siteUrl" .Values.ingress.hostname -}}
-        {{- end -}}
+    {{- else if (and .Values.ingress.hostname .Values.ingress.enabled) -}}
         "https://{{ .Values.ingress.hostname }}"
     {{- else -}}
         "http://127.0.0.1:8000"

--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -151,14 +151,23 @@ Return whether Redis uses password authentication or not
 {{- end -}}
 
 {{/*
-Set site url
+Set site url. Either use siteUrl if set, or if ingress is enabled, use the
+ingress hostname.
+
+To enable ingress to the app with any Host header being set, e.g. as when a
+reverse proxy is in front of the app listening on a different DNS name.
 */}}
 {{- define "posthog.site.url" -}}
-{{- if .Values.ingress.hostname -}}
-    "https://{{ .Values.ingress.hostname }}"
-{{- else -}}
-    "http://127.0.0.1:8000"
-{{- end -}}
+    {{- if .Values.siteUrl -}}
+        {{- .Values.siteUrl -}}
+    {{- else if .Values.ingress.enabled -}}
+        {{- if not .Values.ingress.hostname -}}
+            {{- required "When ingress is enabled you must either set ingress.hostname or siteUrl" .Values.ingress.hostname -}}
+        {{- end -}}
+        "https://{{ .Values.ingress.hostname }}"
+    {{- else -}}
+        "http://127.0.0.1:8000"
+    {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/posthog/tests/application-settings.yaml
+++ b/charts/posthog/tests/application-settings.yaml
@@ -59,28 +59,6 @@ tests:
             name: SITE_URL
             value: "https://somehost"
 
-  # NOTE: I couldn't figure a way to assert here, but I'll leave the test
-  # commented for context
-  #
-  # - it: if ingress enabled but no hostname or siteUrl given, raise error
-  #   templates:
-  #     - templates/web-deployment.yaml
-  #     - templates/worker-deployment.yaml
-  #     - templates/events-deployment.yaml
-  #     - templates/plugins-deployment.yaml
-  #     - templates/plugins-async-deployment.yaml
-  #     - templates/migrate.job.yaml
-  #   set:
-  #     cloud: local
-  #     siteUrl:
-  #     pluginsAsync:
-  #       enabled: true
-  #     ingress:
-  #       enabled: true
-  #       hostname:
-
-  #   asserts:
-
   - it: SITE_URL defaults to http://127.0.0.1:8000 if ingress disabled and no siteUrl
     templates:
       - templates/web-deployment.yaml

--- a/charts/posthog/tests/application-settings.yaml
+++ b/charts/posthog/tests/application-settings.yaml
@@ -1,0 +1,105 @@
+suite: Global application settings propagated to pods
+templates:
+  # This list may be too broad or too narrow, I've just added to all deployments
+  # that use the django backend.
+  - templates/web-deployment.yaml
+  - templates/worker-deployment.yaml
+  - templates/events-deployment.yaml
+  - templates/plugins-deployment.yaml
+  - templates/plugins-async-deployment.yaml
+  - templates/migrate.job.yaml
+  # NOTE: we need to include this as it is required by the other templates
+  - templates/secrets.yaml
+
+tests:
+  - it: SITE_URL set to .Values.siteUrl over everything else
+    templates:
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/plugins-deployment.yaml
+      - templates/plugins-async-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      siteUrl: https://my.site.com
+      pluginsAsync:
+        enabled: true
+      ingress:
+        enabled: true
+        hostname: somehost
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SITE_URL
+            value: "https://my.site.com"
+
+  - it: SITE_URL set to ingress.hostname if ingress is enabled and hostname is set
+    templates:
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/plugins-deployment.yaml
+      - templates/plugins-async-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      siteUrl:
+      pluginsAsync:
+        enabled: true
+      ingress:
+        enabled: true
+        hostname: somehost
+
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SITE_URL
+            value: "https://somehost"
+
+  # NOTE: I couldn't figure a way to assert here, but I'll leave the test
+  # commented for context
+  #
+  # - it: if ingress enabled but no hostname or siteUrl given, raise error
+  #   templates:
+  #     - templates/web-deployment.yaml
+  #     - templates/worker-deployment.yaml
+  #     - templates/events-deployment.yaml
+  #     - templates/plugins-deployment.yaml
+  #     - templates/plugins-async-deployment.yaml
+  #     - templates/migrate.job.yaml
+  #   set:
+  #     cloud: local
+  #     siteUrl:
+  #     pluginsAsync:
+  #       enabled: true
+  #     ingress:
+  #       enabled: true
+  #       hostname:
+
+  #   asserts:
+
+  - it: SITE_URL defaults to http://127.0.0.1:8000 if ingress disabled and no siteUrl
+    templates:
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/plugins-deployment.yaml
+      - templates/plugins-async-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      siteUrl:
+      pluginsAsync:
+        enabled: true
+      ingress:
+        enabled: false
+
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SITE_URL
+            value: "http://127.0.0.1:8000"

--- a/charts/posthog/tests/ingress.yaml
+++ b/charts/posthog/tests/ingress.yaml
@@ -162,3 +162,12 @@ tests:
             meta.helm.sh/release-namespace: NAMESPACE
             key1: value1
             key2: value2
+
+  - it: can set hostname to empty to capture all traffic
+    set:
+      ingress:
+        enabled: true
+        hostname: ''
+    asserts:
+      - isNull:
+          path: spec.rules[0].host

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -5,7 +5,7 @@ cloud:
 notificationEmail:
 
 # -- Site url specifies the canonical URL root the site can be accessed using.
-# This is used to e.g. generate sharable links to Dashboards.
+# This is used to e.g. generate shareable links to Dashboards.
 siteUrl:
 
 image:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -4,6 +4,10 @@ cloud:
 # -- Notification email for notifications to be sent to from the PostHog stack
 notificationEmail:
 
+# -- Site url specifies the canonical URL root the site can be accessed using.
+# This is used to e.g. generate sharable links to Dashboards.
+siteUrl:
+
 image:
   # -- PostHog image repository to use.
   repository: posthog/posthog


### PR DESCRIPTION
Previously you would be able to set ingress.hostname to an empty string.
However, the SITE_URL would be set incorrectly, thus e.g. links to
sharable dashboards would no longer work.

We want to be able to set the hostname to empty such that the ingress
controller will pick up any traffic, no matter what the "Host" http
header. This was we can allow users to provide reverse proxies on
different addresses which are just proxying the original Host headers
through.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
