### PR TITLE
Separate `decide` deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.3.6
+version: 30.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: decide
+        role: events
   {{- if not .Values.decide.hpa.enabled }}
   replicas: {{ .Values.decide.replicacount }}
   {{- end }}
@@ -31,7 +31,7 @@ spec:
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: decide
+        role: events
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
@@ -140,9 +140,9 @@ spec:
           timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            # For readiness, we want to use the checks specific to the decide
+            # For readiness, we want to use the checks specific to the events
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz?role=decide
+            path: /_readyz?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           httpGet:
             # For readiness, we want to use the checks specific to the decide
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz?role=decide
+            path: /_readyz?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: events
+        role: decide
   {{- if not .Values.decide.hpa.enabled }}
   replicas: {{ .Values.decide.replicacount }}
   {{- end }}
@@ -31,7 +31,7 @@ spec:
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: events
+        role: decide
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
@@ -140,9 +140,9 @@ spec:
           timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            # For readiness, we want to use the checks specific to the events
+            # For readiness, we want to use the checks specific to the decide
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz?role=events
+            path: /_readyz?role=decide
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -1,0 +1,178 @@
+{{- if .Values.decide.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-decide
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: decide
+  {{- if not .Values.decide.hpa.enabled }}
+  replicas: {{ .Values.decide.replicacount }}
+  {{- end }}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.decide.rollout.maxSurge }}
+      maxUnavailable: {{ .Values.decide.rollout.maxUnavailable }}
+
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.web.podAnnotations }}
+{{ toYaml .Values.web.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: decide
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.web.podLabels }}
+{{ toYaml .Values.web.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.web.affinity }}
+      affinity:
+{{ toYaml .Values.web.affinity | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.tolerations }}
+      tolerations:
+{{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.schedulerName }}
+      schedulerName: "{{ .Values.web.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      # I do not know for sure if the old one has been used anywhere, so do both :(
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.decide.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.decide.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ .Chart.Name }}-decide
+        image: {{ template "posthog.image.fullPath" . }}
+        command:
+          - ./bin/docker-server
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        # Expose the port on which Prometheus /metrics endpoint resides
+        - containerPort: 8001
+        env:
+        # Kafka env variables
+        {{- include "snippet.kafka-env" . | indent 8 }}
+
+        # Object Storage env variables
+        {{- include "snippet.objectstorage-env" . | indent 8 }}
+
+        # Redis env variables
+        {{- include "snippet.redis-env" . | indent 8 }}
+
+        # statsd env variables
+        {{- include "snippet.statsd-env" . | indent 8 }}
+
+        - name: DISABLE_SECURE_SSL_REDIRECT
+          value: '1'
+        - name: IS_BEHIND_PROXY
+          value: '1'
+      {{- if eq .Values.web.secureCookies false }}
+        - name: SECURE_COOKIES
+          value: '0'
+      {{- end }}
+        # PostHog app settings
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
+        - name: PRIMARY_DB
+          value: clickhouse
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.decide.env }}
+{{ toYaml .Values.decide.env | indent 8 }}
+{{- else if .Values.web.env }}
+{{ toYaml .Values.web.env | indent 8 }}
+{{- end }}
+
+        {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
+
+        livenessProbe:
+          httpGet:
+            path: /_livez
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            # For readiness, we want to use the checks specific to the decide
+            # role, which may be a subset of all the apps dependencies
+            path: /_readyz?role=decide
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+        startupProbe:
+          httpGet:
+            # For startup, we want to make sure that everything is in place,
+            # including postgres. This does however mean we would not be able to
+            # deploy new releases when we have a postgres outage
+            path: /_readyz
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+        resources:
+        {{ if not .Values.decide.resources }}
+{{ toYaml .Values.web.resources | indent 12 }}
+        {{ else }}
+{{ toYaml .Values.decide.resources | indent 12 }}
+        {{ end }}
+        {{- if .Values.decide.securityContext.enabled }}
+        securityContext: {{- omit .Values.decide.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+{{- end }}

--- a/charts/posthog/templates/decide-hpa.yaml
+++ b/charts/posthog/templates/decide-hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.decide.enabled .Values.decide.hpa.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-decide
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-decide
+  minReplicas: {{ .Values.decide.hpa.minpods }}
+  maxReplicas: {{ .Values.decide.hpa.maxpods }}
+  metrics:
+  {{- with .Values.decide.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  behavior: 
+    {{ toYaml .Values.decide.hpa.behavior | nindent 4 }}
+{{- end }}

--- a/charts/posthog/templates/decide-service.yaml
+++ b/charts/posthog/templates/decide-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.decide.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "posthog.fullname" . }}-decide
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+   {{- range $key, $value := .Values.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "posthog.fullname" . }}
+    role: decide
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/posthog/templates/decide-service.yaml
+++ b/charts/posthog/templates/decide-service.yaml
@@ -24,7 +24,7 @@ spec:
 {{- end }}
   selector:
     app: {{ template "posthog.fullname" . }}
-    role: decide
+    role: events
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}

--- a/charts/posthog/templates/decide-service.yaml
+++ b/charts/posthog/templates/decide-service.yaml
@@ -24,7 +24,7 @@ spec:
 {{- end }}
   selector:
     app: {{ template "posthog.fullname" . }}
-    role: events
+    role: decide
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -94,7 +94,7 @@ spec:
             path: "/capture"
             backend: *INGESTION
 
-          {{- if .Values.decide.enabled}}
+          {{- if .Values.decide.ingressEnabled}}
           - pathType: Prefix
             path: "/decide/"
             backend: *INGESTION

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -94,12 +94,25 @@ spec:
             path: "/capture"
             backend: *INGESTION
 
+          {{- if .Values.decide.enabled}}
+          - pathType: Prefix
+            path: "/decide/"
+            backend: *INGESTION
+          - pathType: Exact
+            path: "/decide"
+            backend:
+              service:
+                name: {{ template "posthog.fullname" . }}-decide
+                port:
+                  number: {{ .Values.service.externalPort }}
+          {{- else }}
           - pathType: Prefix
             path: "/decide/"
             backend: *INGESTION
           - pathType: Exact
             path: "/decide"
             backend: *INGESTION
+          {{- end }}
 
           - pathType: Prefix
             path: "/e/"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -93,6 +93,7 @@ events:
 decide:
   # -- Whether to install the PostHog decide stack or not.
   enabled: false
+  ingressEnabled: false
 
   # -- Count of decide pods to run. This setting is ignored if `decide.hpa.enabled` is set to `true`.
   replicacount: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -90,6 +90,43 @@ events:
   podSecurityContext:
     enabled: false
 
+decide:
+  # -- Whether to install the PostHog decide stack or not.
+  enabled: false
+
+  # -- Count of decide pods to run. This setting is ignored if `decide.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the decide stack.
+    enabled: false
+    # -- CPU threshold percent for the decide stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the decide stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the decide stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  rollout:
+    # The max surge in pods during a rollout
+    maxSurge: 25%
+    # The max unavailable during a rollout
+    maxUnavailable: 25%
+
+  # -- Additional env variables to inject into the decide stack, uses `web.env` if empty.
+  env: []
+
+  # -- Container security context for the decide stack HorizontalPodAutoscaler.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the decide stack HorizontalPodAutoscaler.
+  podSecurityContext:
+    enabled: false
+
 web:
   # -- Whether to install the PostHog web stack or not.
   enabled: true


### PR DESCRIPTION
## Description
Add a new, optional deployment for decide endpoint. If enabled, `/decide` will get its own deployment

*Why?*

Atm it looks like decide can be adversely affected by noisy neighbours. This is not what we want! It also makes debugging much easier if we can view the traffic for this independently

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
