### PR TITLE
alerts: raise GraphileJobExecutionLag to 10+5min and make paging

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.10.2
+version: 30.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2226,13 +2226,13 @@ prometheus:
                 description: "The `session_recording_events_dlq` topic offset has increased over the past 5 minutes."
 
             - alert: GraphileJobExecutionLag
-              expr: (max by(task_identifier) (posthog_celery_graphile_lag_seconds{task_identifier!="bufferJob"})) > 300
+              expr: (max by(task_identifier) (posthog_celery_graphile_lag_seconds{task_identifier!="bufferJob"})) > 600
               for: 5m
               labels:
                 rotation: common
-                severity: warning # TODO: graduate to critical after 48h
+                severity: critical
               annotations:
-                summary: Graphile jobs execution lag exceeds 5 minutes for more than 5 minutes.
+                summary: Graphile jobs execution lag exceeds 10 minutes for more than 5 minutes.
                 runbook_url: https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
                 description: |
                   Jobs of type {{ $labels.task_identifier }} have been sitting in the Graphile execution queue for more


### PR DESCRIPTION
## Description

Set the new GraphileJobExecutionLag alert to page the common on-call rotation. Unfortunately, execution latency on prod-us does spike up to 10 minutes during afternoon rollouts, so I'm raising the alert trigger to "10+ minutes during 5 minutes" (effectively 15 minutes after a catastrophic p-s-jobs failure). It's higher than I'd love it, but the way forward here is working on plugin-server's startup speed (proposed Q2 goal), not creating false-positives with unreasonable paging targets. 

![image](https://user-images.githubusercontent.com/6241083/225277358-a1fc0f35-2d4a-43e1-826d-57d03195f11a.png)


Check values in grafana: [prod-us](http://grafana-prod-us/explore?left=%7B%22datasource%22:%22PBFA97CFB590B2093%22,%22queries%22:%5B%7B%22datasource%22:%22Prometheus%22,%22expr%22:%22%28max%20by%28task_identifier%29%20%28posthog_celery_graphile_lag_seconds%7Btask_identifier%21%3D%5C%22bufferJob%5C%22%7D%29%29%22,%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%221678712636688%22,%22to%22:%221678874708310%22%7D%7D&orgId=1) - [prod-eu](http://grafana-prod-eu/explore?left=%7B%22datasource%22:%22PBFA97CFB590B2093%22,%22queries%22:%5B%7B%22datasource%22:%22Prometheus%22,%22expr%22:%22%28max%20by%28task_identifier%29%20%28posthog_celery_graphile_lag_seconds%7Btask_identifier%21%3D%5C%22bufferJob%5C%22%7D%29%29%22,%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%221678712636688%22,%22to%22:%221678874708310%22%7D%7D&orgId=1)

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
