### PR TITLE
Add the ability to configure access_management capabilities

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -17,6 +17,7 @@ spec:
       {{ .Values.clickhouse.backup.backup_user }}/networks/ip: "0.0.0.0/0"
       {{ template "clickhouse.backupPasswordValue" . }}
       {{- end}}
+      {{- merge dict .Values.clickhouse.users .Values.clickhouse.defaultUsers | toYaml | nindent 6 }}
     profiles:
       {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}
 

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -17,7 +17,9 @@ spec:
       {{ .Values.clickhouse.backup.backup_user }}/networks/ip: "0.0.0.0/0"
       {{ template "clickhouse.backupPasswordValue" . }}
       {{- end}}
-      {{- merge dict .Values.clickhouse.users .Values.clickhouse.defaultUsers | toYaml | nindent 6 }}
+      {{- if .Values.clickhouse.users }} 
+      {{- .Values.clickhouse.users | toYaml | nindent 6 }}
+      {{- end}}
     profiles:
       {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}
 

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -17,8 +17,8 @@ spec:
       {{ .Values.clickhouse.backup.backup_user }}/networks/ip: "0.0.0.0/0"
       {{ template "clickhouse.backupPasswordValue" . }}
       {{- end}}
-      {{- if .Values.clickhouse.users }} 
-      {{- .Values.clickhouse.users | toYaml | nindent 6 }}
+      {{- if .Values.clickhouse.additionalUsersConfig }} 
+      {{- .Values.clickhouse.additionalUsersConfig | toYaml | nindent 6 }}
       {{- end}}
     profiles:
       {{- merge dict .Values.clickhouse.profiles .Values.clickhouse.defaultProfiles | toYaml | nindent 6 }}

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -74,7 +74,6 @@ tests:
             clusterServiceTemplate: service-template
             dataVolumeClaimTemplate: data-volumeclaim-template
 
-
   - it: pod-template spec.volumes should not exist if persistence is disabled
     set:
       clickhouse.persistence.enabled: false
@@ -309,9 +308,9 @@ tests:
           value:
             someuser/k8s_secret_password: clickhouse-creds/password
             someuser/networks/ip:
-            - 10.0.0.0/8
-            - 172.16.0.0/12
-            - 192.168.0.0/16
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
             someuser/profile: default
             someuser/quota: default
 
@@ -329,9 +328,9 @@ tests:
           path: spec.configuration.users
           value:
             admin/networks/ip:
-            - 10.0.0.0/8
-            - 172.16.0.0/12
-            - 192.168.0.0/16
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
             admin/password: a1f31e03-c88e-4ca6-a2df-ad49183d15d9
             admin/profile: default
             admin/quota: default
@@ -491,3 +490,11 @@ tests:
           of: ClickHouseInstallation
       - isNotNull:
           path: spec.configuration.users.[backup/networks/ip]
+
+  - it: tests set users admin access_management
+    set:
+      clickhouse.users.admin/access_management: "1"
+    asserts:
+      - equal:
+          path: spec.configuration.users.admin/access_management
+          value: "1"

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -493,7 +493,7 @@ tests:
 
   - it: tests set users admin access_management
     set:
-      clickhouse.users.admin/access_management: "1"
+      clickhouse.additionalUsersConfig.admin/access_management: "1"
     asserts:
       - equal:
           path: spec.configuration.users.admin/access_management

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1310,7 +1310,7 @@ clickhouse:
       # -- ClickHouse image repository.
       repository: clickhouse/clickhouse-server
       # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-      tag: "22.3.6.5"
+      tag: "22.3.13.80"
       # -- Image pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.35.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.41.3"
+  default: ":release-1.40.1"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 
@@ -39,9 +39,11 @@ env: []
 #   - name: FOO
 #     value: bar
 
+
 migrate:
   # -- Whether to install the PostHog migrate job or not.
   enabled: true
+
 
 events:
   # -- Whether to install the PostHog events stack or not.
@@ -99,7 +101,8 @@ web:
     behavior:
 
   # -- Resource limits for web service.
-  resources: {}
+  resources:
+    {}
 
   # -- Additional env variables to inject into the web stack deployment.
   env:
