### PR TITLE
add support for topologySpreadConstraints

### DIFF
--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -60,6 +60,11 @@ spec:
         {{- toYaml .params.tolerations | nindent 8 }}
       {{- end }}
 
+      {{- if .params.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .params.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+
       {{- if .params.schedulerName }}
       schedulerName: "{{ .params.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/clickhouse_instance.yaml
+++ b/charts/posthog/templates/clickhouse_instance.yaml
@@ -80,6 +80,9 @@ spec:
           {{- if .Values.clickhouse.nodeSelector }}
           nodeSelector: {{ toYaml .Values.clickhouse.nodeSelector | nindent 12 }}
           {{- end }}
+          {{- if .Values.clickhouse.topologySpreadConstraints }}
+          topologySpreadConstraints: {{ toYaml .Values.clickhouse.topologySpreadConstraints | nindent 12 }}
+          {{- end }}
 
           {{- if .Values.clickhouse.persistence.enabled }}
           volumes:

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
 
       {{- if .Values.events.topologySpreadConstraints }}
-      tolerations: {{ toYaml .Values.events.topologySpreadConstraints | nindent 8 }}
+      topologySpreadConstraints: {{ toYaml .Values.events.topologySpreadConstraints | nindent 8 }}
       {{- end }}
 
       {{- if .Values.web.schedulerName }}

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -57,6 +57,10 @@ spec:
 {{ toYaml .Values.web.tolerations | indent 8 }}
       {{- end }}
 
+      {{- if .Values.events.topologySpreadConstraints }}
+      tolerations: {{ toYaml .Values.events.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.web.schedulerName }}
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -55,6 +55,10 @@ spec:
       tolerations: {{ toYaml .Values.pgbouncer.tolerations | nindent 8 }}
       {{- end }}
 
+      {{- if .Values.pgbouncer.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.pgbouncer.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.pgbouncer.schedulerName }}
       schedulerName: "{{ .Values.pgbouncer.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
 
       {{- if .Values.web.topologySpreadConstraints }}
-      tolerations: {{ toYaml .Values.web.topologySpreadConstraints | nindent 8 }}
+      topologySpreadConstraints: {{ toYaml .Values.web.topologySpreadConstraints | nindent 8 }}
       {{- end }}
 
       {{- if .Values.web.schedulerName }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -57,6 +57,10 @@ spec:
 {{ toYaml .Values.web.tolerations | indent 8 }}
       {{- end }}
 
+      {{- if .Values.web.topologySpreadConstraints }}
+      tolerations: {{ toYaml .Values.web.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.web.schedulerName }}
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -56,6 +56,10 @@ spec:
 {{ toYaml .Values.worker.tolerations | indent 8 }}
       {{- end }}
 
+      {{- if .Values.worker.topologySpreadConstraints }}
+      tolerations: {{ toYaml .Values.worker.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.worker.schedulerName }}
       schedulerName: "{{ .Values.worker.schedulerName }}"
       {{- end }}

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
 
       {{- if .Values.worker.topologySpreadConstraints }}
-      tolerations: {{ toYaml .Values.worker.topologySpreadConstraints | nindent 8 }}
+      topologySpreadConstraints: {{ toYaml .Values.worker.topologySpreadConstraints | nindent 8 }}
       {{- end }}
 
       {{- if .Values.worker.schedulerName }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -83,6 +83,15 @@ events:
   # -- Additional env variables to inject into the events stack, uses `web.env` if empty.
   env: []
 
+  # -- TopologySpreadConstraints settings for the events stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: events
+
   # -- Container security context for the events stack HorizontalPodAutoscaler.
   securityContext:
     enabled: false
@@ -149,6 +158,16 @@ web:
   tolerations: []
   # -- Affinity settings for web stack deployment.
   affinity: {}
+
+  # -- TopologySpreadConstraints settings for the web stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: web
+
   # :TODO:
   secureCookies: true
 
@@ -236,6 +255,15 @@ worker:
   # -- Affinity settings for the worker stack deployment.
   affinity: {}
 
+  # -- TopologySpreadConstraints settings for the worker stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: worker
+
   # -- Container security context for the worker stack deployment.
   securityContext:
     enabled: false
@@ -287,6 +315,15 @@ plugins:
   tolerations: []
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
+
+  # -- TopologySpreadConstraints settings for the plugins stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins
 
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
@@ -365,6 +402,15 @@ pluginsAsync:
   tolerations: []
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
+
+  # -- TopologySpreadConstraints settings for the plugins-async stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins-async
 
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
@@ -449,6 +495,15 @@ pluginsIngestion:
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
 
+  # -- TopologySpreadConstraints settings for the plugins-ingestion stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins-ingestion
+
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
     enabled: false
@@ -525,6 +580,15 @@ pluginsExports:
   tolerations: []
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
+
+  # -- TopologySpreadConstraints settings for the plugins-exports stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins-exports
 
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
@@ -603,6 +667,15 @@ pluginsJobs:
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
 
+  # -- TopologySpreadConstraints settings for the plugins-jobs stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins-jobs
+
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
     enabled: false
@@ -678,6 +751,15 @@ pluginsScheduler:
   tolerations: []
   # -- Affinity settings for the plugin-server stack deployment.
   affinity: {}
+
+  # -- TopologySpreadConstraints settings for the plugins-scheduler stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: plugins-scheduler
 
   # -- Container security context for the plugin-server stack deployment.
   securityContext:
@@ -1035,6 +1117,15 @@ pgbouncer:
   # -- Affinity settings for the pgbouncer stack deployment.
   affinity: {}
 
+  # -- TopologySpreadConstraints settings for the pgbouncer stack deployment.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       role: pgbouncer
+
   # -- Container security context for the pgbouncer stack deployment.
   securityContext:
     enabled: false
@@ -1291,6 +1382,15 @@ clickhouse:
   # -- Affinity settings for clickhouse pod
   affinity: {}
   # -- Clickhouse resource requests/limits. See more at http://kubernetes.io/docs/user-guide/compute-resources/
+  # -- TopologySpreadConstraints settings for the clickhouse pods.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       clickhouse.altinity.com/app: chop
+
   resources: {}
   #   limits:
   #     cpu: 1000m


### PR DESCRIPTION
## Description
This PR adds support for configuring [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for the various deployments. This makes it easier to spread pods across availability zones than regular anti-affinity rules.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204767834161181