### PR TITLE
fix(ingress): ensure only capture and decide go to events deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.2.4
+version: 30.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -78,24 +78,54 @@ spec:
                 port:
                   number: {{ .Values.service.externalPort }}
           {{- if (ne (include "ingress.type" .) "clb") }}
+          # Match any url with a prefix ending with a forward-slash. Previously
+          # we would match without the forward-slash. To ensure that we pick up
+          # with the forward-slash omitted we also match Exact. Note tat we
+          # could use e.g. [ingress-nginx regex
+          # support](https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#regular-expression-support)
+          # but to keep this agnostic we use a combination of Prefix and Exact.
           - pathType: Prefix
+            path: "/capture/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/capture"
             backend: *INGESTION
+
           - pathType: Prefix
+            path: "/decide/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/decide"
             backend: *INGESTION
+
           - pathType: Prefix
+            path: "/e/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/e"
             backend: *INGESTION
+
           - pathType: Prefix
+            path: "/engage/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/engage"
             backend: *INGESTION
+
           - pathType: Prefix
+            path: "/track/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/track"
             backend: *INGESTION
+
           - pathType: Prefix
+            path: "/s/"
+            backend: *INGESTION
+          - pathType: Exact
             path: "/s"
             backend: *INGESTION
+
           {{- else }}
           - pathType: ImplementationSpecific
             path: "/capture/*"

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -80,10 +80,14 @@ spec:
           {{- if (ne (include "ingress.type" .) "clb") }}
           # Match any url with a prefix ending with a forward-slash. Previously
           # we would match without the forward-slash. To ensure that we pick up
-          # with the forward-slash omitted we also match Exact. Note tat we
+          # with the forward-slash omitted we also match Exact. Note that we
           # could use e.g. [ingress-nginx regex
           # support](https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#regular-expression-support)
           # but to keep this agnostic we use a combination of Prefix and Exact.
+          #
+          # NOTE: we still use a Prefix match on paths with a forward-slash,
+          # just in case there are cases that we have subpaths for these
+          # endpoints that still need to be passed to the `posthog-events` pods.
           - pathType: Prefix
             path: "/capture/"
             backend: *INGESTION

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -81,8 +81,7 @@ spec:
           # Match any url with a prefix ending with a forward-slash. Previously
           # we would match without the forward-slash. To ensure that we pick up
           # with the forward-slash omitted we also match Exact. Note that we
-          # could use e.g. [ingress-nginx regex
-          # support](https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#regular-expression-support)
+          # could use e.g. [ingress-nginx regex support](https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#regular-expression-support)
           # but to keep this agnostic we use a combination of Prefix and Exact.
           #
           # NOTE: we still use a Prefix match on paths with a forward-slash,

--- a/charts/posthog/tests/__snapshot__/ingress.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/ingress.yaml.snap
@@ -22,7 +22,21 @@ the "spec" path should match the snapshot when using default values:
               name: RELEASE-NAME-posthog-events
               port:
                 number: 8000
+          path: /capture/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
           path: /capture
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /decide/
           pathType: Prefix
         - backend:
             service:
@@ -30,6 +44,13 @@ the "spec" path should match the snapshot when using default values:
               port:
                 number: 8000
           path: /decide
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /e/
           pathType: Prefix
         - backend:
             service:
@@ -37,6 +58,13 @@ the "spec" path should match the snapshot when using default values:
               port:
                 number: 8000
           path: /e
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /engage/
           pathType: Prefix
         - backend:
             service:
@@ -44,6 +72,13 @@ the "spec" path should match the snapshot when using default values:
               port:
                 number: 8000
           path: /engage
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /track/
           pathType: Prefix
         - backend:
             service:
@@ -51,6 +86,13 @@ the "spec" path should match the snapshot when using default values:
               port:
                 number: 8000
           path: /track
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /s/
           pathType: Prefix
         - backend:
             service:
@@ -58,4 +100,4 @@ the "spec" path should match the snapshot when using default values:
               port:
                 number: 8000
           path: /s
-          pathType: Prefix
+          pathType: Exact


### PR DESCRIPTION
Previously we would match e.g. any path that started with `/e` and route
this to the `events` pods. This isn't desired as this captures e.g.
`/events/` which is a user facing UI. Likewise for the other endpoints
that were previously k8s ingress `Prefix` rules.

Note that the ingress rules only match on path i.e. before any query
string components and the `?` character.

NOTE: I believe we do _not_ have any data that is passed in the request path
so I think we are safe to do an Exact.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