@@ -194,7 +197,8 @@ worker:
   env: []
 
   # -- Resource limits for the worker stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the worker stack deployment.
   nodeSelector: {}
@@ -239,7 +243,8 @@ plugins:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -281,6 +286,7 @@ plugins:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
+
 
 pluginsAsync:
   # -- Whether to install the PostHog plugin-server async stack or not.
@@ -309,7 +315,8 @@ pluginsAsync:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -351,6 +358,7 @@ pluginsAsync:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
+
 
 # -- A deconstructed plugin-server that handles the various workloads of the
 # pipeline separately. For most workloads this will not be needed, rather you
@@ -384,7 +392,8 @@ pluginsIngestion:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -426,6 +435,7 @@ pluginsIngestion:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
+
 
 pluginsExports:
   # -- Whether to install the PostHog plugin-server exports capability as an
@@ -453,7 +463,8 @@ pluginsExports:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -496,6 +507,7 @@ pluginsExports:
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
 
+
 pluginsJobs:
   # -- Whether to install the PostHog plugin-server jobs capability as an
   # individual workload.
@@ -522,7 +534,8 @@ pluginsJobs:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -591,7 +604,8 @@ pluginsScheduler:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources: {}
+  resources:
+    {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -634,6 +648,7 @@ pluginsScheduler:
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
 
+
 email:
   # -- SMTP service host.
   host:
@@ -653,6 +668,7 @@ email:
   use_ssl:
   # -- Outbound email sender to use.
   from_email:
+
 
 saml:
   # -- Whether password-based login is disabled and users automatically redirected to SAML login. Requires SAML to be properly configured.
@@ -702,6 +718,7 @@ saml:
   # attr_email: "email"
   attr_email:
 
+
 service:
   # -- PostHog service name.
   name: posthog
@@ -712,6 +729,7 @@ service:
 
   # -- PostHog service annotations.
   annotations: {}
+
 
 ###
 ###
@@ -748,6 +766,7 @@ cert-manager:
       - 1.1.1.1
       - 208.67.222.222
 
+
 ###
 ###
 ### ---- INGRESS ----
@@ -779,6 +798,7 @@ ingress:
   # -- TLS secret to be used by the ingress.
   secretName:
 
+
 ingress-nginx:
   controller:
     config:
@@ -801,24 +821,24 @@ ingress-nginx:
       #
       log-format-escape-json: "true"
       log-format-upstream: '{
-        "time": "$time_iso8601",
-        "remote_addr": "$proxy_protocol_addr",
-        "request_id": "$request_id",
-        "correlation_id": "$request_id",
-        "remote_user": "$remote_user",
-        "bytes_sent": $bytes_sent,
-        "request_time": $request_time,
-        "status": $status,
-        "host": "$host",
-        "request_proto": "$server_protocol",
-        "uri": "$uri",
-        "request_query": "$args",
-        "request_length": $request_length,
-        "duration": $request_time,
-        "method": "$request_method",
-        "http_referrer": "$http_referer",
-        "http_user_agent": "$http_user_agent",
-        "http_x_forwarded_for": "$http_x_forwarded_for"
+          "time": "$time_iso8601",
+          "remote_addr": "$proxy_protocol_addr",
+          "request_id": "$request_id",
+          "correlation_id": "$request_id",
+          "remote_user": "$remote_user",
+          "bytes_sent": $bytes_sent,
+          "request_time": $request_time,
+          "status": $status,
+          "host": "$host",
+          "request_proto": "$server_protocol",
+          "uri": "$uri",
+          "request_query": "$args",
+          "request_length": $request_length,
+          "duration": $request_time,
+          "method": "$request_method",
+          "http_referrer": "$http_referer",
+          "http_user_agent": "$http_user_agent",
+          "http_x_forwarded_for": "$http_x_forwarded_for"
         }'
 
     # Pass NGINX generated $request_id as X-Correlation-ID such that downstreams can use it
@@ -838,6 +858,7 @@ ingress-nginx:
     #     annotations:
     #       prometheus.io/port: "10254"
     #       prometheus.io/scrape: "true"
+
 
 ###
 ###
