### PR TITLE
ci(monitoring): install loki/promtail/grafana in CI k3s deployments

### DIFF
--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -36,3 +36,17 @@ plugins:
 # Enable pluginsAsync for this test
 pluginsAsync:
   enabled: true
+
+# Enable monitoring deployments. We are using these in our own deployments so
+# it's worth having these tested before they hit our clusters.
+loki:
+  enabled: true
+
+promtail:
+  enabled: true
+
+grafana:
+  enabled: true
+
+eventrouter:
+  enabled: true

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -32,3 +32,17 @@ plugins:
   env:
     - name: BUFFER_CONVERSION_SECONDS
       value: "1"
+
+# Enable monitoring deployments. We are using these in our own deployments so
+# it's worth having these tested before they hit our clusters.
+loki:
+  enabled: true
+
+promtail:
+  enabled: true
+
+grafana:
+  enabled: true
+
+eventrouter:
+  enabled: true


### PR DESCRIPTION
I was trying to [upgrade Loki Helm
chart](https://github.com/PostHog/charts-clickhouse/pull/570) to version
3.x (which is largely the previous loki-simple-scalable chart), which
would allow us to scale for more log bandwidth.

However, it requires manual installing of CRDs if we are upgrading.
Adding this to the k3s tests means we will also be testing the upgrade
and would have spotted this.

It does however mean that if there are any flakes caused by e.g.
additional memory requirements or another factor then it could be
annoying to have these e.g. block a release.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
