### PR TITLE
chart: add GraphileJobExecutionLag alert

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.10.0
+version: 30.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2221,6 +2221,20 @@ prometheus:
                 summary: Failed to process some session recording events and have been sent to the dead letter queue for review.
                 description: "The `session_recording_events_dlq` topic offset has increased over the past 5 minutes."
 
+            - alert: GraphileJobExecutionLag
+              expr: (max by(task_identifier) (posthog_celery_graphile_lag_seconds{task_identifier!="bufferJob"})) > 300
+              for: 5m
+              labels:
+                rotation: common
+                severity: warning # TODO: graduate to critical after 48h
+              annotations:
+                summary: Graphile jobs execution lag exceeds 5 minutes for more than 5 minutes.
+                description: |
+                  Jobs of type {{ $labels.task_identifier }} have been sitting in the Graphile execution queue for more
+                  than 5 minutes, possibly delaying apps and/or exports.
+                  Check https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
+                  for more context and steps to recovery.
+
             - alert: KafkaDiskCritical
               expr: min by (instance) (aws_msk_node_filesystem_free_bytes{mountpoint="/kafka/datalogs"}) < 536870912000
               for: 2m

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2169,7 +2169,10 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Jobs scheduled via Apps jobs have been delayed by more than 5 minutes for more than 5 minutes.
-                description: "Latest timestamp registered as processed on topic 'jobs', consumer group 'jobs-inserter' more then 5 minutes old"
+                description: |
+                  Latest timestamp registered as processed on topic 'jobs', consumer group 'jobs-inserter' more then 5 minutes old.
+                  Check https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
+                  for more context and steps to recovery.
 
             - alert: IngestionConsumerDelayed
               expr: (time() * 1000 - (max(latest_processed_timestamp_ms{groupId="ingestion",topic="events_plugin_ingestion"}))) > 300000

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2169,6 +2169,7 @@ prometheus:
                 severity: critical
               annotations:
                 summary: Jobs scheduled via Apps jobs have been delayed by more than 5 minutes for more than 5 minutes.
+                runbook_url: https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
                 description: |
                   Latest timestamp registered as processed on topic 'jobs', consumer group 'jobs-inserter' more then 5 minutes old.
                   Check https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
@@ -2232,6 +2233,7 @@ prometheus:
                 severity: warning # TODO: graduate to critical after 48h
               annotations:
                 summary: Graphile jobs execution lag exceeds 5 minutes for more than 5 minutes.
+                runbook_url: https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
                 description: |
                   Jobs of type {{ $labels.task_identifier }} have been sitting in the Graphile execution queue for more
                   than 5 minutes, possibly delaying apps and/or exports.


### PR DESCRIPTION
## Description

Add a (non-paging for now) monitor on the new `posthog_celery_graphile_lag_seconds` metric.

It links to the runbook draft introduced in https://github.com/PostHog/product-internal/pull/453

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