@@ -874,6 +895,7 @@ externalPostgresql:
   existingSecret:
   # -- Name of the key pointing to the password in your Kubernetes secret
   existingSecretPasswordKey: postgresql-password
+
 
 ###
 ###
@@ -984,6 +1006,7 @@ pgbouncer:
   ## -- PgBouncer pod(s) annotation.
   podAnnotations: {}
 
+
 ###
 ###
 ### ---- REDIS ----
@@ -1051,6 +1074,7 @@ externalRedis:
   # -- Name of the key pointing to the password in your Kubernetes secret.
   existingSecretPasswordKey: ""
 
+
 ###
 ###
 ### ---- KAFKA ----
@@ -1092,6 +1116,7 @@ externalKafka:
   # - External Kafka brokers. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided as array/list.
   brokers: []
 
+
 ###
 ###
 ### ---- ZOOKEEPER ----
@@ -1115,10 +1140,9 @@ zookeeper:
     enabled: false
     service:
       annotations:
-        "prometheus.io/scrape":
-          "false" # let's make Prometheus skip the scraping of the
-          # service as we already scrape the pods (see below
-          # and https://github.com/bitnami/charts/issues/10101)
+        "prometheus.io/scrape": "false" # let's make Prometheus skip the scraping of the
+                                        # service as we already scrape the pods (see below
+                                        # and https://github.com/bitnami/charts/issues/10101)
 
   ## -- Zookeeper pod(s) annotation.
   podAnnotations:
@@ -1126,6 +1150,7 @@ zookeeper:
     # prometheus.io/scrape: "true"
     # prometheus.io/path: /metrics
     # prometheus.io/port: "9141"
+
 
 ###
 ###
@@ -1168,7 +1193,7 @@ clickhouse:
     # -- ClickHouse image repository.
     repository: clickhouse/clickhouse-server
     # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-    tag: "22.3.13.80"
+    tag: "22.3.6.5"
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
@@ -1236,6 +1261,7 @@ clickhouse:
     default/allow_experimental_window_functions: "1"
     default/allow_nondeterministic_mutations: "1"
 
+
   ## -- Clickhouse cluster layout. (Experimental, use at own risk)
   ## For a full list of options, see https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md
   ## section on clusters and layouts.
@@ -1247,8 +1273,7 @@ clickhouse:
   ## You can use this to override settings, for example `prometheus/port: 9363`
   ## For the full list of settings, see:
   ## - https://clickhouse.com/docs/en/operations/settings/settings/
-  settings:
-    {}
+  settings: {}
     # Uncomment those lines if you want to enable the built-in Prometheus HTTP endpoint in ClickHouse.
     # prometheus/endpoint: /metrics
     # prometheus/port: 9363
@@ -1260,6 +1285,11 @@ clickhouse:
   defaultSettings:
     default_database: "posthog"
     format_schema_path: /etc/clickhouse-server/config.d/
+
+  ## -- specify additional user configs for ClickHouse. This will be added to
+  ## the users.xml configuration. See
+  ## https://github.com/Altinity/clickhouse-operator for details.
+  additionalUsersConfig:
 
   ## -- ClickHouse pod(s) annotation.
   podAnnotations:
@@ -1280,7 +1310,7 @@ clickhouse:
       # -- ClickHouse image repository.
       repository: clickhouse/clickhouse-server
       # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-      tag: "22.3.13.80"
+      tag: "22.3.6.5"
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
@@ -1322,6 +1352,7 @@ clickhouse:
         value: "0"
       # Add settings for remote backup storage.
 
+
 ## External clickhouse configuration
 ##
 externalClickhouse:
@@ -1344,6 +1375,7 @@ externalClickhouse:
   # -- Whether to verify TLS connection connecting to ClickHouse
   verify: false
 
+
 cloudwatch:
   # -- Enable cloudwatch container insights to get logs and metrics on AWS
   enabled: false
@@ -1357,6 +1389,7 @@ cloudwatch:
     port: 2020
     readHead: "On"
     readTail: "Off"
+
 
 # Provide affinity for hooks if needed
 hooks:
@@ -1372,6 +1405,7 @@ hooks:
     # -- Hook job resource limits/requests
     resources: {}
 
+
 serviceAccount:
   # -- Configures if a ServiceAccount with this name should be created
   create: true
