### PR TITLE
CI: upgrade eksctl to the latest stable

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,8 +2,11 @@ name: Release Chart
 
 on:
   pull_request:
+    paths:
+      - charts/**
+      - .github/workflows/release-chart.yaml
   push:
-    branches: 
+    branches:
       - main
 
 jobs:

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Install eksctl to easily manage EKS clusters
       env:
-        EKSCTL_VERSION: 0.98.0
+        EKSCTL_VERSION: 0.115.0
       run: |
         curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz
         ./eksctl version
@@ -77,16 +77,6 @@ jobs:
           --tags="provisioned_by=github_action" \
           --version 1.23 \
           --nodes 3
-
-        # WORKAROUND: the latest eksctl release (at the time of writing 0.98.0)
-        # write the .kubeconfig file with a now deprecated apiVersion
-        # client.authentication.k8s.io/v1alpha1. Until a new release with the fix
-        # is deployed, let's manually rewrite the kubeconfig via aws cli.
-        #
-        # Ref: https://github.com/elastic/cloud-on-k8s/issues/5668
-        aws eks update-kubeconfig \
-          --name ${{ steps.vars.outputs.k8s_cluster_name }} \
-          --region us-east-1
 
         # EKS clusters use IAM users and roles to control access to the cluster.
         # The rules are implemented in a config map called aws-auth.


### PR DESCRIPTION
## Description
With #599 we've upgraded the default k8s version for CI to v1.23. Unfortunately, I didn't realise the `eksctl` we were using didn't support it.

Edit: while opening this PR I've realised the `release-chart` workflow got executed. I think that's unnecessary so I've added few paths to its config.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
YOLO

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
