### PR TITLE
feat(alerts): add alert on exports consumer group backlog

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.2.0
+version: 30.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1774,6 +1774,60 @@ prometheus:
                 summary: Exports and WebHooks backlog appears to have been increasing for 10 minutes straight.
                 description: "The backlog on consumer group clickhouse-plugin-server-async for topic clickhouse_events_json is increasing."
 
+            - alert: ClickHouseEventsConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_events_json", consumergroup="group1"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: ClickHouse events ingestion lag has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group group1 for topic clickhouse_events_json is increasing."
+
+            - alert: ClickHousePersonConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_person", consumergroup="group1"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: ClickHouse person ingestion lag has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group group1 for topic clickhouse_person is increasing."
+
+            - alert: ClickHousePersonConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_groups", consumergroup="group1"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: ClickHouse groups ingestion lag has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group group1 for topic clickhouse_groups is increasing."
+
+            - alert: ClickHousePersonDistinctIdConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_person_distinct_id", consumergroup="group1"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: ClickHouse person distinct id ingestion lag has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group group1 for topic clickhouse_person_distinct_id is increasing."
+
+            - alert: EventsIngestionConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="events_plugin_ingestion", consumergroup="clickhouse-ingestion"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: Events ingestion processing lag has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group clickhouse-ingestion for topic events_plugin_ingestion is increasing."
+
+            - alert: EventsIngestionBufferConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="conversion_events_buffer", consumergroup="ingester"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: Events ingestion processing lag for delayed events has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group ingester for topic conversion_events_buffer is increasing."
+
         - name: Kubernetes # via kube-state-metrics
           rules:
             - alert: KubernetesNodeReady

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1775,7 +1775,7 @@ prometheus:
                 description: "The backlog on consumer group clickhouse-plugin-server-async for topic clickhouse_events_json is increasing."
 
             - alert: ClickHouseConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic=~"clickhouse_events_json|clickhouse_person|clickhouse_groups|clickhouse_person_distinct_id", consumergroup="group1"}[10m])) > 0
+              expr: sum(delta(kafka_consumergroup_lag{consumergroup="group1"}[10m])) by (topic) > 0
               for: 10m
               labels:
                 severity: critical

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1792,7 +1792,7 @@ prometheus:
                 summary: ClickHouse person ingestion lag has been increasing for 10 minutes straight.
                 description: "The backlog on consumer group group1 for topic clickhouse_person is increasing."
 
-            - alert: ClickHousePersonConsumerLagIncreasing
+            - alert: ClickHouseGroupsConsumerLagIncreasing
               expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_groups", consumergroup="group1"}[10m])) > 0
               for: 10m
               labels:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1763,6 +1763,17 @@ prometheus:
       # https://github.com/samber/awesome-prometheus-alerts
       #
       groups:
+        - name: PostHog
+          rules:
+            - alert: ExportsConsumerGroupBacklogIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_events_json", consumergroup="clickhouse-plugin-server-async"}[10m])) > 0
+              for: 10m
+              labels:
+                severity: critical
+              annotations:
+                summary: Exports and WebHooks backlog appears to have been increasing for 10 minutes straight.
+                description: "The backlog on consumer group clickhouse-plugin-server-async for topic clickhouse_events_json is increasing."
+
         - name: Kubernetes # via kube-state-metrics
           rules:
             - alert: KubernetesNodeReady

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1765,7 +1765,7 @@ prometheus:
       groups:
         - name: PostHog
           rules:
-            - alert: ExportsConsumerGroupBacklogIncreasing
+            - alert: ExportsConsumerLagIncreasing
               expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_events_json", consumergroup="clickhouse-plugin-server-async"}[10m])) > 0
               for: 10m
               labels:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1774,41 +1774,14 @@ prometheus:
                 summary: Exports and WebHooks backlog appears to have been increasing for 10 minutes straight.
                 description: "The backlog on consumer group clickhouse-plugin-server-async for topic clickhouse_events_json is increasing."
 
-            - alert: ClickHouseEventsConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_events_json", consumergroup="group1"}[10m])) > 0
+            - alert: ClickHouseConsumerLagIncreasing
+              expr: sum(delta(kafka_consumergroup_lag{topic=~"clickhouse_events_json|clickhouse_person|clickhouse_groups|clickhouse_person_distinct_id", consumergroup="group1"}[10m])) > 0
               for: 10m
               labels:
                 severity: critical
               annotations:
-                summary: ClickHouse events ingestion lag has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group group1 for topic clickhouse_events_json is increasing."
-
-            - alert: ClickHousePersonConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_person", consumergroup="group1"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: ClickHouse person ingestion lag has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group group1 for topic clickhouse_person is increasing."
-
-            - alert: ClickHouseGroupsConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_groups", consumergroup="group1"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: ClickHouse groups ingestion lag has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group group1 for topic clickhouse_groups is increasing."
-
-            - alert: ClickHousePersonDistinctIdConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_person_distinct_id", consumergroup="group1"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: ClickHouse person distinct id ingestion lag has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group group1 for topic clickhouse_person_distinct_id is increasing."
+                summary: ClickHouse ingestion lag on topic {{ $labels.topic }} has been increasing for 10 minutes straight.
+                description: "The backlog on consumer group group1 for topic {{ $labels.topic }} is increasing."
 
             - alert: EventsIngestionConsumerLagIncreasing
               expr: sum(delta(kafka_consumergroup_lag{topic="events_plugin_ingestion", consumergroup="clickhouse-ingestion"}[10m])) > 0


### PR DESCRIPTION
Adds a critical alert that checks to see it the delta in consumer lag
between now and 10 minutes ago is consistently >0 for 10 minutes
straight.

There are possibly cases where this doesn't work. I did the detla as I
didn't want to add an arbitrary message backlog value that might not
translate to all deployments of the app.

This should however catch the case were the lag is strictly
monotonically increasing.

I've also added lag alerts for:

 1. initial events ingestion
 2. clickhouse ingestion for events, persons, groups, person_distinct_id

This is in relation to https://posthog.slack.com/archives/C04F42Y4JRJ/p1670954181738359

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
