### PR TITLE
CI: make Kubernetes v1.23 as default

### DIFF
--- a/.devcontainer/setup_container.sh
+++ b/.devcontainer/setup_container.sh
@@ -3,7 +3,7 @@
 set -e -o pipefail
 
 # Install k3s
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.22 INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_SKIP_ENABLE=true sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.23 INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_SKIP_ENABLE=true sh -
 
 # Install k9s for easy debugging https://k9scli.io/
 curl -sS https://webinstall.dev/k9s | bash

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -75,7 +75,7 @@ jobs:
           --zones="us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
           --instance-types="m6i.xlarge" \
           --tags="provisioned_by=github_action" \
-          --version 1.22 \
+          --version 1.23 \
           --nodes 3
 
         # WORKAROUND: the latest eksctl release (at the time of writing 0.98.0)

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -41,7 +41,7 @@ jobs:
       id: k8s_cluster_creation
       run: |
         # Get the DO K8 version slug
-        DO_K8S_VERSION=$(doctl k8s options versions -ojson | jq --raw-output 'first(.[] | select(.slug | test("^1.22.[0-9]+-do.[0-9]+$")) | .slug)')
+        DO_K8S_VERSION=$(doctl k8s options versions -ojson | jq --raw-output 'first(.[] | select(.slug | test("^1.23.[0-9]+-do.[0-9]+$")) | .slug)')
 
         doctl k8s clusters create \
           ${{ steps.vars.outputs.k8s_cluster_name }} \

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -71,7 +71,7 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --project ${{ secrets.GCP_PROJECT_ID }} \
           --region us-central1 \
-          --cluster-version 1.22 \
+          --cluster-version 1.23 \
           --labels="provisioned_by=github_action" \
           --machine-type e2-standard-2 \
           --num-nodes 2

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -40,12 +40,12 @@ jobs:
           #
           # It can be very useful to see the "Helm diff" step's output from the
           # latest dev version.
-          - k3s-channel: v1.22
+          - k3s-channel: v1.23
             test: upgrade
             values: ci/values/k3s.yaml
 
           # We run one install test with split plugin-server ingestion
-          - k3s-channel: v1.22
+          - k3s-channel: v1.23
             test: install
             values: ci/values/k3s-plugin-server-split.yaml
 

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.22 INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.23 INSTALL_K3S_EXEC="--disable=traefik --disable=metrics-server" sh -
           mkdir ~/.kube
           sudo k3s kubectl config view --raw > ~/.kube/config
 

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -90,12 +90,12 @@ To release a new chart, bump the `version` in `charts/posthog/Chart.yaml`. We us
     MAJOR version when you make incompatible API changes
     MINOR version when you add functionality in a backwards compatible manner
     PATCH version when you make backwards compatible bug fixes
-    
-Read API here as the chart values interface. When increasing the MAJOR version, ensure to add 
+
+Read API here as the chart values interface. When increasing the MAJOR version, ensure to add
 appropriate documentation to the [Upgrade notes](https://posthog.com/docs/runbook/upgrade-notes).
 
-Charts are [published on push](https://github.com/PostHog/charts-clickhouse/blob/main/.github/workflows/release-chart.yml) 
+Charts are [published on push](https://github.com/PostHog/charts-clickhouse/blob/main/.github/workflows/release-chart.yml)
 to the `main` branch.
 
-Note that development charts are also released on PRs such that changes can be tested as required 
+Note that development charts are also released on PRs such that changes can be tested as required
 before merge, e.g. changing staging/dev to use the chart for more end to end validation.


### PR DESCRIPTION
## Description
K8s v1.22 is approaching EOL next week. v1.23 is running fine on CI and PostHog Cloud since a bit now, let's use it as the new default
 
## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
