### PR TITLE
chart: add prometheus-pushgateway for celery metrics

### DIFF
--- a/charts/posthog/Chart.lock
+++ b/charts/posthog/Chart.lock
@@ -32,6 +32,9 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.10.4
+- name: prometheus-pushgateway
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 2.1.1
 - name: prometheus-kafka-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.6.0
@@ -44,5 +47,5 @@ dependencies:
 - name: prometheus-statsd-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 0.3.1
-digest: sha256:5ac223659ced28c44ff2c89963e0268427f848b5d4db98df9b8f1010f22f8207
-generated: "2022-12-20T11:35:36.888806538Z"
+digest: sha256:64a899e41608da7fc9bd0a8689b9f0005d1cfffbd83e4fb78e6f1cff1ba7d4ef
+generated: "2023-02-07T15:10:06.892265+01:00"

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.3.4
+version: 30.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -73,6 +73,11 @@ dependencies:
     version: 15.10.4
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled
+
+  - name: prometheus-pushgateway
+    version: 2.1.1
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: prometheus-pushgateway.enabled
 
   - name: prometheus-kafka-exporter
     version: 1.6.0

--- a/charts/posthog/README.md
+++ b/charts/posthog/README.md
@@ -40,7 +40,7 @@ This repo uses several types of test suite targeting different goals:
 - **integration tests**: to verify if applying the rendered Helm templates against a Kubernetes target cluster gives us the stack and PostHog installation we expect
 
 #### Lint tests
-We use `helm lint` that can be invoked via: `helm lint --strict --set “cloud=local” charts/posthog`
+We use `helm lint` that can be invoked via: `helm lint --strict --set "cloud=local" charts/posthog`
 
 #### Unit tests
 In order to run the test suite, you need to install the `helm-unittest` plugin. You can do that by running: `helm plugin install https://github.com/quintush/helm-unittest --version 0.2.8`

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2606,6 +2606,19 @@ prometheus:
                 summary: Redis rejected connections (instance {{ $labels.instance }})
                 description: "Some connections to Redis has been rejected"
 
+###
+###
+### ---- prometheus-pushgateway ----
+###
+###
+prometheus-pushgateway:
+  # -- Whether to install the `prometheus-pushgateway` or not.
+  enabled: true
+  # -- Map of annotations to add to the pods.
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9091"
 
 ###
 ###


### PR DESCRIPTION
## Description

Unlocks https://github.com/PostHog/posthog/pull/14110 by adding the [PushGateway](https://prometheus.io/docs/practices/pushing/) in our prom stack. While this service must be using sparingly, it does fit what we need
to achieve with celery metrics: jobs are scheduled on one of several pods and update one gauge about the region.

We need to only keep the latest value, and the gateway allows us to make that aggregation.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

nope

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
