### PR TITLE
Add value for Kubernetes cluster name

### DIFF
--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -8,6 +8,14 @@
   {{- end -}}
 {{- end }}
 
+{{- define "posthog.clusterName" }}
+  {{- if .Values.clusterName -}}
+    {{- .Values.clusterName -}}
+  {{- else -}}
+    cluster
+  {{- end -}}
+{{- end }}
+
 {{- define "snippet.posthog-env" }}
 - name: SECRET_KEY
   valueFrom:

--- a/charts/posthog/templates/_posthog.tpl
+++ b/charts/posthog/templates/_posthog.tpl
@@ -8,14 +8,6 @@
   {{- end -}}
 {{- end }}
 
-{{- define "posthog.clusterName" }}
-  {{- if .Values.clusterName -}}
-    {{- .Values.clusterName -}}
-  {{- else -}}
-    cluster
-  {{- end -}}
-{{- end }}
-
 {{- define "snippet.posthog-env" }}
 - name: SECRET_KEY
   valueFrom:

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -12,7 +12,7 @@
         {{ if .Values.clickhouse.enabled }}
         until (
             NODES_COUNT=$(wget -qO- \
-                "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local:8123" \
+                "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local:8123" \
                 --post-data "SELECT count() FROM clusterAllReplicas('{{ .Values.clickhouse.cluster }}', system, one)"
             )
             test ! -z $NODES_COUNT && test $NODES_COUNT -eq {{ mul .Values.clickhouse.layout.shardsCount .Values.clickhouse.layout.replicasCount }}
@@ -22,20 +22,20 @@
         done
         {{ end }}
 
-        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.pgbouncer.port" . }});
+        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local" {{ include "posthog.pgbouncer.port" . }});
         do
             echo "waiting for PgBouncer"; sleep 1;
         done
 
         {{ if .Values.postgresql.enabled }}
-        until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.postgresql.port" . }});
+        until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local" {{ include "posthog.postgresql.port" . }});
         do
             echo "waiting for PostgreSQL"; sleep 1;
         done
         {{ end }}
 
         {{ if .Values.redis.enabled }}
-        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.redis.port" . }});
+        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local" {{ include "posthog.redis.port" . }});
         do
             echo "waiting for Redis"; sleep 1;
         done
@@ -48,7 +48,7 @@
         KAFKA_HOST=$(echo $KAFKA_BROKERS | cut -f1 -d:)
         KAFKA_PORT=$(echo $KAFKA_BROKERS | cut -f2 -d:)
 
-        until (nc -vz "$KAFKA_HOST.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" $KAFKA_PORT);
+        until (nc -vz "$KAFKA_HOST.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local" $KAFKA_PORT);
         do
             echo "waiting for Kafka"; sleep 1;
         done

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -12,7 +12,7 @@
         {{ if .Values.clickhouse.enabled }}
         until (
             NODES_COUNT=$(wget -qO- \
-                "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local:8123" \
+                "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local:8123" \
                 --post-data "SELECT count() FROM clusterAllReplicas('{{ .Values.clickhouse.cluster }}', system, one)"
             )
             test ! -z $NODES_COUNT && test $NODES_COUNT -eq {{ mul .Values.clickhouse.layout.shardsCount .Values.clickhouse.layout.replicasCount }}
@@ -22,20 +22,20 @@
         done
         {{ end }}
 
-        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.pgbouncer.port" . }});
+        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.pgbouncer.port" . }});
         do
             echo "waiting for PgBouncer"; sleep 1;
         done
 
         {{ if .Values.postgresql.enabled }}
-        until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.postgresql.port" . }});
+        until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.postgresql.port" . }});
         do
             echo "waiting for PostgreSQL"; sleep 1;
         done
         {{ end }}
 
         {{ if .Values.redis.enabled }}
-        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.redis.port" . }});
+        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" {{ include "posthog.redis.port" . }});
         do
             echo "waiting for Redis"; sleep 1;
         done
@@ -48,7 +48,7 @@
         KAFKA_HOST=$(echo $KAFKA_BROKERS | cut -f1 -d:)
         KAFKA_PORT=$(echo $KAFKA_BROKERS | cut -f2 -d:)
 
-        until (nc -vz "$KAFKA_HOST.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" $KAFKA_PORT);
+        until (nc -vz "$KAFKA_HOST.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local" $KAFKA_PORT);
         do
             echo "waiting for Kafka"; sleep 1;
         done

--- a/charts/posthog/templates/clickhouse-backup-cronjob.yaml
+++ b/charts/posthog/templates/clickhouse-backup-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                 - |
                   until (
                       wget -qO- \
-                          "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@clickhouse-posthog.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local:8123" \
+                          "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@clickhouse-posthog.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local:8123" \
                           --post-data "SELECT count() FROM clusterAllReplicas('posthog', system, one)"
                   ); do
                       echo "waiting for ClickHouse cluster to become available"; sleep 1;

--- a/charts/posthog/templates/clickhouse-backup-cronjob.yaml
+++ b/charts/posthog/templates/clickhouse-backup-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                 - |
                   until (
                       wget -qO- \
-                          "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@clickhouse-posthog.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ include "posthog.clusterName" . }}.local:8123" \
+                      "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@clickhouse-posthog.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.{{ .Values.clusterName }}.local:8123" \
                           --post-data "SELECT count() FROM clusterAllReplicas('posthog', system, one)"
                   ); do
                       echo "waiting for ClickHouse cluster to become available"; sleep 1;

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -8,6 +8,9 @@ notificationEmail:
 # This is used to e.g. generate shareable links to Dashboards.
 siteUrl:
 
+# -- Cluster name used for internal DNS resolution (svc.{{clusterName}}.local)
+clusterName: cluster
+
 image:
   # -- PostHog image repository to use.
   repository: posthog/posthog


### PR DESCRIPTION
## Description
Adding a configurable value for the name of the Kubernetes cluster. I need this because my hosting provider assigns custom cluster names and this breaks the internal communication in the initContainers snippet making in stay in a pending state forever. 
I have made the change wherever I could find the pattern `svc.cluster.local`. (test code excluded)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Configured the correct cluster name in my custom values.yaml and was succesfully able to deploy. I have also tested the fallback to the default cluster name in the same way.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
