### PR TITLE
Decide deployment services check

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-decide-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-decide-wait-for-service-dependencies.tpl
@@ -1,0 +1,44 @@
+{{/* Common initContainers-decide-wait-for-service-dependencies definition */}}
+{{- define "_snippet-initContainers-decide-wait-for-service-dependencies" }}
+- name: decide-wait-for-service-dependencies
+  image: {{ .Values.busybox.image }}
+  imagePullPolicy: {{ .Values.busybox.pullPolicy }}
+  env:
+    {{- include "snippet.clickhouse-env" . | nindent 4 }}
+  command:
+    - /bin/sh
+    - -c
+    - >
+        {{ if .Values.clickhouse.enabled }}
+        until (
+            NODES_COUNT=$(wget -qO- \
+                "http://$CLICKHOUSE_USER:$CLICKHOUSE_PASSWORD@{{ include "posthog.clickhouse.fullname" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local:8123" \
+                --post-data "SELECT count() FROM clusterAllReplicas('{{ .Values.clickhouse.cluster }}', system, one)"
+            )
+            test ! -z $NODES_COUNT && test $NODES_COUNT -eq {{ mul .Values.clickhouse.layout.shardsCount .Values.clickhouse.layout.replicasCount }}
+        );
+        do
+            echo "waiting for all ClickHouse nodes to be available"; sleep 1;
+        done
+        {{ end }}
+
+        {{ if .Values.redis.enabled }}
+        until (nc -vz "{{ include "posthog.redis.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.redis.port" . }});
+        do
+            echo "waiting for Redis"; sleep 1;
+        done
+        {{ end }}
+
+        {{ if .Values.kafka.enabled }}
+
+        KAFKA_BROKERS="{{ include "posthog.kafka.brokers" . }}"
+
+        KAFKA_HOST=$(echo $KAFKA_BROKERS | cut -f1 -d:)
+        KAFKA_PORT=$(echo $KAFKA_BROKERS | cut -f2 -d:)
+
+        until (nc -vz "$KAFKA_HOST.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" $KAFKA_PORT);
+        do
+            echo "waiting for Kafka"; sleep 1;
+        done
+        {{ end }}
+{{- end }}

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -170,6 +170,5 @@ spec:
         securityContext: {{- omit .Values.decide.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
       initContainers:
-      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
-      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+      {{- include "_snippet-initContainers-decide-wait-for-service-dependencies" . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
**Initial draft changes so discussion can be done here

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
based on https://posthog.slack.com/archives/C05034MPYA0/p1679596107221869, the decide pods still rely postgres because of the startup checks. This means that if postgres is down, decide pods will be down and error out regardless of caching

## Discussion points
- Possibly, split up wait checks (postgres // rest of the services) so there's not repeated check scripts for each deployment
- If possible, I think the decide deployment should wait briefly for postgres and migrations and timeout after X amount of time. Not sure the exact mechanics here but we don't want decide deployment to _never_ connect to postgres/pgbouncer. 
- Main point is that postgres isn't _mission critical_ for decide deployment to operate as it can use a populated redis cache so we should not have the deployment be blocked by postgres being up
