### PR TITLE
chart: use web role for decide pool readiness

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.4.0
+version: 30.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           httpGet:
             # For readiness, we want to use the checks specific to the decide
             # role, which may be a subset of all the apps dependencies
-            path: /_readyz?role=events
+            path: /_readyz?role=web
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}


### PR DESCRIPTION
## Description

Use web role for decide pool readiness. The `events` probe currently fails due to kafka down.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
