### PR TITLE
chart: tag pageable alerts to rotation:common

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.4.2
+version: 30.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1863,6 +1863,7 @@ prometheus:
                 sum by (role) (increase(django_http_responses_total_by_status_view_method_total[5m])) > 0.02
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Django error rate exceeds 2% on role {{ $labels.role }}
@@ -1876,6 +1877,7 @@ prometheus:
               expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 300
               for: 2m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: End-to-end analytics event ingestion lag exceeds 5 minutes.
@@ -1889,6 +1891,7 @@ prometheus:
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="async_handlers",topic="clickhouse_events_json"}))) > 300000
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Exports and WebHooks have delayed by more than 5 minutes for more than 5 minutes.
@@ -1898,6 +1901,7 @@ prometheus:
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="scheduled-tasks-runner",topic="scheduled_tasks"}))) > 300000
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: RunEveryX tasks have been delayed by more than 5 minutes for more than 5 minutes.
@@ -1907,6 +1911,7 @@ prometheus:
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="jobs-inserter",topic="jobs"}))) > 300000
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Jobs scheduled via Apps jobs have been delayed by more than 5 minutes for more than 5 minutes.
@@ -1916,6 +1921,7 @@ prometheus:
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="ingestion",topic="events_plugin_ingestion"}))) > 300000
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Ingestion for analytics events has been delayed by more than 5 minutes for more than 5 minutes.
@@ -1945,6 +1951,7 @@ prometheus:
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="session-recordings",topic="session_recording_events"}))) > 300000
               for: 5m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Ingestion for session recording and web performance events has been delayed by more than 5 minutes for more than 5 minutes.
@@ -1954,6 +1961,7 @@ prometheus:
               expr: sum(delta(kafka_topic_partition_current_offset{topic="session_recording_events_dlq"}[5m])) > 0
               for: 1m
               labels:
+                rotation: common
                 severity: critical
               annotations:
                 summary: Failed to process some session recording events and have been sent to the dead letter queue for review.


### PR DESCRIPTION
## Description

Tag monitors that should go to the common on-call rotation with the `rotation:common` label. We can add more labels later on for per-team business-hours rotations.

We'll need to audit the other alerts to check whether some are eligible for the common rotation.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
