### PR TITLE
Added additional backend for static web files

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -63,6 +63,20 @@ spec:
                 name: {{ template "posthog.fullname" . }}-web
                 port:
                   number: {{ .Values.service.externalPort }}
+          {{- if .Values.ingress.separateStatic -}}  
+          {{- if (ne (include "ingress.type" .) "clb") }}
+          - pathType: Prefix
+            path: "/static"
+          {{- else }}
+          - pathType: ImplementationSpecific
+            path: "/static/*"
+          {{- end }}
+            backend:
+              service:
+                name: {{ template "posthog.fullname" . }}-web-static
+                port:
+                  number: {{ .Values.service.externalPort }}
+          {{- end -}}
           {{- if (ne (include "ingress.type" .) "clb") }}
           - pathType: Prefix
             path: "/batch"

--- a/charts/posthog/templates/web-static-service.yaml
+++ b/charts/posthog/templates/web-static-service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.web.enabled -}}
+{{- if .Values.ingress.separateStatic -}} 
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "posthog.fullname" . }}-web-static
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "posthog.fullname" . }}
+    role: web
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -497,6 +497,8 @@ ingress:
     secretName: ""
   # -- Whether to enable letsencrypt. Defaults to true if hostname is defined and nginx and cert-manager are enabled otherwise false.
   letsencrypt:
+  # -- Enable separated backend service for static files. Useful in case of enabling GCP IAP only over web interface  
+  separateStatic: false
   nginx:
     # -- Whether nginx is enabled
     enabled: false


### PR DESCRIPTION
## Description
When trying to hide Posthog web interface behind Google IAP (GCP) you have issues with static files which cannot be served.
Idea was to create additional backend and route path, so static files can still be public, while Posthog login is hidden.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested in our test and production enviroment.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
