### PR TITLE
Revert "feat(alerts): add alert on exports consumer group backlog (#651)"

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.2.0
+version: 30.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.2.1
+version: 30.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1763,44 +1763,6 @@ prometheus:
       # https://github.com/samber/awesome-prometheus-alerts
       #
       groups:
-        - name: PostHog
-          rules:
-            - alert: ExportsConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="clickhouse_events_json", consumergroup="clickhouse-plugin-server-async"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: Exports and WebHooks backlog appears to have been increasing for 10 minutes straight.
-                description: "The backlog on consumer group clickhouse-plugin-server-async for topic clickhouse_events_json is increasing."
-
-            - alert: ClickHouseConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{consumergroup="group1"}[10m])) by (topic) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: ClickHouse ingestion lag on topic {{ $labels.topic }} has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group group1 for topic {{ $labels.topic }} is increasing."
-
-            - alert: EventsIngestionConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="events_plugin_ingestion", consumergroup="clickhouse-ingestion"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: Events ingestion processing lag has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group clickhouse-ingestion for topic events_plugin_ingestion is increasing."
-
-            - alert: EventsIngestionBufferConsumerLagIncreasing
-              expr: sum(delta(kafka_consumergroup_lag{topic="conversion_events_buffer", consumergroup="ingester"}[10m])) > 0
-              for: 10m
-              labels:
-                severity: critical
-              annotations:
-                summary: Events ingestion processing lag for delayed events has been increasing for 10 minutes straight.
-                description: "The backlog on consumer group ingester for topic conversion_events_buffer is increasing."
-
         - name: Kubernetes # via kube-state-metrics
           rules:
             - alert: KubernetesNodeReady


### PR DESCRIPTION
Turns out this was very noisy. I'll implement some time lag based
metrics we can alert on instead.
   
This reverts commit cd522ac3859c2baed401a0d035749c443b281bfb.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
