### PR TITLE
ci(helm): separate release chart and version bump github workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump chart version & release
+name: Bump chart version
 
 on:
   pull_request:
@@ -73,19 +73,3 @@ jobs:
         with:
             branch: ${{ github.event.pull_request.base.ref }}
             message: 'Bump version to ${{ steps.new-version.outputs.new-version }}'
-
-      - name: Add helm repositories
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-          helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
-          helm repo add jetstack https://charts.jetstack.io
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          charts_repo_url: 'https://posthog.github.io/charts-clickhouse/'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Add -<sha> to version in charts/posthog/Chart.yaml and update Chart.lock
         if: github.ref != 'refs/heads/main'
         run: |
-          sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g' charts/posthog/Chart.yaml
+          sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g'
+          charts/posthog/Chart.yaml
+          cat charts/posthog/Chart.yaml
           helm dependency update charts/posthog/
 
       - name: Add helm repositories

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -20,9 +20,7 @@ jobs:
       - name: Add -<sha> to version in charts/posthog/Chart.yaml and update Chart.lock
         if: github.ref != 'refs/heads/main'
         run: |
-          sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g'
-          charts/posthog/Chart.yaml
-          cat charts/posthog/Chart.yaml
+          sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g' charts/posthog/Chart.yaml
           helm dependency update charts/posthog/
 
       - name: Add helm repositories
@@ -38,5 +36,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: 'true'
         with:
           charts_repo_url: 'https://posthog.github.io/charts-clickhouse/'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -33,6 +33,15 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Add helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+          helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         env:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -17,20 +17,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
       - name: Add -<sha> to version in charts/posthog/Chart.yaml and update Chart.lock
         if: github.ref != 'refs/heads/main'
         run: |
           sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g' charts/posthog/Chart.yaml
           helm dependency update charts/posthog/
 
-      - name: Add helm repositories
+      - name: Configure Git
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-          helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
-          helm repo add jetstack https://charts.jetstack.io
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,40 @@
+name: Release Chart
+
+on:
+  pull_request:
+  push:
+    branches: 
+      - master
+
+jobs:
+  release:
+    name: Release chart to repo
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Add -<sha> to version in charts/posthog/Chart.yaml and update Chart.lock
+        if: github.ref != 'refs/heads/main'
+        run: |
+          sed -i 's/^version: \(.*\)$/version: \1-${{ github.sha }}/g' charts/posthog/Chart.yaml
+          helm dependency update charts/posthog/
+
+      - name: Add helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+          helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_repo_url: 'https://posthog.github.io/charts-clickhouse/'


### PR DESCRIPTION
To enable e.g. testing of pre release chart versions, release charts on
pull_requests.

Prior to this we would run the release and the version bump at the same time, on pull_request merged.

I'm not sure how the repo handles lot's of versions. It might be worth only doing so on tag or label but 
we shall see.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
