### PR TITLE
CI - k6 ingestion test: use nginx

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -125,11 +125,9 @@ jobs:
 
       - name: Set PostHog endpoints to use for the ingestion test
         run: |
-          POSTHOG_API_ADDRESS=$(kubectl get svc -n posthog posthog-web -o jsonpath="{.spec.clusterIP}")
-          POSTHOG_EVENTS_ADDRESS=$(kubectl get svc -n posthog posthog-events -o jsonpath="{.spec.clusterIP}")
 
-          echo "POSTHOG_API_ENDPOINT=http://${POSTHOG_API_ADDRESS}:8000" | tee -a "$GITHUB_ENV"
-          echo "POSTHOG_EVENT_ENDPOINT=http://${POSTHOG_EVENTS_ADDRESS}:8000" | tee -a "$GITHUB_ENV"
+          echo "POSTHOG_API_ENDPOINT=http://posthog-ingress-nginx-controller.posthog.svc:80" | tee -a "$GITHUB_ENV"
+          echo "POSTHOG_EVENT_ENDPOINT=http://posthog-ingress-nginx-controller.posthog.svc:80" | tee -a "$GITHUB_ENV"
 
           # Skip the source ip address check in ingestion-test.js
           echo "SKIP_SOURCE_IP_ADDRESS_CHECK=true" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -125,9 +125,9 @@ jobs:
 
       - name: Set PostHog endpoints to use for the ingestion test
         run: |
-
-          echo "POSTHOG_API_ENDPOINT=http://posthog-ingress-nginx-controller.posthog.svc:80" | tee -a "$GITHUB_ENV"
-          echo "POSTHOG_EVENT_ENDPOINT=http://posthog-ingress-nginx-controller.posthog.svc:80" | tee -a "$GITHUB_ENV"
+          POSTHOG_INGRESS=$(kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+          echo "POSTHOG_API_ENDPOINT=http://${POSTHOG_INGRESS}" | tee -a "$GITHUB_ENV"
+          echo "POSTHOG_EVENT_ENDPOINT=http://${POSTHOG_INGRESS}" | tee -a "$GITHUB_ENV"
 
           # Skip the source ip address check in ingestion-test.js
           echo "SKIP_SOURCE_IP_ADDRESS_CHECK=true" | tee -a "$GITHUB_ENV"

--- a/ci/values/k3s-plugin-server-ingestion-async-split.yaml
+++ b/ci/values/k3s-plugin-server-ingestion-async-split.yaml
@@ -1,9 +1,10 @@
 cloud: k3s
 
 image:
-  tag: latest
+  tag: latest # TODO: remove this override once 1.41.0 is the default
 
 ingress:
+  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false

--- a/ci/values/k3s-plugin-server-ingestion-async-split.yaml
+++ b/ci/values/k3s-plugin-server-ingestion-async-split.yaml
@@ -4,7 +4,6 @@ image:
   tag: latest # TODO: remove this override once 1.41.0 is the default
 
 ingress:
-  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -1,9 +1,10 @@
 cloud: k3s
 
 image:
-  tag: latest
+  tag: latest # TODO: remove this override once 1.41.0 is the default
 
 ingress:
+  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false

--- a/ci/values/k3s-plugin-server-split.yaml
+++ b/ci/values/k3s-plugin-server-split.yaml
@@ -4,7 +4,6 @@ image:
   tag: latest # TODO: remove this override once 1.41.0 is the default
 
 ingress:
-  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -1,7 +1,6 @@
 cloud: k3s
 
 ingress:
-  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false

--- a/ci/values/k3s.yaml
+++ b/ci/values/k3s.yaml
@@ -1,5 +1,7 @@
 cloud: k3s
+
 ingress:
+  enabled: false
   nginx:
     enabled: true
     redirectToTLS: false


### PR DESCRIPTION
## Description
While working on another task, I realised that for the CI k6 ingestion test we install the ingress and ingress-nginx despite we don't use them in CI.

This PR points the CI k6 test to run against the ingress instead of directly hitting the pods (so that we can also test the routing to them). 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
