### PR TITLE
feat(recordings): add separate deployments/hpa for ingestion

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.7.5
+version: 30.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/plugins-analytics-ingestion-deployment.yaml
+++ b/charts/posthog/templates/plugins-analytics-ingestion-deployment.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.pluginsAnalyticsIngestion.enabled }}
+{{/*
+    The ingestion deployments handle processing of analytic events e.g. captured
+    via the `/e/` and similar endpoints. Specifically, unlike the
+    `posthog-plugins-ingestion` deployment if does _not_ handle session
+    recordings events.
+
+    To allow for near real time processing of most of the events, we will divert
+    some events that break certain criteria e.g. sending 1000s of events per
+    second with the same distinct id to a separate consumer to be processed.
+    This is consumer is run by the plugins-ingestion-overflow deployment and can
+    be scaled independently.
+
+    NOTE: before the PostHog app supports the `ingestion-overflow` mode, we'll
+    end up starting two deployments that are the same, but on a subsequent
+    deploy when we have the support, we should then start using the overflow
+    functionality.
+ */}}
+{{ include "plugins-deployment" ( dict "root" . "params" .Values.pluginsAnalyticsIngestion "name" "plugins-ingestion" "mode" "analytics-ingestion" ) }}
+{{ end }}

--- a/charts/posthog/templates/recordings-ingestion-deployment.yaml
+++ b/charts/posthog/templates/recordings-ingestion-deployment.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.recordingsIngestion.enabled }}
+{{/*
+    Ingests Recordings events, transforming them ready for playback. At the time
+    of writing this is based on the `plugins-server` and the
+    `plugins-deployment` but there is no need for it to be part of plugin
+    server and could be separated in the future.
+ */}}
+{{ include "plugins-deployment" ( dict "root" . "params" .Values.recordingsIngestion "name" "recordings-ingestion" "mode" "recordings-ingestion" ) }}
+{{ end }}

--- a/charts/posthog/tests/plugins-analytics-ingestion-deployment.yaml
+++ b/charts/posthog/tests/plugins-analytics-ingestion-deployment.yaml
@@ -1,0 +1,177 @@
+suite: PostHog analytics events ingestion deployment definition
+templates:
+  - templates/plugins-analytics-ingestion-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if pluginsAnalyticsIngestion.enabled is set to false
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.podSecurityContext.enabled: true
+      pluginsAnalyticsIngestion.podSecurityContext.runAsUser: 1001
+      pluginsAnalyticsIngestion.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should have a container securityContext
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.securityContext.enabled: true
+      pluginsAnalyticsIngestion.securityContext.runAsUser: 1001
+      pluginsAnalyticsIngestion.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not have a pod securityContext
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+
+  - it: should not have a container securityContext
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: sets PLUGIN_SERVER_MODE
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PLUGIN_SERVER_MODE
+            value: analytics-ingestion
+
+  - it: sets INGESTION_OVERFLOW_ENABLED to false by default
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTION_OVERFLOW_ENABLED
+            value: "false"
+
+  - it: can set INGESTION_OVERFLOW_ENABLED to true
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion:
+        enabled: true
+        env:
+          - name: INGESTION_OVERFLOW_ENABLED
+            value: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGESTION_OVERFLOW_ENABLED
+            value: "true"
+
+  - it: sets SENTRY_DSN env var
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      sentryDSN: main.endpoint
+      pluginsAnalyticsIngestion.sentryDSN: pluginsAnalyticsIngestion.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: pluginsAnalyticsIngestion.endpoint
+
+  - it: sets SENTRY_DSN env var with default
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pluginsAnalyticsIngestion.enabled: true
+      sentryDSN: main.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: main.endpoint
+
+  - it: allows setting imagePullSecrets
+    template: templates/plugins-analytics-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      pluginsAnalyticsIngestion.enabled: true
+      image.pullSecrets: [secret]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: secret]

