### PR TITLE
alerts: add two MSK disk alerts

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.5.0
+version: 30.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1967,6 +1967,31 @@ prometheus:
                 summary: Failed to process some session recording events and have been sent to the dead letter queue for review.
                 description: "The `session_recording_events_dlq` topic offset has increased over the past 5 minutes."
 
+            - alert: KafkaDiskCritical
+              expr: min by (instance) (aws_msk_node_filesystem_free_bytes{mountpoint="/kafka/datalogs"}) < 536870912000
+              for: 2m
+              labels:
+                severity: critical
+                rotation: common
+              annotations:
+                summary: Less than 500GB free on Kafka broker(s)
+                description: |
+                  Kafka disks are getting full and should be upscaled before we lose new events.
+                  We should upscale the disks, or (as a last-ditch option) lower the data retention
+                  to free up disk space.
+
+            - alert: KafkaDiskCapacityPlanning
+              expr: min by (instance) (aws_msk_node_filesystem_free_bytes{mountpoint="/kafka/datalogs"}) < 1036870912000
+              for: 2m
+              labels:
+                severity: warning
+                rotation: infra
+              annotations:
+                summary: Less than 1GB free on Kafka broker(s)
+                description: |
+                  Kafka disks are getting full and should be upscaled before we lose new events.
+                  If not handled, the KafkaDiskCritical will page the common rotation.
+
         - name: Kubernetes # via kube-state-metrics
           rules:
             - alert: KubernetesNodeReady


### PR DESCRIPTION
## Description

Add two alerts about MSK disk capacity:

- KafkaDiskCapacityPlanning triggering at 1TB, to be routed to a non-paging rotation for infra
- KafkaDiskCritical at 500GB, routed to common on-call paging rotation.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
