### PR TITLE
chore: set Strict-Transport-Security header

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -19,6 +19,8 @@ metadata:
     {{- end }}
    {{- end }}
    {{- if (and (eq (include "ingress.type" .) "nginx") .Values.ingress.nginx.redirectToTLS "true") }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=30; includeSubDomains";
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    {{- if eq (include "ingress.letsencrypt" .) "true"}}

--- a/charts/posthog/tests/ingress.yaml
+++ b/charts/posthog/tests/ingress.yaml
@@ -51,6 +51,8 @@ tests:
             meta.helm.sh/release-name: RELEASE-NAME
             meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |
+              more_set_headers "Strict-Transport-Security: max-age=30; includeSubDomains";
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
@@ -73,6 +75,8 @@ tests:
             meta.helm.sh/release-name: RELEASE-NAME
             meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |
+              more_set_headers "Strict-Transport-Security: max-age=30; includeSubDomains";
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
@@ -127,6 +131,8 @@ tests:
             meta.helm.sh/release-name: RELEASE-NAME
             meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |
+              more_set_headers "Strict-Transport-Security: max-age=30; includeSubDomains";
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
 

--- a/charts/posthog/tests/ingress.yaml
+++ b/charts/posthog/tests/ingress.yaml
@@ -143,6 +143,8 @@ tests:
             meta.helm.sh/release-name: RELEASE-NAME
             meta.helm.sh/release-namespace: NAMESPACE
             kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |
+              more_set_headers "Strict-Transport-Security: max-age=30; includeSubDomains";
             nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             nginx.ingress.kubernetes.io/ssl-redirect: "true"
             cert-manager.io/cluster-issuer: "letsencrypt-prod"


### PR DESCRIPTION
## Description
The security header Strict-Transport-Security is disabled; we need to enable it to force the site to use HTTPS.
This change sets the header with a max-age of 30 seconds.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
In a self-hosted installation, we can see the header is set:

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/115043334/204679482-b1c479b1-1557-4ce1-8200-d8cb7963c8fd.png">


## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
