### PR TITLE
chore(session-recordings): separate session recordings from events

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -122,8 +122,6 @@ spec:
             path: "/track"
             backend: *INGESTION
 
-          {{- else }}
-
           - pathType: Prefix
             path: "/s/"
             backend: &SESSION_RECORDINGS
@@ -135,6 +133,8 @@ spec:
             path: "/s"
             backend: *SESSION_RECORDINGS
             backend: 
+
+          {{- else }}
 
           - pathType: ImplementationSpecific
             path: "/capture/*"
@@ -153,7 +153,11 @@ spec:
             backend: *INGESTION
           - pathType: ImplementationSpecific
             path: "/s/*"
-            backend: *INGESTION
+            backend: 
+              service:
+                name: {{ template "posthog.fullname" . }}-session-recordings
+                port:
+                  number: {{ .Values.service.externalPort }}
           {{- end }}
 {{- if .Values.ingress.tls }}
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -122,14 +122,20 @@ spec:
             path: "/track"
             backend: *INGESTION
 
+          {{- else }}
+
           - pathType: Prefix
             path: "/s/"
-            backend: *INGESTION
+            backend: &SESSION_RECORDINGS
+              service:
+                name: {{ template "posthog.fullname" . }}-session-recordings
+                port:
+                  number: {{ .Values.service.externalPort }}
           - pathType: Exact
             path: "/s"
-            backend: *INGESTION
+            backend: *SESSION_RECORDINGS
+            backend: 
 
-          {{- else }}
           - pathType: ImplementationSpecific
             path: "/capture/*"
             backend: *INGESTION

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -132,7 +132,6 @@ spec:
           - pathType: Exact
             path: "/s"
             backend: *SESSION_RECORDINGS
-            backend: 
 
           {{- else }}
 

