### PR TITLE
Allow extra volumes for clickhouse-backup

### DIFF
--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -81,8 +81,9 @@ spec:
           nodeSelector: {{ toYaml .Values.clickhouse.nodeSelector | nindent 12 }}
           {{- end }}
 
-          {{- if .Values.clickhouse.persistence.enabled }}
+          {{- if or .Values.clickhouse.persistence.enabled .Values.clickhouse.extraVolumes }}
           volumes:
+          {{- if .Values.clickhouse.persistence.enabled }}
           {{- if .Values.clickhouse.persistence.existingClaim }}
             - name: existing-volumeclaim
               persistentVolumeClaim:
@@ -91,6 +92,10 @@ spec:
             - name: data-volumeclaim-template
               persistentVolumeClaim:
                 claimName: data-volumeclaim-template
+          {{- end }}
+          {{- end }}
+          {{- with .Values.clickhouse.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
 
@@ -148,6 +153,9 @@ spec:
               ports:
                 - name: backup-rest
                   containerPort: 7171
+              {{- with .Values.clickhouse.backup.extraVolumeMounts }}
+              volumeMounts: {{- toYaml . | nindent 16 }}
+              {{- end }}
             {{- end }}
 
     serviceTemplates:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using GCS as upload target it requires a client-key JSON file, which needs to be mounted as volume.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Deployment in google cloud.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
