### PR TITLE
fix: make clickhouse CRDs optional

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -261,6 +261,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | zookeeper.metrics.service.annotations."prometheus.io/scrape" | string | `"false"` |  |
 | zookeeper.podAnnotations | string | `nil` |  |
 | clickhouse.enabled | bool | `true` | Whether to install clickhouse. If false, `clickhouse.host` must be set |
+| clickhouse.installCRDs | bool | `true` | Whether to install `clickhouse` CRDs. |
 | clickhouse.namespace | string | `nil` | Which namespace to install clickhouse and the `clickhouse-operator` to (defaults to namespace chart is installed to) |
 | clickhouse.cluster | string | `"posthog"` | Clickhouse cluster |
 | clickhouse.database | string | `"posthog"` | Clickhouse database |

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 26.10.0
+version: 26.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/posthog/templates/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -1,25 +1,27 @@
 # Template Parameters:
 #
-# KIND=ClickHouseInstallationTemplate
-# SINGULAR=clickhouseinstallationtemplate
-# PLURAL=clickhouseinstallationtemplates
-# SHORT=chit
+# KIND=ClickHouseInstallation
+# SINGULAR=clickhouseinstallation
+# PLURAL=clickhouseinstallations
+# SHORT=chi
 #
+
+{{- if .Values.clickhouse.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clickhouseinstallationtemplates.clickhouse.altinity.com
+  name: clickhouseinstallations.clickhouse.altinity.com
   labels:
     clickhouse.altinity.com/chop: 0.18.4
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
   names:
-    kind: ClickHouseInstallationTemplate
-    singular: clickhouseinstallationtemplate
-    plural: clickhouseinstallationtemplates
+    kind: ClickHouseInstallation
+    singular: clickhouseinstallation
+    plural: clickhouseinstallations
     shortNames:
-      - chit
+      - chi
   versions:
     - name: v1
       served: true
@@ -1331,4 +1333,4 @@ spec:
                           # List useTypeXXX constants from model
                           - ""
                           - "merge"
-
+{{- end }}

--- a/charts/posthog/templates/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/posthog/templates/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -473,7 +473,7 @@ spec:
                       type: object
                       description: |
                         allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
-                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separately look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
                         currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
                         More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
                       # nullable: true
@@ -663,7 +663,7 @@ spec:
                             type: object
                             description: |
                               describe current cluster layout, how much shards in cluster, how much replica in shard
-                              allows override settings on each shard and replica separatelly
+                              allows override settings on each shard and replica separately
                             # nullable: true
                             properties:
                               type:
@@ -1110,7 +1110,7 @@ spec:
                                 x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                description: "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
                                 # nullable: true
                                 properties:
                                   hostTemplate:
@@ -1171,7 +1171,7 @@ spec:
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            description: "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
                             # nullable: true
                             items:
                               type: object
@@ -1299,7 +1299,7 @@ spec:
                             type: object
                             description: |
                               allows pass standard object's metadata from template to Service
-                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              Could be use for define specifically for Cloud Provider metadata which impact to behavior of service
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true

--- a/charts/posthog/templates/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/posthog/templates/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -1,25 +1,26 @@
 # Template Parameters:
 #
-# KIND=ClickHouseInstallation
-# SINGULAR=clickhouseinstallation
-# PLURAL=clickhouseinstallations
-# SHORT=chi
+# KIND=ClickHouseInstallationTemplate
+# SINGULAR=clickhouseinstallationtemplate
+# PLURAL=clickhouseinstallationtemplates
+# SHORT=chit
 #
+{{- if .Values.clickhouse.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clickhouseinstallations.clickhouse.altinity.com
+  name: clickhouseinstallationtemplates.clickhouse.altinity.com
   labels:
     clickhouse.altinity.com/chop: 0.18.4
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
   names:
-    kind: ClickHouseInstallation
-    singular: clickhouseinstallation
-    plural: clickhouseinstallations
+    kind: ClickHouseInstallationTemplate
+    singular: clickhouseinstallationtemplate
+    plural: clickhouseinstallationtemplates
     shortNames:
-      - chi
+      - chit
   versions:
     - name: v1
       served: true
@@ -1331,4 +1332,4 @@ spec:
                           # List useTypeXXX constants from model
                           - ""
                           - "merge"
-
+{{- end }}

--- a/charts/posthog/templates/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/posthog/templates/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -472,7 +472,7 @@ spec:
                       type: object
                       description: |
                         allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
-                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separately look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
                         currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
                         More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
                       # nullable: true
@@ -662,7 +662,7 @@ spec:
                             type: object
                             description: |
                               describe current cluster layout, how much shards in cluster, how much replica in shard
-                              allows override settings on each shard and replica separatelly
+                              allows override settings on each shard and replica separately
                             # nullable: true
                             properties:
                               type:
@@ -1109,7 +1109,7 @@ spec:
                                 x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                description: "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
                                 # nullable: true
                                 properties:
                                   hostTemplate:
@@ -1170,7 +1170,7 @@ spec:
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            description: "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
                             # nullable: true
                             items:
                               type: object
@@ -1298,7 +1298,7 @@ spec:
                             type: object
                             description: |
                               allows pass standard object's metadata from template to Service
-                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              Could be use for define specifically for Cloud Provider metadata which impact to behavior of service
                               More info: https://kubernetes.io/docs/concepts/services-networking/service/
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true

--- a/charts/posthog/templates/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/charts/posthog/templates/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -2,6 +2,7 @@
 #
 # NONE
 #
+{{- if .Values.clickhouse.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -290,4 +291,4 @@ spec:
                         It can be set to a file and line number with a logging line.
                         Ex.: file.go:123
                         Each time when this line is being executed, a stack trace will be written to the Info log.
-
+{{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -869,6 +869,8 @@ zookeeper:
 clickhouse:
   # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
   enabled: true
+  # -- Whether to install `clickhouse` CRDs.
+  installCRDs: false
   # -- Which namespace to install clickhouse and the `clickhouse-operator` to (defaults to namespace chart is installed to)
   namespace:
   # -- Clickhouse cluster

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -870,7 +870,7 @@ clickhouse:
   # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
   enabled: true
   # -- Whether to install `clickhouse` CRDs.
-  installCRDs: false
+  installCRDs: true
   # -- Which namespace to install clickhouse and the `clickhouse-operator` to (defaults to namespace chart is installed to)
   namespace:
   # -- Clickhouse cluster


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When trying to add a self-hosted external clickhouse instance that is maintained by argocd, the CRDs generated by clickhouse operator are clashing with the ones generated by posthog charts. This change makes posthog clickhouse CRDs optional.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
1. Set `cloud=aws` and `clickhouse.installCRDs=false` in values.yaml
2. helm dep up
3. helm template . -f values.yaml
4. The output should not have clickhouse CRDs.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