--- a/charts/posthog/tests/plugins-analytics-ingestion-hpa.yaml
+++ b/charts/posthog/tests/plugins-analytics-ingestion-hpa.yaml
@@ -1,0 +1,103 @@
+suite: PostHog plugins ingestion HPA definition
+templates:
+  - templates/plugins-analytics-ingestion-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if pluginsAnalyticsIngestion.enabled and pluginsAnalyticsIngestion.hpa.enabled are set to false
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: false
+      pluginsAnalyticsIngestion.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if pluginsAnalyticsIngestion.enabled is true and pluginsAnalyticsIngestion.hpa.enabled is set to false
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should be not empty if pluginsAnalyticsIngestion.enabled and pluginsAnalyticsIngestion.hpa.enabled are set to true
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should have the correct apiVersion
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isAPIVersion:
+          of: autoscaling/v2beta2
+        documentIndex: 1
+
+  - it: should be the correct kind
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: HorizontalPodAutoscaler
+        documentIndex: 1
+
+  - it: sets hpa spec
+    templates:
+      - templates/plugins-analytics-ingestion-deployment.yaml
+    set:
+      cloud: private
+      pluginsAnalyticsIngestion.enabled: true
+      pluginsAnalyticsIngestion:
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-plugins-ingestion
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600
+        documentIndex: 1

--- a/charts/posthog/tests/recordings-ingestion-deployment.yaml
+++ b/charts/posthog/tests/recordings-ingestion-deployment.yaml
@@ -1,0 +1,149 @@
+suite: PostHog recordings ingestion deployment definition
+templates:
+  - templates/recordings-ingestion-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if recordingsIngestion.enabled is set to false
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      recordingsIngestion.podSecurityContext.enabled: true
+      recordingsIngestion.podSecurityContext.runAsUser: 1001
+      recordingsIngestion.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should have a container securityContext
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      recordingsIngestion.securityContext.enabled: true
+      recordingsIngestion.securityContext.runAsUser: 1001
+      recordingsIngestion.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not have a pod securityContext
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      recordingsIngestion.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+
+  - it: should not have a container securityContext
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      recordingsIngestion.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: sets PLUGIN_SERVER_MODE
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PLUGIN_SERVER_MODE
+            value: recordings-ingestion
+
+  - it: sets SENTRY_DSN env var
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      sentryDSN: main.endpoint
+      recordingsIngestion.sentryDSN: recordingsIngestion.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: recordingsIngestion.endpoint
+
+  - it: sets SENTRY_DSN env var with default
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsIngestion.enabled: true
+      sentryDSN: main.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: main.endpoint
+
+  - it: allows setting imagePullSecrets
+    template: templates/recordings-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      recordingsIngestion.enabled: true
+      image.pullSecrets: [secret]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: secret]

--- a/charts/posthog/tests/recordings-ingestion-hpa.yaml
+++ b/charts/posthog/tests/recordings-ingestion-hpa.yaml
@@ -1,0 +1,103 @@
+suite: PostHog recordings ingestion HPA definition
+templates:
+  - templates/recordings-ingestion-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if recordingsIngestion.enabled and recordingsIngestion.hpa.enabled are set to false
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: false
+      recordingsIngestion.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if recordingsIngestion.enabled is true and recordingsIngestion.hpa.enabled is set to false
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: true
+      recordingsIngestion.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should be not empty if recordingsIngestion.enabled and recordingsIngestion.hpa.enabled are set to true
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: true
+      recordingsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should have the correct apiVersion
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: true
+      recordingsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isAPIVersion:
+          of: autoscaling/v2beta2
+        documentIndex: 1
+
+  - it: should be the correct kind
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: true
+      recordingsIngestion.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: HorizontalPodAutoscaler
+        documentIndex: 1
+
+  - it: sets hpa spec
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      recordingsIngestion.enabled: true
+      recordingsIngestion:
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-recordings-ingestion
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600
+        documentIndex: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -530,6 +530,100 @@ pluginsIngestion:
   sentryDSN:
 
 
