### PR TITLE
Ingress: move `/engage` calls from web to events

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 27.2.0
+version: 27.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -86,6 +86,9 @@ spec:
             path: "/e"
             backend: *INGESTION
           - pathType: Prefix
+            path: "/engage"
+            backend: *INGESTION
+          - pathType: Prefix
             path: "/track"
             backend: *INGESTION
           - pathType: Prefix
@@ -100,6 +103,9 @@ spec:
             backend: *INGESTION
           - pathType: ImplementationSpecific
             path: "/e/*"
+            backend: *INGESTION
+          - pathType: ImplementationSpecific
+            path: "/engage/*"
             backend: *INGESTION
           - pathType: ImplementationSpecific
             path: "/track/*"

--- a/charts/posthog/tests/__snapshot__/ingress.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/ingress.yaml.snap
@@ -43,6 +43,13 @@ the "spec" path should match the snapshot when using default values:
               name: RELEASE-NAME-posthog-events
               port:
                 number: 8000
+          path: /engage
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
           path: /track
           pathType: Prefix
         - backend:


### PR DESCRIPTION
## Description
While reviewing [this](https://github.com/PostHog/charts-clickhouse/pull/594#issuecomment-1285608933) customer report I've found that we are incorrectly routing `/engage` calls to the default deployment (`posthog-web`) instead of `posthog-events`.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
