### PR TITLE
Update default Clickhouse version to 22.3.13.80

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -372,7 +372,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.secure | bool | `false` | Whether to use TLS connection connecting to ClickHouse |
 | clickhouse.verify | bool | `false` | Whether to verify TLS certificate on connection to ClickHouse |
 | clickhouse.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.image.tag | string | `"22.3.6.5"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.image.tag | string | `"22.3.13.80"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.tolerations | list | `[]` | Toleration labels for clickhouse pod assignment |
 | clickhouse.affinity | object | `{}` | Affinity settings for clickhouse pod |
@@ -398,7 +398,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.podAnnotations | string | `nil` |  |
 | clickhouse.podDistribution | string | `nil` |  |
 | clickhouse.client.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.client.image.tag | string | `"22.3.6.5"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.client.image.tag | string | `"22.3.13.80"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.client.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.backup.enabled | bool | `false` |  |
 | clickhouse.backup.image.repository | string | `"altinity/clickhouse-backup"` | Clickhouse backup image repository. |

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.0.1
+version: 29.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -49,6 +49,12 @@ For more information about how it works and how to write test cases, please look
 
 To run the test suite you can execute: `helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/clickhouse-operator/*.yaml' charts/posthog`
 
+If you need to update the snapshots, execute:
+
+```
+helm unittest --helm3 --strict --file 'tests/*.yaml' --file 'tests/**/*.yaml' charts/posthog -u
+```
+
 #### Integration tests
 - [kubetest](https://github.com/PostHog/charts-clickhouse/tree/main/ci/kubetest): to verify if applying the rendered Helm templates against a Kubernetes target cluster gives us the stack we expect (example: are the disks encrypted? Can this pod communicate with this service?)
 - [k6](https://github.com/PostHog/charts-clickhouse/tree/main/ci/k6): HTTP test used to verify the reliability, performance and compliance of the PostHog installation (example: is the PostHog ingestion working correctly?)

--- a/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
@@ -30,7 +30,7 @@ should match the snapshot when backup is true:
                   value: backup
                 - name: BACKUP_PASSWORD
                   value: backup_password
-                image: clickhouse/clickhouse-server:22.3.6.5
+                image: clickhouse/clickhouse-server:22.3.13.80
                 imagePullPolicy: IfNotPresent
                 name: run-backup-cron
                 volumeMounts:

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -75,7 +75,7 @@ the manifest should match the snapshot when using default values:
               - /bin/bash
               - -c
               - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-              image: clickhouse/clickhouse-server:22.3.6.5
+              image: clickhouse/clickhouse-server:22.3.13.80
               name: clickhouse
               ports:
               - containerPort: 8123

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -344,7 +344,7 @@ tests:
           count: 1
       - equal:
           path: spec.templates.podTemplates[0].spec.containers[0].image
-          value: "clickhouse/clickhouse-server:22.3.6.5"
+          value: "clickhouse/clickhouse-server:22.3.13.80"
 
   - it: allows modifying clickhouse-server version
     set:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1305,7 +1305,7 @@ clickhouse:
       # -- ClickHouse image repository.
       repository: clickhouse/clickhouse-server
       # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-      tag: "22.3.6.5"
+      tag: "22.3.13.80"
       # -- Image pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1193,7 +1193,7 @@ clickhouse:
     # -- ClickHouse image repository.
     repository: clickhouse/clickhouse-server
     # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-    tag: "22.3.6.5"
+    tag: "22.3.13.80"
     # -- Image pull policy
     pullPolicy: IfNotPresent
 

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -25,5 +25,5 @@ def test_clickhouse_pod_image(kube):
     is_posthog_healthy(kube)
     pod_spec = get_clickhouse_pod_spec(kube)
     assert (
-        pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.6.5-alpine"
+        pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.13.80-alpine"
     )

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -24,6 +24,4 @@ def test_clickhouse_pod_image(kube):
 
     is_posthog_healthy(kube)
     pod_spec = get_clickhouse_pod_spec(kube)
-    assert (
-        pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.13.80-alpine"
-    )
+    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.13.80-alpine"

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -14,7 +14,7 @@ cloud: "local"
 
 clickhouse:
   image:
-    tag: 22.3.6.5-alpine
+    tag: 22.3.13.80-alpine
 """
 
 
@@ -24,4 +24,6 @@ def test_clickhouse_pod_image(kube):
 
     is_posthog_healthy(kube)
     pod_spec = get_clickhouse_pod_spec(kube)
-    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.6.5-alpine"
+    assert (
+        pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.3.6.5-alpine"
+    )


### PR DESCRIPTION
22.3.6.5 has a slow memory leak, eventually causing OOM. This has been fixed in later patch versions.

See: https://src.posthog.cc/search?q=repo:posthog/charts-clickhouse+22.3.6.5&patternType=standard

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
