### PR TITLE
ci: ignore auto-gen ALL_VALUES.md file, rely on codespelling source

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: .git,./ci/k6/lib/*,./charts/posthog/crds/*,./charts/posthog/tests/clickhouse-operator/__snapshot__/*,./charts/posthog/templates/clickhouse-operator/*,./charts/posthog/grafana-dashboards/http-by-application-endpoint.json,./charts/posthog/grafana-dashboards/instance-overview.json,./yarn.lock,charts/posthog/ALL_VALUES.md
+          skip: .git,./ci/k6/lib/*,./charts/posthog/crds/*,./charts/posthog/tests/clickhouse-operator/__snapshot__/*,./charts/posthog/templates/clickhouse-operator/*,./charts/posthog/grafana-dashboards/http-by-application-endpoint.json,./charts/posthog/grafana-dashboards/instance-overview.json,./yarn.lock,./charts/posthog/ALL_VALUES.md

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: .git,./ci/k6/lib/*,./charts/posthog/crds/*,./charts/posthog/tests/clickhouse-operator/__snapshot__/*,./charts/posthog/templates/clickhouse-operator/*,./charts/posthog/grafana-dashboards/http-by-application-endpoint.json,./charts/posthog/grafana-dashboards/instance-overview.json,./yarn.lock
+          skip: .git,./ci/k6/lib/*,./charts/posthog/crds/*,./charts/posthog/tests/clickhouse-operator/__snapshot__/*,./charts/posthog/templates/clickhouse-operator/*,./charts/posthog/grafana-dashboards/http-by-application-endpoint.json,./charts/posthog/grafana-dashboards/instance-overview.json,./yarn.lock,charts/posthog/ALL_VALUES.md


### PR DESCRIPTION
It's probably better to just check the source. The auto generated values
docs ends up json encoding default values, which causes issues e.g. with
codespell trying to spellcheck works including the `n` from `\n` e.g.
the `nWe` in `lose new events.\nWe should`.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