+pluginsAnalyticsIngestion:
+  # -- Whether to install the PostHog plugin-server analytics ingestion
+  # capability as an individual workload. Note that this is different from the
+  # `pluginsIngestion` setting above specifically in that the deployment
+  # controlled by these settings does not handle session recordings. This
+  # deployment is intended to be a replacement for `pluginsIngestion` and is
+  # intended to be used along side the `recordingsIngestion` deployment.
+  #
+  # The reason these values were added is to be able to scale analytics and
+  # session recordings events indepentently, and to be able to roll this out in
+  # a backwards compatible way.
+  enabled: false
+
+  # -- Count of plugin-server pods to run. This setting is ignored if
+  # `pluginsAnalyticsIngestion.hpa.enabled` is set to `true`. 
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the plugin stack.
+    enabled: false
+    # -- CPU threshold percent for the plugin-server stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the plugin-server stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the plugin-server stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  rollout:
+    # The max surge in pods during a rollout
+    maxSurge: 25%
+    # The max unavailable during a rollout
+    maxUnavailable: 25%
+
+  # -- Additional env variables to inject into the plugin-server stack deployment.
+  env:
+    - name: INGESTION_OVERFLOW_ENABLED
+      # -- Whether or not to send events to a "slow-lane" to be consumed
+      # separately by the pluginsIngestionOverflow deployment. When setting this
+      # to true, you must set pluginsIngestionOverflow.enabled to `true``
+      # otherwise some events will not be processed in cases of overflow. This
+      # behaviour is triggered for instance if there are too many events to be
+      # processed in near real time from a single device.
+      value: "false"
+
+  # -- Resource limits for the plugin-server stack deployment.
+  resources:
+    {}
+
+  # -- Node labels for the plugin-server stack deployment.
+  nodeSelector: {}
+  # -- Toleration labels for the plugin-server stack deployment.
+  tolerations: []
+  # -- Affinity settings for the plugin-server stack deployment.
+  affinity: {}
+
+  # -- Container security context for the plugin-server stack deployment.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the plugin-server stack deployment.
+  podSecurityContext:
+    enabled: false
+
+  livenessProbe:
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 10
+    # -- The liveness probe period seconds
+    periodSeconds: 10
+    # -- The liveness probe success threshold
+    successThreshold: 1
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 2
+
+  readinessProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 3
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 50
+    # -- The readiness probe period seconds
+    periodSeconds: 30
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 5
+
+  # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
+  sentryDSN:
+
+
 pluginsIngestionOverflow:
   # -- Whether to install the PostHog plugin-server ingestion overflow
   # capability as an individual workload.
@@ -552,6 +646,83 @@ pluginsIngestionOverflow:
     # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
     # for configuration options
     behavior:
+
+  # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
+  sentryDSN:
+
+
+recordingsIngestion:
+  # -- Whether to install the PostHog session recordings ingestion capability as
+  # an individual workload.
+  enabled: false
+
+  # -- Count of plugin-server pods to run. This setting is ignored if `recordingsIngestion.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the plugin stack.
+    enabled: false
+    # -- CPU threshold percent for the plugin-server stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the plugin-server stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the plugin-server stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  rollout:
+    # The max surge in pods during a rollout
+    maxSurge: 25%
+    # The max unavailable during a rollout
+    maxUnavailable: 25%
+
+  # -- Additional env variables to inject into the plugin-server stack deployment.
+  env: []
+
+  # -- Resource limits for the plugin-server stack deployment.
+  resources:
+    {}
+
+  # -- Node labels for the plugin-server stack deployment.
+  nodeSelector: {}
+  # -- Toleration labels for the plugin-server stack deployment.
+  tolerations: []
+  # -- Affinity settings for the plugin-server stack deployment.
+  affinity: {}
+
+  # -- Container security context for the plugin-server stack deployment.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the plugin-server stack deployment.
+  podSecurityContext:
+    enabled: false
+
+  livenessProbe:
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 10
+    # -- The liveness probe period seconds
+    periodSeconds: 10
+    # -- The liveness probe success threshold
+    successThreshold: 1
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 2
+
+  readinessProbe:
+    # -- The readiness probe failure threshold
+    failureThreshold: 3
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 50
+    # -- The readiness probe period seconds
+    periodSeconds: 30
+    # -- The readiness probe success threshold
+    successThreshold: 1
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 5
 
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:


### PR DESCRIPTION
This should allow us to scale session recordings separately from
analytics events ingestion. It is backwards compatible with the existing
deployments setup which doesn't change. Rather we can update chart
values to set:

 1. pluginsIngestion.enabled = false
 2. pluginsAnalyticsIngestion.enabled = true
 3. recordingsIngestion.enabled = true

Which will switch to separate deployments.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
