### PR TITLE
CI - fix 'set-output' deprecation

### DIFF
--- a/.github/workflows/pr-deploy-cleanup.yaml
+++ b/.github/workflows/pr-deploy-cleanup.yaml
@@ -31,19 +31,20 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2 # no way of getting the correct ref from the issue event, hence the below
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Declare variables that we can share across steps
         id: vars
         run: |
           GIT_SHORT="$(git rev-parse --short HEAD)"
           PR_NUM=${{ github.event.number }}
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
 
-          echo "::set-output name=git_short::${GIT_SHORT}"
-          echo "::set-output name=fqdn_record::${PR_NUM}.pr.posthog.cc"
-          echo "::set-output name=pr_number::${PR_NUM}"
-          echo "##[set-output name=branch_name;]$(echo ${GITHUB_REF#refs/heads/})"
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+          echo "git_short=${GIT_SHORT}" >> $GITHUB_OUTPUT
+          echo "fqdn_record=${PR_NUM}.pr.posthog.cc" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Install doctl to access k8s config
         uses: digitalocean/action-doctl@v2
@@ -57,24 +58,24 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ steps.vars.outputs.branch_name }}
           desc: Environment was pruned
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       # Only ran if the correct comment is used! We should have automatic cleanup on merge, but this allows us to manually
       # cleanup. For instance, you may restore a branch, deploy it, and keep it around for demo purposes.
       - name: Delete preview namespace
         id: delete_preview
         run: |
-          doctl kubernetes cluster kubeconfig save $PR_CLUSTER_ID 
+          doctl kubernetes cluster kubeconfig save $PR_CLUSTER_ID
 
           kubectl patch chi posthog -n pr-${{ steps.vars.outputs.pr_number }} -p '{"metadata":{"finalizers":null}}' --type=merge || true # if the resource cannot be found, we still want to clean up
           kubectl delete chi posthog -n pr-${{ steps.vars.outputs.pr_number }} --ignore-not-found
           helm uninstall -n pr-${{ steps.vars.outputs.pr_number }} posthog
-          
+
           # delete all instances of all resources, in the specified namespace
           # just in case someone has made a change to the chart that stops uninstall cleaning up correctly
           kubectl delete all --all --namespace pr-${{ steps.vars.outputs.pr_number }}
           kubectl delete namespace pr-${{ steps.vars.outputs.pr_number }}
 
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
         env:
           PR_CLUSTER_ID: ${{ secrets.PR_CLUSTER_ID }} # probably not _SECRET_, but best kept out of the YAML

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -6,7 +6,7 @@ name: PR - Preview Deploy
 
 on:
   pull_request:
-    types: 
+    types:
       - labeled
       - synchronize
 
@@ -40,18 +40,20 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2 # no way of getting the correct ref from the issue event, hence the below
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Declare variables that we can share across steps
         id: vars
         run: |
           GIT_SHORT="$(git rev-parse --short HEAD)"
           PR_NUM=${{ github.event.number }}
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
 
-          echo "::set-output name=git_short::${GIT_SHORT}"
-          echo "::set-output name=fqdn_record::${PR_NUM}.pr.posthog.cc"
-          echo "::set-output name=pr_number::${PR_NUM}"
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+          echo "git_short=${GIT_SHORT}" >> $GITHUB_OUTPUT
+          echo "fqdn_record=${PR_NUM}.pr.posthog.cc" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: start deployment
         uses: bobheadxi/deployments@v1
@@ -61,18 +63,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ github.head_ref }}
           ref: ${{ github.head_ref }}
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Install doctl to access k8s config
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Install PostHog using the Helm chart
         id: helm_install
         run: |
-          doctl kubernetes cluster kubeconfig save $PR_CLUSTER_ID 
+          doctl kubernetes cluster kubeconfig save $PR_CLUSTER_ID
 
           helm upgrade --install \
             -f ci/values/pr/values.yaml \
@@ -82,8 +84,8 @@ jobs:
             --namespace pr-${{ steps.vars.outputs.pr_number }} \
             posthog ./charts/posthog \
             --wait \
-            --wait-for-jobs 
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
+            --wait-for-jobs
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
         env:
           PR_CLUSTER_ID: ${{ secrets.PR_CLUSTER_ID }} # probably not _SECRET_, but best kept out of the YAML
 
@@ -97,5 +99,4 @@ jobs:
           ref: ${{ github.head_ref }}
           env_url: https://${{ steps.vars.outputs.fqdn_record }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }} 
-
+        if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/test-amazon-web-services-install.yaml
+++ b/.github/workflows/test-amazon-web-services-install.yaml
@@ -58,10 +58,10 @@ jobs:
     - name: Declare variables that we can share across steps
       id: vars
       run: |
