### PR TITLE
chart: pass PROM_PUSHGATEWAY_ADDRESS to workers when relevant

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.3.5
+version: 30.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -102,6 +102,12 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
 
+        # prometheus pushgateway if enabled
+        {{- if index .Values "prometheus-pushgateway" "enabled" }}
+        - name: PROM_PUSHGATEWAY_ADDRESS
+          value: "posthog-prometheus-pushgateway:9091"
+        {{- end }}
+
         - name: PRIMARY_DB
           value: clickhouse
         {{- include "snippet.posthog-env" . | indent 8 }}

--- a/charts/posthog/tests/worker-deployment.yaml
+++ b/charts/posthog/tests/worker-deployment.yaml
@@ -102,6 +102,17 @@ tests:
             name: SENTRY_DSN
             value: sentry.endpoint
 
+  - it: sets PROM_PUSHGATEWAY_ADDRESS env var when available
+    template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      prometheus-pushgateway.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROM_PUSHGATEWAY_ADDRESS
+            value: "posthog-prometheus-pushgateway:9091"
 
   - it: allows setting imagePullSecrets
     template: templates/worker-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed


### PR DESCRIPTION
## Description

Sister PR to https://github.com/PostHog/charts-clickhouse/pull/676, now that the pushgateway is deployed, expose its address to the worker pods, and only them. The pushgateway should be used sparingly, that's why I'm not adding it to common env values.

This assumes that the chart user does not override the service name and port in the `prometheus-pushgateway` subchart values. Alternatively, we could just add to the common envvars in our deploy values. 

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Manually added it on dev's worker deploy, and metrics are coming in fine to grafana

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
