### PR TITLE
chart: add End2EndIngestionLag and DjangoErrorRate alerts

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.3.6
+version: 30.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1843,7 +1843,7 @@ prometheus:
                 summary: End-to-end analytics event ingestion lag exceeds 5 minutes.
                 description: |
                   Our end-to-end probe measured an ingestion lag higher than 5 minutes for scenario {{ $labels.scenario }}.
-                  Check the Kafka (cluster overview) dashboard to identify what topics and partitions are lagging and
+                  Check the "Kafka (cluster overview)" dashboard to identify what topics and partitions are lagging and
                   follow the https://posthog.com/docs/runbook/services/plugin-server/ingestion-lag runbook for recovery
                   steps.
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1819,6 +1819,21 @@ prometheus:
       groups:
         - name: PostHog
           rules:
+            - alert: DjangoErrorRate
+              expr: |
+                sum by (role) (increase(django_http_responses_total_by_status_view_method_total{status=~"^5.*"}[5m])) /
+                sum by (role) (increase(django_http_responses_total_by_status_view_method_total[5m])) > 0.02
+              for: 5m
+              labels:
+                severity: warning # TODO: move up to critical after testing for two days
+              annotations:
+                summary: Django error rate exceeds 2% on role {{ $labels.role }}
+                description: |
+                  Django reports a high error rate (5xx status codes) on role {{ $labels.role }}.
+                  Check the "Exceptions" widget in the "HTTP by application endpoint" dashboard and the pod logs to
+                  identify the issue. Either a dependency is unhealthy, or a recent code change triggered a bug and
+                  needs to be rolled-back.
+
             - alert: End2EndIngestionLag
               expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 3000
               for: 2m

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1819,6 +1819,19 @@ prometheus:
       groups:
         - name: PostHog
           rules:
+            - alert: End2EndIngestionLag
+              expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 3000
+              for: 2m
+              labels:
+                severity: warning # TODO: move up to critical after testing for two days
+              annotations:
+                summary: End-to-end analytics event ingestion lag exceeds 5 minutes.
+                description: |
+                  Our end-to-end probe measured an ingestion lag higher than 5 minutes for scenario {{ $labels.scenario }}.
+                  Check the Kafka (cluster overview) dashboard to identify what topics and partitions are lagging and
+                  follow the https://posthog.com/docs/runbook/services/plugin-server/ingestion-lag runbook for recovery
+                  steps.
+
             - alert: ExportsConsumerDelayed
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="async_handlers",topic="clickhouse_events_json"}))) > 300000
               for: 5m

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1835,7 +1835,7 @@ prometheus:
                   needs to be rolled-back.
 
             - alert: End2EndIngestionLag
-              expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 3000
+              expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 300
               for: 2m
               labels:
                 severity: warning # TODO: move up to critical after testing for two days


### PR DESCRIPTION
## Description

Part of porting our internal alerts to all regions, https://github.com/PostHog/posthog-cloud-infra/issues/1052. 

- End2EndIngestionLag mirrors `End-to-end ingestion lag exceeds norm`, with the new gauges added last week.
- DjangoErrorRate mirrors `HTTP 500 Response Exceeding avg. 500`, but with a 1% target instead of a 500 errors count. Looking back at prod-us, this would have triggered during the two django incidents we had this month, but not during smaller transient spikes.

For now, the alerts are marked as `warning` to test it, I'll pass it to `critical` and disable the old one in two days, if it does not misbehave.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
