### PR TITLE
fix(alerts): make overflow alert not so sensitive

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.7.2
+version: 30.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1924,10 +1924,10 @@ prometheus:
                   delta(
                     kafka_consumergroup_lag{
                       topic='events_plugin_ingestion_overflow', consumergroup="clickhouse-ingestion-overflow"
-                    }[10m]
+                    }[2m]
                   )
                 ) > 0
-              for: 1m
+              for: 10m
               labels:
                 rotation: common
                 severity: warning


### PR DESCRIPTION
Instead of just checking 1 ten min stretch, we chech 2m diffs and we
need 10 consecutive failures of these for the warning to trigger.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
