### PR TITLE
Allow setting envvars in the events deployment

### DIFF
--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -116,6 +116,9 @@ spec:
 {{- if .Values.web.env }}
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}
+{{- if .Values.events.env }}
+{{ toYaml .Values.events.env | indent 8 }}
+{{- end }}
 
         {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
 

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -183,6 +183,32 @@ tests:
             name: SENTRY_DSN
             value: sentry.endpoint
 
+  - it: sets env vars from global, web and events sections
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+            - name: FIRST
+              value: one
+      web:
+        env:
+            - name: SECOND
+              value: two
+      events:
+        env:
+            - name: THIRD
+              value: three
+      asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            - name: FIRST
+              value: one
+            - name: SECOND
+              value: two
+            - name: THIRD
+              value: three
+
   - it: allows setting imagePullSecrets
     template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -74,6 +74,9 @@ events:
     # for configuration options
     behavior:
 
+  # -- Additional env variables to inject into the events stack, applied after `web.env`.
+  env: []
+
   # -- Container security context for the events stack HorizontalPodAutoscaler.
   securityContext:
     enabled: false


### PR DESCRIPTION
## Description

Allow to set envvars to the events deployment, separate from the web deployment. This will be used to tune this deployment's behavior and performance.

Because this deploy already uses `.Values.web.env`, the new `.Values.events.env` list is added on top of it for backwards-compatibility. I am updating `.Values.web.env`'s doc to reflect that it also impacts events.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Introduced a new unit test

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
