### PR TITLE
CI - update checkout action & bump DO cluster size

### DIFF
--- a/.github/workflows/pr-deploy-cleanup.yaml
+++ b/.github/workflows/pr-deploy-cleanup.yaml
@@ -30,7 +30,7 @@ jobs:
             return member
 
       - name: Checkout
-        uses: actions/checkout@v2 # no way of getting the correct ref from the issue event, hence the below
+        uses: actions/checkout@v3 # no way of getting the correct ref from the issue event, hence the below
         if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Declare variables that we can share across steps

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -39,7 +39,7 @@ jobs:
             return member
 
       - name: Checkout
-        uses: actions/checkout@v2 # no way of getting the correct ref from the issue event, hence the below
+        uses: actions/checkout@v3 # no way of getting the correct ref from the issue event, hence the below
         if: ${{ steps.permissions.outputs.result == 'true' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
 
       - name: Declare variables that we can share across steps

--- a/.github/workflows/test-digitalocean-install.yaml
+++ b/.github/workflows/test-digitalocean-install.yaml
@@ -47,8 +47,8 @@ jobs:
           ${{ steps.vars.outputs.k8s_cluster_name }} \
           --version "$DO_K8S_VERSION" \
           --tag="provisioned_by:github_action" \
-          --size s-2vcpu-4gb \
-          --count 2 \
+          --size s-4vcpu-8gb \
+          --count 3 \
           --wait
 
     - name: Install PostHog using the Helm chart


### PR DESCRIPTION
## Description
* `actions/checkout@v2` is getting deprecated
* DO action is using pretty small instances compared to AWS or GCP
 
## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
