### PR TITLE
PgBouncer: use service FQDN

### DIFF
--- a/charts/posthog/templates/_pgbouncer.tpl
+++ b/charts/posthog/templates/_pgbouncer.tpl
@@ -1,14 +1,25 @@
-{{/* Common pgbouncer helpers used by PostHog */}}
+{{/* Common PgBouncer helpers used by PostHog */}}
 
 {{/*
-Set pgbouncer host
+Set PgBouncer FQDN
+*/}}
+{{- define "posthog.pgbouncer.fqdn" -}}
+    {{- $fullname := include "posthog.fullname" . -}}
+    {{- $serviceName := printf "%s-pgbouncer" $fullname -}}
+    {{- $releaseNamespace := .Release.Namespace -}}
+    {{- $clusterDomain := .Values.clusterDomain -}}
+    {{- printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain -}}
+{{- end -}}
+
+{{/*
+Set PgBouncer host
 */}}
 {{- define "posthog.pgbouncer.host" -}}
     {{- template "posthog.fullname" . }}-pgbouncer
 {{- end -}}
 
 {{/*
-Set pgbouncer port
+Set PgBouncer port
 */}}
 {{- define "posthog.pgbouncer.port" -}}
     6543

--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -22,7 +22,7 @@
         done
         {{ end }}
 
-        until (nc -vz "{{ include "posthog.pgbouncer.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.pgbouncer.port" . }});
+        until (nc -vz "{{ include "posthog.pgbouncer.fqdn" . }}" {{ include "posthog.pgbouncer.port" . }});
         do
             echo "waiting for PgBouncer"; sleep 1;
         done

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2579,3 +2579,7 @@ busybox:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
+
+
+# -- Kubernetes cluster domain name
+clusterDomain: cluster.local


### PR DESCRIPTION
## Description
We currently do not use a FQDN record to connect to pgbouncer. Due to Kubernetes internals, this will translate in several DNS requests before receiving the right answer:

bash-5.1$ nslookup posthog-pgbouncer
Server:		172.20.0.10
Address:	172.20.0.10:53

Name:	posthog-pgbouncer.posthog.svc.cluster.local
Address: 172.20.88.150

** server can't find posthog-pgbouncer.cluster.local: NXDOMAIN

** server can't find posthog-pgbouncer.cluster.local: NXDOMAIN

** server can't find posthog-pgbouncer.svc.cluster.local: NXDOMAIN

** server can't find posthog-pgbouncer.svc.cluster.local: NXDOMAIN

** server can't find posthog-pgbouncer.ec2.internal: NXDOMAIN

** server can't find posthog-pgbouncer.ec2.internal: NXDOMAIN
```

This PR adds a new `posthog.pgbouncer.fqdn` that can be used to directly target the FQDN record.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
CI is ✅ 

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
