### PR TITLE
Disable internal_metrics by default

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | web.env[0] | object | `{"name":"SOCIAL_AUTH_GOOGLE_OAUTH2_KEY","value":null}` | Set google oauth 2 key. Requires posthog ee license. |
 | web.env[1] | object | `{"name":"SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET","value":null}` | Set google oauth 2 secret. Requires posthog ee license. |
 | web.env[2] | object | `{"name":"SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS","value":"posthog.com"}` | Set google oauth 2 whitelisted domains users can log in from. |
-| web.internalMetrics.capture | bool | `true` | Whether to capture information on operation of posthog into posthog, exposed in /instance/status page |
+| web.internalMetrics.capture | bool | `false` | Whether to capture information on operation of posthog into posthog, exposed in /instance/status page |
 | web.nodeSelector | object | `{}` | Node labels for web stack deployment. |
 | web.tolerations | list | `[]` | Toleration labels for web stack deployment. |
 | web.affinity | object | `{}` | Affinity settings for web stack deployment. |

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 29.0.10
+version: 29.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -125,8 +125,8 @@ web:
       value: "posthog.com"
 
   internalMetrics:
-    # -- Whether to capture information on operation of posthog into posthog, exposed in /instance/status page
-    capture: true
+    # -- Deprecated: Whether to capture information on operation of posthog into posthog, exposed in /instance/status page
+    capture: false
 
   # -- Node labels for web stack deployment.
   nodeSelector: {}


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/12943 removes the feature completely and it hasnt been useful for months. For old releases, keep the environment variable around