### PR TITLE
feat(plugin-server): enable scraping of plugin-server

### DIFF
--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -22,6 +22,9 @@ spec:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.root.Template.BasePath "/secrets.yaml") .root | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8001"
         {{- if .params.podAnnotations }}
         {{- toYaml .params.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/secrets.yaml: {{ include (print $.root.Template.BasePath "/secrets.yaml") .root | sha256sum }}
         prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
+        prometheus.io/path: /_metrics
         prometheus.io/port: "8001"
         {{- if .params.podAnnotations }}
         {{- toYaml .params.podAnnotations | nindent 8 }}


### PR DESCRIPTION
This adds annotations to the plugin server to instruct prometheus to
scrape the metrics endpoint.

The metrics I am immediately interested in are
https://github.com/PostHog/posthog/pull/13350/files for time lag on
consumers but this also adds node level metrics.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