-        TEST_NAME="helm-test-e2e-aws-install-$(git rev-parse --short HEAD)"
-        echo "::set-output name=k8s_cluster_name::${TEST_NAME}"
-        echo "::set-output name=dns_record::${TEST_NAME}"
-        echo "::set-output name=fqdn_record::${TEST_NAME}.posthog.cc"
+        TEST_NAME="helm-test-e2e-aws-$(date '+%F')-$(git rev-parse --short HEAD)"
+        echo "k8s_cluster_name=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "dns_record=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "fqdn_record=${TEST_NAME}.posthog.cc" >> $GITHUB_OUTPUT
 
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -32,10 +32,10 @@ jobs:
     - name: Declare variables that we can share across steps
       id: vars
       run: |
-        TEST_NAME="helm-test-e2e-do-install-$(git rev-parse --short HEAD)"
-        echo "::set-output name=k8s_cluster_name::${TEST_NAME}"
-        echo "::set-output name=dns_record::${TEST_NAME}"
-        echo "::set-output name=fqdn_record::${TEST_NAME}.posthog.cc"
+        TEST_NAME="helm-test-e2e-do-$(date '+%F')-$(git rev-parse --short HEAD)"
+        echo "k8s_cluster_name=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "dns_record=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "fqdn_record=${TEST_NAME}.posthog.cc" >> $GITHUB_OUTPUT
 
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -59,10 +59,10 @@ jobs:
     - name: Declare variables that we can share across steps
       id: vars
       run: |
-        TEST_NAME="helm-test-e2e-gcp-install-$(git rev-parse --short HEAD)"
-        echo "::set-output name=k8s_cluster_name::${TEST_NAME}"
-        echo "::set-output name=dns_record::${TEST_NAME}"
-        echo "::set-output name=fqdn_record::${TEST_NAME}.posthog.cc"
+        TEST_NAME="helm-test-e2e-gcp-$(date '+%F')-$(git rev-parse --short HEAD)"
+        echo "k8s_cluster_name=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "dns_record=${TEST_NAME}" >> $GITHUB_OUTPUT
+        echo "fqdn_record=${TEST_NAME}.posthog.cc" >> $GITHUB_OUTPUT
 
     - name: Deploy a new k8s cluster
       id: k8s_cluster_creation

--- a/.github/workflows/test-google-cloud-platform-install.yaml
+++ b/.github/workflows/test-google-cloud-platform-install.yaml
@@ -210,8 +210,8 @@ jobs:
         POSTHOG_EVENTS_NEG_INFO=$(kubectl get svc -n posthog posthog-events -o json | jq --raw-output '.["metadata"]["annotations"]["cloud.google.com/neg-status"]')
         POSTHOG_EVENTS_NEG_NAME=$(echo "$POSTHOG_EVENTS_NEG_INFO" | jq --raw-output '.["network_endpoint_groups"]["8000"]')
         IFS=" " read -r -a POSTHOG_EVENTS_NEG_ZONES <<< "$(echo "$POSTHOG_EVENTS_NEG_INFO" | jq --raw-output '.["zones"] | join(",")')"
-        echo "::set-output name=posthog_events_neg_name::${POSTHOG_EVENTS_NEG_NAME}"
-        echo "::set-output name=posthog_events_neg_zones::${POSTHOG_EVENTS_NEG_ZONES[@]}"
+        echo "posthog_events_neg_name=${POSTHOG_EVENTS_NEG_NAME}"
+        echo "posthog_events_neg_zones=${POSTHOG_EVENTS_NEG_ZONES[@]}"
 
         #
         # posthog-web
@@ -219,8 +219,8 @@ jobs:
         POSTHOG_WEB_NEG_INFO=$(kubectl get svc -n posthog posthog-web -o json | jq --raw-output '.["metadata"]["annotations"]["cloud.google.com/neg-status"]')
         POSTHOG_WEB_NEG_NAME=$(echo "$POSTHOG_WEB_NEG_INFO" | jq --raw-output '.["network_endpoint_groups"]["8000"]')
         IFS=" " read -r -a POSTHOG_WEB_NEG_ZONES <<< "$(echo "$POSTHOG_WEB_NEG_INFO" | jq --raw-output '.["zones"] | join(",")')"
-        echo "::set-output name=posthog_web_neg_name::${POSTHOG_WEB_NEG_NAME}"
-        echo "::set-output name=posthog_web_neg_zones::${POSTHOG_WEB_NEG_ZONES[@]}"
+        echo "posthog_web_neg_name=${POSTHOG_WEB_NEG_NAME}"
+        echo "posthog_web_neg_zones=${POSTHOG_WEB_NEG_ZONES[@]}"
 
     - name: Delete the k8s cluster and all the associated resources
       if: ${{ always() && steps.k8s_cluster_creation.outcome == 'success' }}

--- a/.github/workflows/test-kubetest.yaml
+++ b/.github/workflows/test-kubetest.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout
 
-      - run: echo "::set-output name=test-files::$(cd ./ci/kubetest/ && ls test_*.py | jq -R '[.]' |  jq -s -c 'add')\n"
+      - run: echo "test-files=$(cd ./ci/kubetest/ && ls test_*.py | jq -R '[.]' |  jq -s -c 'add')\n" >> $GITHUB_OUTPUT
         id: test-files-generator
 
 


### PR DESCRIPTION
## Description
Let's get ahead of the `set-output` [deprecation from GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
I didn't.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
