### PR TITLE
Add support for Kubernetes v1.25, drop v1.22

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -24,13 +24,13 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         include:
+          - k3s-channel: v1.25
+            test: install
+            values: ci/values/k3s.yaml
           - k3s-channel: v1.24
             test: install
             values: ci/values/k3s.yaml
           - k3s-channel: v1.23
-            test: install
-            values: ci/values/k3s.yaml
-          - k3s-channel: v1.22
             test: install
             values: ci/values/k3s.yaml
 

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: 🦔 PostHog is developer-friendly, open-source product analytics.
 icon: https://camo.githubusercontent.com/11f72f57f33d7d34807bafc1314844f7a91bcdea/68747470733a2f2f706f7374686f672d7374617469632d66696c65732e73332e75732d656173742d322e616d617a6f6e6177732e636f6d2f576562736974652d4173736574732f6769746875622d636f7665722e706e67
-kubeVersion: ">= 1.22-0 <= 1.24-0"
+kubeVersion: ">= 1.23-0 <= 1.25-0"
 home: https://posthog.com
 sources:
   - https://github.com/PostHog/charts-clickhouse
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 27.2.2
+version: 28.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -20,7 +20,7 @@ This Helm chart bootstraps a [PostHog](https://posthog.com/) installation on a [
 
 
 ## Prerequisites
-- Kubernetes >=1.22 <= 1.24
+- Kubernetes >=1.23 <= 1.25
 - Helm >= 3.7.0
 
 ## Installation


### PR DESCRIPTION
## Description
This PR adds the support for Kubernetes v1.25 and drops the support for v1.22 as [EOL since 2022-10-28](https://kubernetes.io/releases/#release-v1-22).

Accompanying release notes are available at: https://github.com/PostHog/posthog.com/pull/4513

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