@@ -1382,6 +1416,7 @@ serviceAccount:
   name:
   # -- Configures annotation for the ServiceAccount
   annotations: {}
+
 
 ###
 ###
@@ -1458,32 +1493,32 @@ grafana:
     datasources.yaml:
       apiVersion: 1
       datasources:
-        # Comment the snippet below if you are running with `prometheus.enabled: false`
-        - name: Prometheus
-          type: prometheus
-          url: http://posthog-prometheus-server
-          access: proxy
-          isDefault: true
-          jsonData:
-            timeInterval:
-              60s # pass this explicitly so it can be used by '$__rate_interval'
-              # https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
 
-        # Comment the snippet below if you are running with `loki.enabled: false`
-        - name: Loki
-          type: loki
-          url: http://posthog-loki-read:3100
-          access: proxy
-          isDefault: false
+      # Comment the snippet below if you are running with `prometheus.enabled: false`
+      - name: Prometheus
+        type: prometheus
+        url: http://posthog-prometheus-server
+        access: proxy
+        isDefault: true
+        jsonData:
+          timeInterval: 60s # pass this explicitly so it can be used by '$__rate_interval'
+                            # https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
 
-        # Comment the snippet below if you are running with `prometheus.alertmanager.enabled: false`
-        - name: Alertmanager
-          type: alertmanager
-          url: http://posthog-prometheus-alertmanager
-          access: proxy
-          isDefault: false
-          jsonData:
-            implementation: prometheus
+      # Comment the snippet below if you are running with `loki.enabled: false`
+      - name: Loki
+        type: loki
+        url: http://posthog-loki-read:3100
+        access: proxy
+        isDefault: false
+
+      # Comment the snippet below if you are running with `prometheus.alertmanager.enabled: false`
+      - name: Alertmanager
+        type: alertmanager
+        url: http://posthog-prometheus-alertmanager
+        access: proxy
+        isDefault: false
+        jsonData:
+          implementation: prometheus
 
 ###
 ###
@@ -1621,8 +1656,7 @@ promtail:
                   format: RFC3339Nano
 
   ## -- Pod annotations.
-  podAnnotations:
-    {}
+  podAnnotations: {}
     # Uncomment those lines if you want Prometheus server to scrape metrics.
     # prometheus.io/scrape: "true"
     # prometheus.io/path: /metrics
@@ -1640,8 +1674,7 @@ prometheus:
   alertmanager:
     # -- Whether to install Prometheus AlertManager or not.
     enabled: false
-    podAnnotations:
-      {}
+    podAnnotations: {}
       # Uncomment those lines if you want Prometheus server to scrape metrics.
       # prometheus.io/scrape: "true"
       # prometheus.io/path: /metrics
@@ -1971,6 +2004,7 @@ prometheus:
                 summary: Kubernetes API server latency (instance {{ $labels.instance }})
                 description: "Kubernetes API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}."
 
+
         - name: Loki # via embedded exporter
           rules:
             - alert: LokiProcessTooManyRestarts
@@ -1998,7 +2032,7 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Loki request panic (instance {{ $labels.instance }})
-                description: 'The {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% increase of panics'
+                description: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value }}% increase of panics"
 
             - alert: LokiRequestLatency
               expr: (histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{route!~"(?i).*tail.*"}[5m])) by (le))) > 3
@@ -2007,7 +2041,8 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Loki request latency (instance {{ $labels.instance }})
-                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency'
+                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}s 99th percentile latency"
+
 
         - name: Promtail # via embedded exporter
           rules:
@@ -2018,7 +2053,7 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Promtail request errors (instance {{ $labels.instance }})
-                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.'
+                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}% errors."
 
             - alert: PromtailRequestLatency
               expr: histogram_quantile(0.99, sum(rate(promtail_request_duration_seconds_bucket[5m])) by (le)) > 1
@@ -2027,7 +2062,8 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Promtail request latency (instance {{ $labels.instance }})
-                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.'
+                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}s 99th percentile latency."
+
 
         - name: Prometheus # via embedded exporter
           rules:
