### PR TITLE
chore(bitnami): use the pre-2022 bitnami repo index.yaml

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Add helm repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
           helm repo add kubernetes https://kubernetes.github.io/ingress-nginx
           helm repo add jetstack https://charts.jetstack.io

--- a/charts/posthog/Chart.lock
+++ b/charts/posthog/Chart.lock
@@ -6,16 +6,16 @@ dependencies:
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
 - name: kafka
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 14.9.3
 - name: minio
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 11.3.5
 - name: postgresql
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 8.6.1
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 16.8.9
 - name: zookeeper
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
@@ -44,5 +44,5 @@ dependencies:
 - name: prometheus-statsd-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 0.3.1
-digest: sha256:2cfffe0d2d6df0b3c43983b18ecd517ba71ff31bab91901037b51d64dee74eb0
-generated: "2022-11-15T10:43:43.316599+01:00"
+digest: sha256:5ac223659ced28c44ff2c89963e0268427f848b5d4db98df9b8f1010f22f8207
+generated: "2022-12-20T11:35:36.888806538Z"

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -30,12 +30,12 @@ dependencies:
 
   - name: kafka
     version: 14.9.3
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: kafka.enabled
 
   - name: minio
     version: 11.3.5
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: minio.enabled
 
   - name: postgresql
@@ -45,7 +45,7 @@ dependencies:
 
   - name: redis
     version: 16.8.9
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: redis.enabled
 
   - name: zookeeper

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -255,7 +255,7 @@ def exec_subprocess(cmd, ignore_errors=False):
 def install_external_kafka(namespace=NAMESPACE):
     log.debug("🔄 Setting up external Kafka...")
     cmd = """
-          helm repo add bitnami https://charts.bitnami.com/bitnami && \
+          helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami && \
           helm upgrade --install \
             --namespace {namespace} \
             kafka bitnami/kafka \


### PR DESCRIPTION
Bitnami did a bit of a size reduction of their index.yaml for their Helm repo in the last day or so: https://github.com/bitnami/charts/pull/14024

We previously changed to using pre-2022 for other charts that fell out of the [6 month retention
policy](https://github.com/bitnami/charts/issues/10539) but not for all. Looks like a few more have now dropped on of the main index so I'm changing all to use the github hosted pre-2022 index.

We should actually update these charts at some point, but given these will likely be major upgrades I'm not doing it for now. My main aim is to get back to a point where we can release our chart, currently CI chart-releaser is failing.

The driver for this is to get [ingress changes to be more restrictive for event pods](https://github.com/PostHog/charts-clickhouse/pull/656) released but it should also 🤞 unblock others that want to release changes.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
