### PR TITLE
Add clickhouse pod distribution

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -294,6 +294,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.settings | object | `{}` |  |
 | clickhouse.defaultSettings.format_schema_path | string | `"/etc/clickhouse-server/config.d/"` |  |
 | clickhouse.podAnnotations | string | `nil` |  |
+| clickhouse.podDistribution | object | `nil` | Pod distribution specification  |
 | clickhouse.client.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
 | clickhouse.client.image.tag | string | `"22.3.6.5"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.client.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 27.1.1
+version: 27.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -64,6 +64,9 @@ spec:
         metadata:
           annotations: {{ toYaml .Values.clickhouse.podAnnotations | nindent 12 }}
           {{- end }}
+        {{- if .Values.clickhouse.podDistribution }}
+        podDistribution: {{ toYaml .Values.clickhouse.podDistribution | nindent 12 }}
+        {{- end}}
         spec:
           {{- if .Values.clickhouse.affinity }}
           affinity: {{ toYaml .Values.clickhouse.affinity | nindent 12 }}

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -420,6 +420,22 @@ tests:
             key1: value1
             key2: value2
 
+  - it: podDistribution setting should work
+    set:
+      clickhouse.podDistribution:
+        - scope: Shard
+          type: ShardAntiAffinity
+          topologyKey: zone
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.templates.podTemplates[0].podDistribution
+          value:
+            - scope: Shard
+              type: ShardAntiAffinity
+              topologyKey: zone
+
   - it: by default only allows access from in-cluster and with the namespace
     asserts:
       - equal:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1001,6 +1001,13 @@ clickhouse:
     # prometheus.io/path: /metrics
     # prometheus.io/port: "9363"
 
+  ## -- Clickhouse pod distribution.
+  podDistribution:
+    # Uncomment to have replicas of each shard reside in different availability zones.
+    # - scope: Shard
+    #   type: ShardAntiAffinity
+    #   topologyKey: "topology.kubernetes.io/zone"
+
   client:
     image:
       # -- ClickHouse image repository.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Clickhouse operator provides options to specify how the shards and replicas of the cluster are to be distributed between nodes. This is important in a production environment where high availability is needed. For instance, in a 3 shard, 2 replica cluster, it's common to need to have replicas of the same shard in different availability zones. Likewise, for better burst performance, different shards should reside on different nodes.

This capability cannot be replicated using the existing `affinity` values because the label selectors for different shards/replicas need to be dynamic depending on the pod.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Using the following values for clickhouse:

```
clickhouse:
  podDistribution:
    - scope: Shard
      type: ShardAntiAffinity
      topologyKey: "topology.kubernetes.io/zone"
```

The following podAntiAffinity is added to each Clickhouse pod:

```
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            clickhouse.altinity.com/chi: posthog
            clickhouse.altinity.com/cluster: posthog
            clickhouse.altinity.com/namespace: posthog
            clickhouse.altinity.com/shard: "0"
        topologyKey: topology.kubernetes.io/zone
```

where `clickhouse.altinity.com/shard` label selector differs for pods of different shards.

## Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