@@ -2376,6 +2412,7 @@ prometheus:
                 summary: Redis rejected connections (instance {{ $labels.instance }})
                 description: "Some connections to Redis has been rejected"
 
+
 ###
 ###
 ### ---- prometheus-statsd-exporter ----
@@ -2396,6 +2433,7 @@ externalStatsd:
   # -- External Statsd port to use.
   port:
 
+
 ###
 ###
 ### ---- prometheus-kafka-exporter ----
@@ -2414,6 +2452,7 @@ prometheus-kafka-exporter:
   # -- Specify the target Kafka brokers to monitor.
   kafkaServer:
     - posthog-posthog-kafka:9092
+
 
 ###
 ###
@@ -2439,6 +2478,7 @@ prometheus-postgres-exporter:
         name: posthog-posthog-postgresql
         key: postgresql-password
 
+
 ###
 ###
 ### ---- prometheus-redis-exporter ----
@@ -2456,6 +2496,7 @@ prometheus-redis-exporter:
 
   # -- Specify the target Redis instance to monitor.
   redisAddress: redis://posthog-posthog-redis-master:6379
+
 
 ###
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- PostHog image tag to use (example: `release-1.35.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.40.1"
+  default: ":release-1.41.3"
   # -- PostHog image pull policy.
   pullPolicy: IfNotPresent
 
@@ -1193,7 +1193,7 @@ clickhouse:
     # -- ClickHouse image repository.
     repository: clickhouse/clickhouse-server
     # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-    tag: "22.3.6.5"
+    tag: "22.3.13.80"
     # -- Image pull policy
     pullPolicy: IfNotPresent
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -39,11 +39,9 @@ env: []
 #   - name: FOO
 #     value: bar
 
-
 migrate:
   # -- Whether to install the PostHog migrate job or not.
   enabled: true
-
 
 events:
   # -- Whether to install the PostHog events stack or not.
@@ -101,8 +99,7 @@ web:
     behavior:
 
   # -- Resource limits for web service.
-  resources:
-    {}
+  resources: {}
 
   # -- Additional env variables to inject into the web stack deployment.
   env:
@@ -197,8 +194,7 @@ worker:
   env: []
 
   # -- Resource limits for the worker stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the worker stack deployment.
   nodeSelector: {}
@@ -243,8 +239,7 @@ plugins:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -286,7 +281,6 @@ plugins:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
-
 
 pluginsAsync:
   # -- Whether to install the PostHog plugin-server async stack or not.
@@ -315,8 +309,7 @@ pluginsAsync:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -358,7 +351,6 @@ pluginsAsync:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
-
 
 # -- A deconstructed plugin-server that handles the various workloads of the
 # pipeline separately. For most workloads this will not be needed, rather you
@@ -392,8 +384,7 @@ pluginsIngestion:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -435,7 +426,6 @@ pluginsIngestion:
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
-
 
 pluginsExports:
   # -- Whether to install the PostHog plugin-server exports capability as an
@@ -463,8 +453,7 @@ pluginsExports:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -507,7 +496,6 @@ pluginsExports:
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
 
-
 pluginsJobs:
   # -- Whether to install the PostHog plugin-server jobs capability as an
   # individual workload.
@@ -534,8 +522,7 @@ pluginsJobs:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -604,8 +591,7 @@ pluginsScheduler:
   env: []
 
   # -- Resource limits for the plugin-server stack deployment.
-  resources:
-    {}
+  resources: {}
 
   # -- Node labels for the plugin-server stack deployment.
   nodeSelector: {}
@@ -648,7 +634,6 @@ pluginsScheduler:
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
 
-
 email:
   # -- SMTP service host.
   host:
@@ -668,7 +653,6 @@ email:
   use_ssl:
   # -- Outbound email sender to use.
   from_email:
-
 
 saml:
   # -- Whether password-based login is disabled and users automatically redirected to SAML login. Requires SAML to be properly configured.
@@ -718,7 +702,6 @@ saml:
   # attr_email: "email"
   attr_email:
 
-
 service:
   # -- PostHog service name.
   name: posthog
@@ -729,7 +712,6 @@ service:
 
   # -- PostHog service annotations.
   annotations: {}
-
 
 ###
 ###
@@ -766,7 +748,6 @@ cert-manager:
       - 1.1.1.1
       - 208.67.222.222
 
-
 ###
 ###
 ### ---- INGRESS ----
@@ -798,7 +779,6 @@ ingress:
   # -- TLS secret to be used by the ingress.
   secretName:
 
-
 ingress-nginx:
   controller:
     config:
@@ -821,24 +801,24 @@ ingress-nginx:
       #
       log-format-escape-json: "true"
       log-format-upstream: '{
-          "time": "$time_iso8601",
-          "remote_addr": "$proxy_protocol_addr",
-          "request_id": "$request_id",
-          "correlation_id": "$request_id",
-          "remote_user": "$remote_user",
-          "bytes_sent": $bytes_sent,
-          "request_time": $request_time,
-          "status": $status,
-          "host": "$host",
-          "request_proto": "$server_protocol",
-          "uri": "$uri",
-          "request_query": "$args",
-          "request_length": $request_length,
-          "duration": $request_time,
-          "method": "$request_method",
-          "http_referrer": "$http_referer",
-          "http_user_agent": "$http_user_agent",
-          "http_x_forwarded_for": "$http_x_forwarded_for"
+        "time": "$time_iso8601",
+        "remote_addr": "$proxy_protocol_addr",
+        "request_id": "$request_id",
+        "correlation_id": "$request_id",
+        "remote_user": "$remote_user",
+        "bytes_sent": $bytes_sent,
+        "request_time": $request_time,
+        "status": $status,
+        "host": "$host",
+        "request_proto": "$server_protocol",
+        "uri": "$uri",
+        "request_query": "$args",
+        "request_length": $request_length,
+        "duration": $request_time,
+        "method": "$request_method",
+        "http_referrer": "$http_referer",
+        "http_user_agent": "$http_user_agent",
+        "http_x_forwarded_for": "$http_x_forwarded_for"
         }'
 
     # Pass NGINX generated $request_id as X-Correlation-ID such that downstreams can use it
@@ -858,7 +838,6 @@ ingress-nginx:
     #     annotations:
     #       prometheus.io/port: "10254"
     #       prometheus.io/scrape: "true"
-
 
 ###
 ###
@@ -895,7 +874,6 @@ externalPostgresql:
   existingSecret:
   # -- Name of the key pointing to the password in your Kubernetes secret
   existingSecretPasswordKey: postgresql-password
-
 
 ###
 ###
@@ -1006,7 +984,6 @@ pgbouncer:
   ## -- PgBouncer pod(s) annotation.
   podAnnotations: {}
 
-
 ###
 ###
 ### ---- REDIS ----
@@ -1074,7 +1051,6 @@ externalRedis:
   # -- Name of the key pointing to the password in your Kubernetes secret.
   existingSecretPasswordKey: ""
 
-
 ###
 ###
 ### ---- KAFKA ----
@@ -1116,7 +1092,6 @@ externalKafka:
   # - External Kafka brokers. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided as array/list.
   brokers: []
 
-
 ###
 ###
 ### ---- ZOOKEEPER ----
@@ -1140,9 +1115,10 @@ zookeeper:
     enabled: false
     service:
       annotations:
-        "prometheus.io/scrape": "false" # let's make Prometheus skip the scraping of the
-                                        # service as we already scrape the pods (see below
-                                        # and https://github.com/bitnami/charts/issues/10101)
+        "prometheus.io/scrape":
+          "false" # let's make Prometheus skip the scraping of the
+          # service as we already scrape the pods (see below
+          # and https://github.com/bitnami/charts/issues/10101)
 
   ## -- Zookeeper pod(s) annotation.
   podAnnotations:
@@ -1150,7 +1126,6 @@ zookeeper:
     # prometheus.io/scrape: "true"
     # prometheus.io/path: /metrics
     # prometheus.io/port: "9141"
-
 
 ###
 ###
@@ -1256,11 +1231,15 @@ clickhouse:
   ## - https://clickhouse.com/docs/en/operations/settings/settings/
   profiles: {}
 
+  ## -- ClickHouse user configs defaults used for defining users
+  ## Use this to set defaults for things like `access_management`
+  ## https://clickhouse.com/docs/en/operations/settings/settings-users#access_management-user-setting
+  defaultUsers: {}
+
   ## -- Default user profile configuration for Clickhouse. !!! Please DO NOT override this !!!
   defaultProfiles:
     default/allow_experimental_window_functions: "1"
     default/allow_nondeterministic_mutations: "1"
-
 
   ## -- Clickhouse cluster layout. (Experimental, use at own risk)
   ## For a full list of options, see https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md
@@ -1273,7 +1252,8 @@ clickhouse:
   ## You can use this to override settings, for example `prometheus/port: 9363`
   ## For the full list of settings, see:
   ## - https://clickhouse.com/docs/en/operations/settings/settings/
-  settings: {}
+  settings:
+    {}
     # Uncomment those lines if you want to enable the built-in Prometheus HTTP endpoint in ClickHouse.
     # prometheus/endpoint: /metrics
     # prometheus/port: 9363
@@ -1347,7 +1327,6 @@ clickhouse:
         value: "0"
       # Add settings for remote backup storage.
 
-
 ## External clickhouse configuration
 ##
 externalClickhouse:
@@ -1370,7 +1349,6 @@ externalClickhouse:
   # -- Whether to verify TLS connection connecting to ClickHouse
   verify: false
 
-
 cloudwatch:
   # -- Enable cloudwatch container insights to get logs and metrics on AWS
   enabled: false
@@ -1384,7 +1362,6 @@ cloudwatch:
     port: 2020
     readHead: "On"
     readTail: "Off"
-
 
 # Provide affinity for hooks if needed
 hooks:
@@ -1400,7 +1377,6 @@ hooks:
     # -- Hook job resource limits/requests
     resources: {}
 
-
 serviceAccount:
   # -- Configures if a ServiceAccount with this name should be created
   create: true
@@ -1411,7 +1387,6 @@ serviceAccount:
   name:
   # -- Configures annotation for the ServiceAccount
   annotations: {}
-
 
 ###
 ###
@@ -1488,32 +1463,32 @@ grafana:
     datasources.yaml:
       apiVersion: 1
       datasources:
+        # Comment the snippet below if you are running with `prometheus.enabled: false`
+        - name: Prometheus
+          type: prometheus
+          url: http://posthog-prometheus-server
+          access: proxy
+          isDefault: true
+          jsonData:
+            timeInterval:
+              60s # pass this explicitly so it can be used by '$__rate_interval'
+              # https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
 
-      # Comment the snippet below if you are running with `prometheus.enabled: false`
-      - name: Prometheus
-        type: prometheus
-        url: http://posthog-prometheus-server
-        access: proxy
-        isDefault: true
-        jsonData:
-          timeInterval: 60s # pass this explicitly so it can be used by '$__rate_interval'
-                            # https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
+        # Comment the snippet below if you are running with `loki.enabled: false`
+        - name: Loki
+          type: loki
+          url: http://posthog-loki-read:3100
+          access: proxy
+          isDefault: false
 
-      # Comment the snippet below if you are running with `loki.enabled: false`
-      - name: Loki
-        type: loki
-        url: http://posthog-loki-read:3100
-        access: proxy
-        isDefault: false
-
-      # Comment the snippet below if you are running with `prometheus.alertmanager.enabled: false`
-      - name: Alertmanager
-        type: alertmanager
-        url: http://posthog-prometheus-alertmanager
-        access: proxy
-        isDefault: false
-        jsonData:
-          implementation: prometheus
+        # Comment the snippet below if you are running with `prometheus.alertmanager.enabled: false`
+        - name: Alertmanager
+          type: alertmanager
+          url: http://posthog-prometheus-alertmanager
+          access: proxy
+          isDefault: false
+          jsonData:
+            implementation: prometheus
 
 ###
 ###
@@ -1651,7 +1626,8 @@ promtail:
                   format: RFC3339Nano
 
   ## -- Pod annotations.
-  podAnnotations: {}
+  podAnnotations:
+    {}
     # Uncomment those lines if you want Prometheus server to scrape metrics.
     # prometheus.io/scrape: "true"
     # prometheus.io/path: /metrics
@@ -1669,7 +1645,8 @@ prometheus:
   alertmanager:
     # -- Whether to install Prometheus AlertManager or not.
     enabled: false
-    podAnnotations: {}
+    podAnnotations:
+      {}
       # Uncomment those lines if you want Prometheus server to scrape metrics.
       # prometheus.io/scrape: "true"
       # prometheus.io/path: /metrics
@@ -1999,7 +1976,6 @@ prometheus:
                 summary: Kubernetes API server latency (instance {{ $labels.instance }})
                 description: "Kubernetes API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}."
 
-
         - name: Loki # via embedded exporter
           rules:
             - alert: LokiProcessTooManyRestarts
@@ -2027,7 +2003,7 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Loki request panic (instance {{ $labels.instance }})
-                description: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value }}% increase of panics"
+                description: 'The {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% increase of panics'
 
             - alert: LokiRequestLatency
               expr: (histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{route!~"(?i).*tail.*"}[5m])) by (le))) > 3
@@ -2036,8 +2012,7 @@ prometheus:
                 severity: warning
               annotations:
                 summary: Loki request latency (instance {{ $labels.instance }})
-                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}s 99th percentile latency"
-
+                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency'
 
         - name: Promtail # via embedded exporter
           rules:
@@ -2048,7 +2023,7 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Promtail request errors (instance {{ $labels.instance }})
-                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}% errors."
+                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.'
 
             - alert: PromtailRequestLatency
               expr: histogram_quantile(0.99, sum(rate(promtail_request_duration_seconds_bucket[5m])) by (le)) > 1
@@ -2057,8 +2032,7 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Promtail request latency (instance {{ $labels.instance }})
-                description: "The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf \"%.2f\" $value }}s 99th percentile latency."
-
+                description: 'The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.'
 
         - name: Prometheus # via embedded exporter
           rules:
@@ -2407,7 +2381,6 @@ prometheus:
                 summary: Redis rejected connections (instance {{ $labels.instance }})
                 description: "Some connections to Redis has been rejected"
 
-
 ###
 ###
 ### ---- prometheus-statsd-exporter ----
@@ -2428,7 +2401,6 @@ externalStatsd:
   # -- External Statsd port to use.
   port:
 
-
 ###
 ###
 ### ---- prometheus-kafka-exporter ----
@@ -2447,7 +2419,6 @@ prometheus-kafka-exporter:
   # -- Specify the target Kafka brokers to monitor.
   kafkaServer:
     - posthog-posthog-kafka:9092
-
 
 ###
 ###
@@ -2473,7 +2444,6 @@ prometheus-postgres-exporter:
         name: posthog-posthog-postgresql
         key: postgresql-password
 
-
 ###
 ###
 ### ---- prometheus-redis-exporter ----
@@ -2491,7 +2461,6 @@ prometheus-redis-exporter:
 
   # -- Specify the target Redis instance to monitor.
   redisAddress: redis://posthog-posthog-redis-master:6379
-
 
 ###
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1231,11 +1231,6 @@ clickhouse:
   ## - https://clickhouse.com/docs/en/operations/settings/settings/
   profiles: {}
 
-  ## -- ClickHouse user configs defaults used for defining users
-  ## Use this to set defaults for things like `access_management`
-  ## https://clickhouse.com/docs/en/operations/settings/settings-users#access_management-user-setting
-  defaultUsers: {}
-
   ## -- Default user profile configuration for Clickhouse. !!! Please DO NOT override this !!!
   defaultProfiles:
     default/allow_experimental_window_functions: "1"


### PR DESCRIPTION
## Description
We have a paying user requesting to have the ability to create users dynamically using SQL
https://clickhouse.com/docs/en/sql-reference/statements/create/user/

In order to do this we must enable `access_management` in the `users.xml` configs.
https://clickhouse.com/docs/en/operations/settings/settings-users#access_management-user-setting

This PR makes it possible to enable this through the following values:
```yaml
clickhouse:
  enable: true
  additionalUsersConfig:
    admin/access_management: "1"
```

Requested by customer here:
https://posthog.slack.com/archives/C03G21222QY/p1668109138746399?thread_ts=1666628600.482729&cid=C03G21222QY

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tested on a Digitalocean K8s cluster 

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

