### PR TITLE
Grafana: set 60s as default Prom scrape interval

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 27.1.2
+version: 27.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1203,6 +1203,9 @@ grafana:
         url: http://posthog-prometheus-server
         access: proxy
         isDefault: true
+        jsonData:
+          timeInterval: 60s # pass this explicitly so it can be used by '$__rate_interval'
+                            # https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
 
       # Comment the snippet below if you are running with `loki.enabled: false`
       - name: Loki


### PR DESCRIPTION
## Description
Prometheus uses a default 60s scrape interval for its target. We should explicitly set it in the Grafana datasource config so that it can derive a good default value for `$__rate_interval`. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested locally.

Prom config
<img width="424" alt="Screenshot 2022-10-04 at 15 13 48" src="https://user-images.githubusercontent.com/4038041/193828695-79a46dd3-8a5e-4c21-b39b-125cb69df6ed.png">

New Grafana config
<img width="349" alt="Screenshot 2022-10-04 at 15 12 10" src="https://user-images.githubusercontent.com/4038041/193828770-e765e960-94fc-407c-8bf2-82adc5ebbfe2.png">


## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
