### PR TITLE
chart: relax startupProbe for events deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.8.2
+version: 30.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -152,10 +152,10 @@ spec:
           timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         startupProbe:
           httpGet:
-            # For startup, we want to make sure that everything is in place,
-            # including postgres. This does however mean we would not be able to
-            # deploy new releases when we have a postgres outage
-            path: /_readyz
+            # Now that capture's only external dependency is Kafka, let's use the
+            # reduced readiness check as its startupProbe. This means that we can
+            # deploy new configs / versions even when Postgres and Redis are down.
+            path: /_readyz?role=events
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
           failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}


### PR DESCRIPTION
## Description

With lightweight capture enabled, the capture endpoints do not rely on any external dependency but Kafka.

Let's make sure we are able to deploy config / code changes during a Redis / Postgres outage, by relaxing the startupProbe for this one deployment.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