--- a/charts/posthog/templates/session-recordings-deployment.yaml
+++ b/charts/posthog/templates/session-recordings-deployment.yaml
@@ -1,0 +1,171 @@
+{{- if .Values.sessionRecordings.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-session-recordings
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: session-recordings
+  {{- if not .Values.sessionRecordings.hpa.enabled }}
+  replicas: {{ .Values.sessionRecordings.replicacount }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.web.podAnnotations }}
+{{ toYaml .Values.web.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: session-recordings
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.web.podLabels }}
+{{ toYaml .Values.web.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.web.affinity }}
+      affinity:
+{{ toYaml .Values.web.affinity | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.tolerations }}
+      tolerations:
+{{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.schedulerName }}
+      schedulerName: "{{ .Values.web.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      # I do not know for sure if the old one has been used anywhere, so do both :(
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.sessionRecordings.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.sessionRecordings.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ .Chart.Name }}-session-recordings
+        image: {{ template "posthog.image.fullPath" . }}
+        command:
+          - ./bin/docker-server
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        # Expose the port on which Prometheus /metrics endpoint resides
+        - containerPort: 8001
+        env:
+        # Kafka env variables
+        {{- include "snippet.kafka-env" . | indent 8 }}
+
+        # Object Storage env variables
+        {{- include "snippet.objectstorage-env" . | indent 8 }}
+
+        # Redis env variables
+        {{- include "snippet.redis-env" . | indent 8 }}
+
+        # statsd env variables
+        {{- include "snippet.statsd-env" . | indent 8 }}
+
+        - name: DISABLE_SECURE_SSL_REDIRECT
+          value: '1'
+        - name: IS_BEHIND_PROXY
+          value: '1'
+      {{- if eq .Values.web.secureCookies false }}
+        - name: SECURE_COOKIES
+          value: '0'
+      {{- end }}
+        # PostHog app settings
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
+        - name: PRIMARY_DB
+          value: clickhouse
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.sessionRecordings.env }}
+{{ toYaml .Values.sessionRecordings.env | indent 8 }}
+{{- else if .Values.web.env }}
+{{ toYaml .Values.web.env | indent 8 }}
+{{- end }}
+
+        {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
+
+        livenessProbe:
+          httpGet:
+            path: /_livez
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            # For readiness, we are using the events role as this should be the
+            # same.
+            path: /_readyz?role=events
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+        startupProbe:
+          httpGet:
+            # For startup, we want to make sure that everything is in place,
+            # including postgres. This does however mean we would not be able to
+            # deploy new releases when we have a postgres outage
+            path: /_readyz
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+        resources:
+        {{ if not .Values.sessionRecordings.resources }}
+{{ toYaml .Values.web.resources | indent 12 }}
+        {{ else }}
+{{ toYaml .Values.sessionRecordings.resources | indent 12 }}
+        {{ end }}
+        {{- if .Values.sessionRecordings.securityContext.enabled }}
+        securityContext: {{- omit .Values.sessionRecordings.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+{{- end }}

--- a/charts/posthog/templates/session-recordings-deployment.yaml
+++ b/charts/posthog/templates/session-recordings-deployment.yaml
@@ -157,11 +157,7 @@ spec:
           successThreshold: {{ .Values.web.startupProbe.successThreshold }}
           timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
         resources:
-        {{ if not .Values.sessionRecordings.resources }}
-{{ toYaml .Values.web.resources | indent 12 }}
-        {{ else }}
 {{ toYaml .Values.sessionRecordings.resources | indent 12 }}
-        {{ end }}
         {{- if .Values.sessionRecordings.securityContext.enabled }}
         securityContext: {{- omit .Values.sessionRecordings.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}

--- a/charts/posthog/templates/session-recordings-hpa.yaml
+++ b/charts/posthog/templates/session-recordings-hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.sessionRecordings.enabled .Values.sessionRecordings.hpa.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-session-recordings
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-session-recordings
+  minReplicas: {{ .Values.sessionRecordings.hpa.minpods }}
+  maxReplicas: {{ .Values.sessionRecordings.hpa.maxpods }}
+  metrics:
+  {{- with .Values.sessionRecordings.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  behavior: 
+    {{ toYaml .Values.sessionRecordings.hpa.behavior | nindent 4 }}
+{{- end }}

--- a/charts/posthog/templates/session-recordings-service.yaml
+++ b/charts/posthog/templates/session-recordings-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.sessionRecordings.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "posthog.fullname" . }}-session-recordings
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+   {{- range $key, $value := .Values.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "posthog.fullname" . }}
+    role: session-recordings
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/posthog/tests/__snapshot__/ingress.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/ingress.yaml.snap
@@ -87,3 +87,17 @@ the "spec" path should match the snapshot when using default values:
                 number: 8000
           path: /track
           pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-session-recordings
+              port:
+                number: 8000
+          path: /s/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-session-recordings
+              port:
+                number: 8000
+          path: /s
+          pathType: Exact

--- a/charts/posthog/tests/__snapshot__/ingress.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/ingress.yaml.snap
@@ -87,17 +87,3 @@ the "spec" path should match the snapshot when using default values:
                 number: 8000
           path: /track
           pathType: Exact
-        - backend:
-            service:
-              name: RELEASE-NAME-posthog-events
-              port:
-                number: 8000
-          path: /s/
-          pathType: Prefix
-        - backend:
-            service:
-              name: RELEASE-NAME-posthog-events
-              port:
-                number: 8000
-          path: /s
-          pathType: Exact

--- a/charts/posthog/tests/session-recordings-deployment.yaml
+++ b/charts/posthog/tests/session-recordings-deployment.yaml
@@ -117,29 +117,6 @@ tests:
               cpu: 4000m
               memory: 16Gi
 
-  - it: for backwards compat. should use the web resources if specified
-    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
-    set:
-      cloud: local
-      web:
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 16Gi
-          requests:
-            cpu: 4000m
-            memory: 16Gi
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].resources
-          value:
-            limits:
-              cpu: 1000m
-              memory: 16Gi
-            requests:
-              cpu: 4000m
-              memory: 16Gi
-
   - it: should set resources when specified and override web resource settings
     template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:

--- a/charts/posthog/tests/session-recordings-deployment.yaml
+++ b/charts/posthog/tests/session-recordings-deployment.yaml
@@ -1,0 +1,252 @@
+suite: PostHog session-recordings deployment definition
+templates:
+  - templates/session-recordings-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if session-recordings.enabled is set to false
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sessionRecordings.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sessionRecordings.podSecurityContext.enabled: true
+      sessionRecordings.podSecurityContext.runAsUser: 1001
+      sessionRecordings.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should have a container securityContext
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sessionRecordings.securityContext.enabled: true
+      sessionRecordings.securityContext.runAsUser: 1001
+      sessionRecordings.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not have a pod securityContext
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sessionRecordings.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+
+  - it: should not have a container securityContext
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sessionRecordings.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+
+  # NOTE: historically we have had the session-recordings pod use any resources specified
+  # for web. However, we would like to separate the connection and allow them to
+  # be set independently, while maintaining backwards compat. for installs that
+  # are setting the web resources.
+  - it: should set resources when specified
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      sessionRecordings:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: for backwards compat. should use the web resources if specified
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      web:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: should set resources when specified and override web resource settings
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      sessionRecordings:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+      web:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 6Gi
+          requests:
+            cpu: 2000m
+            memory: 6Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: sets SENTRY_DSN env var
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint
+
+  - it: uses web.env if session-recordings.env is empty
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+        - name: FIRST
+          value: one
+      web:
+        env:
+          - name: SECOND
+            value: two
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FIRST
+            value: one
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SECOND
+            value: two
+
+  - it: ignores web.env if session-recordings.env is set
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+        - name: FIRST
+          value: one
+      web:
+        env:
+          - name: SECOND
+            value: two
+      sessionRecordings:
+        env:
+          - name: THIRD
+            value: three
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FIRST
+            value: one
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THIRD
+            value: three
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SECOND
+            value: two
+
+  - it: allows setting imagePullSecrets
+    template: templates/session-recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      sessionRecordings.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: secret]

--- a/charts/posthog/tests/session-recordings-hpa.yaml
+++ b/charts/posthog/tests/session-recordings-hpa.yaml
@@ -1,0 +1,81 @@
+suite: PostHog session-recordings HPA definition
+templates:
+  - templates/session-recordings-hpa.yaml
+
+tests:
+  - it: should be empty if session-recordings.enabled and session-recordings.hpa.enabled are set to false
+    set:
+      sessionRecordings.enabled: false
+      sessionRecordings.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if session-recordings.enabled is true and session-recordings.hpa.enabled is set to false
+    set:
+      sessionRecordings.enabled: true
+      sessionRecordings.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if session-recordings.enabled and session-recordings.hpa.enabled are set to true
+    set:
+      sessionRecordings.enabled: true
+      sessionRecordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      sessionRecordings.enabled: true
+      sessionRecordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v2beta2
+
+  - it: should be the correct kind
+    set:
+      sessionRecordings.enabled: true
+      sessionRecordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+
+  - it: sets hpa spec
+    set:
+      sessionRecordings.enabled: true
+      sessionRecordings:
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-session-recordings
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+              - type: Resource
+                resource:
+                  name: cpu
+                  target:
+                    type: Utilization
+                    averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/session-recordings-service.yaml
+++ b/charts/posthog/tests/session-recordings-service.yaml
@@ -1,0 +1,30 @@
+suite: PostHog session-recordings service definition
+templates:
+  - templates/session-recordings-service.yaml
+
+tests:
+  - it: should be empty if session-recordings.enabled is set to false
+    set:
+      sessionRecordings.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if session-recordings.enabled is set to true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -105,6 +105,9 @@ sessionRecordings:
     # for configuration options
     behavior:
 
+  # -- Resource limits for session recordings service.
+  resources: {}
+
   # -- Additional env variables to inject into the session recordings stack, uses `web.env` if empty.
   env: []
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -84,6 +84,37 @@ events:
   podSecurityContext:
     enabled: false
 
+sessionRecordings:
+  # -- Whether to install the PostHog events stack or not.
+  enabled: true
+
+  # -- Count of events pods to run. This setting is ignored if `events.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the events stack.
+    enabled: false
+    # -- CPU threshold percent for the events stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the events stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the events stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  # -- Additional env variables to inject into the events stack, uses `web.env` if empty.
+  env: []
+
+  # -- Container security context for the events stack HorizontalPodAutoscaler.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the events stack HorizontalPodAutoscaler.
+  podSecurityContext:
+    enabled: false
+
 web:
   # -- Whether to install the PostHog web stack or not.
   enabled: true

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -85,33 +85,33 @@ events:
     enabled: false
 
 sessionRecordings:
-  # -- Whether to install the PostHog events stack or not.
+  # -- Whether to install the PostHog session recordings stack or not.
   enabled: true
 
-  # -- Count of events pods to run. This setting is ignored if `events.hpa.enabled` is set to `true`.
+  # -- Count of session recordings pods to run. This setting is ignored if `session recordings.hpa.enabled` is set to `true`.
   replicacount: 1
 
   hpa:
-    # -- Whether to create a HorizontalPodAutoscaler for the events stack.
+    # -- Whether to create a HorizontalPodAutoscaler for the session recordings stack.
     enabled: false
-    # -- CPU threshold percent for the events stack HorizontalPodAutoscaler.
+    # -- CPU threshold percent for the session recordings stack HorizontalPodAutoscaler.
     cputhreshold: 60
-    # -- Min pods for the events stack HorizontalPodAutoscaler.
+    # -- Min pods for the session recordings stack HorizontalPodAutoscaler.
     minpods: 1
-    # -- Max pods for the events stack HorizontalPodAutoscaler.
+    # -- Max pods for the session recordings stack HorizontalPodAutoscaler.
     maxpods: 10
     # -- Set the HPA behavior. See
     # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
     # for configuration options
     behavior:
 
-  # -- Additional env variables to inject into the events stack, uses `web.env` if empty.
+  # -- Additional env variables to inject into the session recordings stack, uses `web.env` if empty.
   env: []
 
-  # -- Container security context for the events stack HorizontalPodAutoscaler.
+  # -- Container security context for the session recordings stack HorizontalPodAutoscaler.
   securityContext:
     enabled: false
-  # -- Pod security context for the events stack HorizontalPodAutoscaler.
+  # -- Pod security context for the session recordings stack HorizontalPodAutoscaler.
   podSecurityContext:
     enabled: false
 


### PR DESCRIPTION
We currently have session recordings events going to the same endpoint
as analytics events and decide endpiont. The characteristics of session
recordings is quite different, and our expectations of priority. It's
much more important that we capture events and service decide endpoints
than we capture all session recordings.

This separates the deployment to offer more flexibility in providing
different service availability.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
