### PR TITLE
Add pgbouncer read deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.11.1
+version: 30.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/pgbouncer-read-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-read-deployment.yaml
@@ -1,0 +1,207 @@
+{{- if .Values.pgbouncer_read.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-pgbouncer-read
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "posthog.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: pgbouncer
+  {{- if not .Values.pgbouncer_read.hpa.enabled }}
+  replicas: {{ .Values.pgbouncer_read.replicacount }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.pgbouncer_read.podAnnotations }}
+        {{ toYaml .Values.pgbouncer_read.podAnnotations | nindent 8 }}
+        {{- end }}
+
+        {{ if .Values.pgbouncer_read.exporter.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "{{ .Values.pgbouncer_read.exporter.port }}"
+        {{- end }}
+
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: pgbouncer
+        {{- if .Values.pgbouncer_read.podLabels }}
+        {{ toYaml .Values.pgbouncer_read.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      # Time to wait before hard killing the container. Note: if the container
+      # shuts down and exits before the terminationGracePeriod is done, we
+      # moves to the next step immediately.
+      terminationGracePeriodSeconds: 65
+
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.pgbouncer_read.affinity }}
+      affinity: {{ toYaml .Values.pgbouncer_read.affinity | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.pgbouncer_read.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.pgbouncer_read.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.pgbouncer_read.tolerations }}
+      tolerations: {{ toYaml .Values.pgbouncer_read.tolerations | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.pgbouncer_read.schedulerName }}
+      schedulerName: "{{ .Values.pgbouncer_read.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.pgbouncer_read.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.pgbouncer_read.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      {{- if or .Values.pgbouncer_read.image.pullSecrets .Values.pgbouncer_read.exporter.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if .Values.pgbouncer_read.image.pullSecrets }}
+        {{- range .Values.pgbouncer_read.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.pgbouncer_read.exporter.image.pullSecrets }}
+        {{- range .Values.pgbouncer_read.exporter.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+
+      containers:
+
+      - name: {{ .Chart.Name }}-pgbouncer-read
+        image: "{{ .Values.pgbouncer_read.image.repository }}:{{ .Values.pgbouncer_read.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncer_read.image.pullPolicy }}
+        ports:
+        - name: pgbouncer
+          containerPort: 6543
+        env:
+        - name: POSTGRESQL_USERNAME
+          value: {{ include "posthog.postgresql.username" . }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "posthog.postgresql.secretName" . }}
+              key: {{ include "posthog.postgresql.secretPasswordKey" . }}
+        - name: POSTGRESQL_DATABASE
+          value: {{ include "posthog.postgresql.database" . }}
+        - name: POSTGRESQL_HOST
+          value: {{ include "posthog.postgresql.host" . }}
+        - name: POSTGRESQL_PORT
+          value: {{ include "posthog.postgresql.port" . | quote }}
+
+        - name: PGBOUNCER_DATABASE
+          value: {{ include "posthog.postgresql.database" . }}
+
+        {{- if .Values.pgbouncer_read.env }}
+        {{ toYaml .Values.pgbouncer_read.env | nindent 8 }}
+        {{- end }}
+
+        readinessProbe:
+          tcpSocket:
+            port: 6543
+          failureThreshold: {{ .Values.pgbouncer_read.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncer_read.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncer_read.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncer_read.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncer_read.readinessProbe.timeoutSeconds }}
+
+        livenessProbe:
+          tcpSocket:
+            port: 6543
+          failureThreshold: {{ .Values.pgbouncer_read.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncer_read.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncer_read.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncer_read.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncer_read.livenessProbe.timeoutSeconds }}
+
+        lifecycle:
+          preStop:
+            exec:
+              command: [
+                "sh", "-c",
+                #
+                # Introduce a delay to the shutdown sequence to wait for the
+                # pod eviction event to propagate into the cluster.
+                #
+                # See: https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304
+                #
+                #
+                # Then, gracefully shutdown pgbouncer by sending a SIGINT
+                # to the process (see https://www.pgbouncer.org/usage.html)
+                # and sleep again for max query timeout + 1s.
+                #
+                # Note: once the connections are all drained, the process will
+                # exit before the 'sleep 31' completes and the pod will be
+                # removed. Unfortunately we will also get an ugly 'FailedPreStopHook'
+                # warning in the k8s event logs but I'm not sure how we can avoid it.
+                #
+                "sleep 30 && kill -INT 1 && sleep 31"
+              ]
+
+        {{- if .Values.pgbouncer_read.extraVolumeMounts }}
+        volumeMounts: {{- toYaml .Values.pgbouncer_read.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+
+        {{- if .Values.pgbouncer_read.resources }}
+        resources: {{ toYaml .Values.pgbouncer_read.resources | nindent 10 }}
+        {{- end }}
+
+        {{- if .Values.pgbouncer_read.securityContext.enabled }}
+        securityContext: {{- omit .Values.pgbouncer_read.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+
+      {{- if .Values.pgbouncer_read.extraVolumes }}
+      volumes: {{- toYaml .Values.pgbouncer_read.extraVolumes | nindent 6 }}
+      {{- end }}
+
+      {{ if .Values.pgbouncer_read.exporter.enabled }}
+      - name: metrics
+        image: "{{ .Values.pgbouncer_read.exporter.image.repository }}:{{ .Values.pgbouncer_read.exporter.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncer_read.exporter.image.pullPolicy }}
+        env:
+        - name: POSTGRESQL_USERNAME
+          value: {{ include "posthog.postgresql.username" . }}
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "posthog.postgresql.secretName" . }}
+              key: {{ include "posthog.postgresql.secretPasswordKey" . }}
+        command:
+          - /bin/sh
+          - -c
+          - >
+              until (nc -vz 127.0.0.1 6543);
+              do
+                echo "waiting for PgBouncer"; sleep 1;
+              done
+
+              pgbouncer_exporter \
+                --web.listen-address=":{{ .Values.pgbouncer_read.exporter.port }}" \
+                --web.telemetry-path="/metrics" \
+                --log.level="info" \
+                --log.format="json" \
+                --pgBouncer.connectionString="postgres://$POSTGRESQL_USERNAME:$POSTGRESQL_PASSWORD@127.0.0.1:6543/pgbouncer?sslmode=disable&connect_timeout=10"
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.pgbouncer_read.exporter.port }}
+
+        {{- if .Values.pgbouncer_read.exporter.resources }}
+        resources: {{ toYaml .Values.pgbouncer_read.exporter.resources | nindent 10 }}
+        {{- end }}
+
+        {{- if .Values.pgbouncer_read.exporter.securityContext.enabled }}
+        securityContext: {{- omit .Values.pgbouncer_read.exporter.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+      {{- end -}}
+{{- end }}

--- a/charts/posthog/templates/pgbouncer-read-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-read-deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: POSTGRESQL_DATABASE
           value: {{ include "posthog.postgresql.database" . }}
         - name: POSTGRESQL_HOST
-          value: {{ include "posthog.postgresql.host" . }}
+          value: {{ .Values.pgbouncerRead.host }}
         - name: POSTGRESQL_PORT
           value: {{ include "posthog.postgresql.port" . | quote }}
 

--- a/charts/posthog/templates/pgbouncer-read-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-read-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pgbouncer_read.enabled -}}
+{{- if .Values.pgbouncerRead.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,29 +11,29 @@ spec:
       app: {{ template "posthog.fullname" . }}
       release: "{{ .Release.Name }}"
       role: pgbouncer
-  {{- if not .Values.pgbouncer_read.hpa.enabled }}
-  replicas: {{ .Values.pgbouncer_read.replicacount }}
+  {{- if not .Values.pgbouncerRead.hpa.enabled }}
+  replicas: {{ .Values.pgbouncerRead.replicacount }}
   {{- end }}
   template:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- if .Values.pgbouncer_read.podAnnotations }}
-        {{ toYaml .Values.pgbouncer_read.podAnnotations | nindent 8 }}
+        {{- if .Values.pgbouncerRead.podAnnotations }}
+        {{ toYaml .Values.pgbouncerRead.podAnnotations | nindent 8 }}
         {{- end }}
 
-        {{ if .Values.pgbouncer_read.exporter.enabled }}
+        {{ if .Values.pgbouncerRead.exporter.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics
-        prometheus.io/port: "{{ .Values.pgbouncer_read.exporter.port }}"
+        prometheus.io/port: "{{ .Values.pgbouncerRead.exporter.port }}"
         {{- end }}
 
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
         role: pgbouncer
-        {{- if .Values.pgbouncer_read.podLabels }}
-        {{ toYaml .Values.pgbouncer_read.podLabels | nindent 8 }}
+        {{- if .Values.pgbouncerRead.podLabels }}
+        {{ toYaml .Values.pgbouncerRead.podLabels | nindent 8 }}
         {{- end }}
     spec:
       # Time to wait before hard killing the container. Note: if the container
@@ -43,35 +43,35 @@ spec:
 
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
 
-      {{- if .Values.pgbouncer_read.affinity }}
-      affinity: {{ toYaml .Values.pgbouncer_read.affinity | nindent 8 }}
+      {{- if .Values.pgbouncerRead.affinity }}
+      affinity: {{ toYaml .Values.pgbouncerRead.affinity | nindent 8 }}
       {{- end }}
 
-      {{- if .Values.pgbouncer_read.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.pgbouncer_read.nodeSelector | nindent 8 }}
+      {{- if .Values.pgbouncerRead.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.pgbouncerRead.nodeSelector | nindent 8 }}
       {{- end }}
 
-      {{- if .Values.pgbouncer_read.tolerations }}
-      tolerations: {{ toYaml .Values.pgbouncer_read.tolerations | nindent 8 }}
+      {{- if .Values.pgbouncerRead.tolerations }}
+      tolerations: {{ toYaml .Values.pgbouncerRead.tolerations | nindent 8 }}
       {{- end }}
 
-      {{- if .Values.pgbouncer_read.schedulerName }}
-      schedulerName: "{{ .Values.pgbouncer_read.schedulerName }}"
+      {{- if .Values.pgbouncerRead.schedulerName }}
+      schedulerName: "{{ .Values.pgbouncerRead.schedulerName }}"
       {{- end }}
 
-      {{- if .Values.pgbouncer_read.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.pgbouncer_read.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.pgbouncerRead.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.pgbouncerRead.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
 
-      {{- if or .Values.pgbouncer_read.image.pullSecrets .Values.pgbouncer_read.exporter.image.pullSecrets }}
+      {{- if or .Values.pgbouncerRead.image.pullSecrets .Values.pgbouncerRead.exporter.image.pullSecrets }}
       imagePullSecrets:
-        {{- if .Values.pgbouncer_read.image.pullSecrets }}
-        {{- range .Values.pgbouncer_read.image.pullSecrets }}
+        {{- if .Values.pgbouncerRead.image.pullSecrets }}
+        {{- range .Values.pgbouncerRead.image.pullSecrets }}
         - name: {{ . }}
         {{- end }}
         {{- end }}
-        {{- if .Values.pgbouncer_read.exporter.image.pullSecrets }}
-        {{- range .Values.pgbouncer_read.exporter.image.pullSecrets }}
+        {{- if .Values.pgbouncerRead.exporter.image.pullSecrets }}
+        {{- range .Values.pgbouncerRead.exporter.image.pullSecrets }}
         - name: {{ . }}
         {{- end }}
         {{- end }}
@@ -80,8 +80,8 @@ spec:
       containers:
 
       - name: {{ .Chart.Name }}-pgbouncer-read
-        image: "{{ .Values.pgbouncer_read.image.repository }}:{{ .Values.pgbouncer_read.image.tag }}"
-        imagePullPolicy: {{ .Values.pgbouncer_read.image.pullPolicy }}
+        image: "{{ .Values.pgbouncerRead.image.repository }}:{{ .Values.pgbouncerRead.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncerRead.image.pullPolicy }}
         ports:
         - name: pgbouncer
           containerPort: 6543
@@ -103,27 +103,27 @@ spec:
         - name: PGBOUNCER_DATABASE
           value: {{ include "posthog.postgresql.database" . }}
 
-        {{- if .Values.pgbouncer_read.env }}
-        {{ toYaml .Values.pgbouncer_read.env | nindent 8 }}
+        {{- if .Values.pgbouncerRead.env }}
+        {{ toYaml .Values.pgbouncerRead.env | nindent 8 }}
         {{- end }}
 
         readinessProbe:
           tcpSocket:
             port: 6543
-          failureThreshold: {{ .Values.pgbouncer_read.readinessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.pgbouncer_read.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.pgbouncer_read.readinessProbe.periodSeconds }}
-          successThreshold: {{ .Values.pgbouncer_read.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.pgbouncer_read.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.pgbouncerRead.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncerRead.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncerRead.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncerRead.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncerRead.readinessProbe.timeoutSeconds }}
 
         livenessProbe:
           tcpSocket:
             port: 6543
-          failureThreshold: {{ .Values.pgbouncer_read.livenessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.pgbouncer_read.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.pgbouncer_read.livenessProbe.periodSeconds }}
-          successThreshold: {{ .Values.pgbouncer_read.livenessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.pgbouncer_read.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.pgbouncerRead.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.pgbouncerRead.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.pgbouncerRead.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.pgbouncerRead.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.pgbouncerRead.livenessProbe.timeoutSeconds }}
 
         lifecycle:
           preStop:
@@ -149,26 +149,26 @@ spec:
                 "sleep 30 && kill -INT 1 && sleep 31"
               ]
 
-        {{- if .Values.pgbouncer_read.extraVolumeMounts }}
-        volumeMounts: {{- toYaml .Values.pgbouncer_read.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.pgbouncerRead.extraVolumeMounts }}
+        volumeMounts: {{- toYaml .Values.pgbouncerRead.extraVolumeMounts | nindent 8 }}
         {{- end }}
 
-        {{- if .Values.pgbouncer_read.resources }}
-        resources: {{ toYaml .Values.pgbouncer_read.resources | nindent 10 }}
+        {{- if .Values.pgbouncerRead.resources }}
+        resources: {{ toYaml .Values.pgbouncerRead.resources | nindent 10 }}
         {{- end }}
 
-        {{- if .Values.pgbouncer_read.securityContext.enabled }}
-        securityContext: {{- omit .Values.pgbouncer_read.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- if .Values.pgbouncerRead.securityContext.enabled }}
+        securityContext: {{- omit .Values.pgbouncerRead.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
 
-      {{- if .Values.pgbouncer_read.extraVolumes }}
-      volumes: {{- toYaml .Values.pgbouncer_read.extraVolumes | nindent 6 }}
+      {{- if .Values.pgbouncerRead.extraVolumes }}
+      volumes: {{- toYaml .Values.pgbouncerRead.extraVolumes | nindent 6 }}
       {{- end }}
 
-      {{ if .Values.pgbouncer_read.exporter.enabled }}
+      {{ if .Values.pgbouncerRead.exporter.enabled }}
       - name: metrics
-        image: "{{ .Values.pgbouncer_read.exporter.image.repository }}:{{ .Values.pgbouncer_read.exporter.image.tag }}"
-        imagePullPolicy: {{ .Values.pgbouncer_read.exporter.image.pullPolicy }}
+        image: "{{ .Values.pgbouncerRead.exporter.image.repository }}:{{ .Values.pgbouncerRead.exporter.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncerRead.exporter.image.pullPolicy }}
         env:
         - name: POSTGRESQL_USERNAME
           value: {{ include "posthog.postgresql.username" . }}
@@ -187,21 +187,21 @@ spec:
               done
 
               pgbouncer_exporter \
-                --web.listen-address=":{{ .Values.pgbouncer_read.exporter.port }}" \
+                --web.listen-address=":{{ .Values.pgbouncerRead.exporter.port }}" \
                 --web.telemetry-path="/metrics" \
                 --log.level="info" \
                 --log.format="json" \
                 --pgBouncer.connectionString="postgres://$POSTGRESQL_USERNAME:$POSTGRESQL_PASSWORD@127.0.0.1:6543/pgbouncer?sslmode=disable&connect_timeout=10"
         ports:
           - name: metrics
-            containerPort: {{ .Values.pgbouncer_read.exporter.port }}
+            containerPort: {{ .Values.pgbouncerRead.exporter.port }}
 
-        {{- if .Values.pgbouncer_read.exporter.resources }}
-        resources: {{ toYaml .Values.pgbouncer_read.exporter.resources | nindent 10 }}
+        {{- if .Values.pgbouncerRead.exporter.resources }}
+        resources: {{ toYaml .Values.pgbouncerRead.exporter.resources | nindent 10 }}
         {{- end }}
 
-        {{- if .Values.pgbouncer_read.exporter.securityContext.enabled }}
-        securityContext: {{- omit .Values.pgbouncer_read.exporter.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- if .Values.pgbouncerRead.exporter.securityContext.enabled }}
+        securityContext: {{- omit .Values.pgbouncerRead.exporter.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
       {{- end -}}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-read-hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.pgbouncer_read.enabled .Values.pgbouncer_read.hpa.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-pgbouncer-read
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-pgbouncer-read
+  minReplicas: {{ .Values.pgbouncer_read.hpa.minpods }}
+  maxReplicas: {{ .Values.pgbouncer_read.hpa.maxpods }}
+  metrics:
+  {{- with .Values.pgbouncer_read.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  behavior:
+    {{ toYaml .Values.pgbouncer_read.hpa.behavior | nindent 4 }}
+{{- end }}

--- a/charts/posthog/templates/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-read-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.pgbouncer_read.enabled .Values.pgbouncer_read.hpa.enabled -}}
+{{- if and .Values.pgbouncerRead.enabled .Values.pgbouncerRead.hpa.enabled -}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-pgbouncer-read
-  minReplicas: {{ .Values.pgbouncer_read.hpa.minpods }}
-  maxReplicas: {{ .Values.pgbouncer_read.hpa.maxpods }}
+  minReplicas: {{ .Values.pgbouncerRead.hpa.minpods }}
+  maxReplicas: {{ .Values.pgbouncerRead.hpa.maxpods }}
   metrics:
-  {{- with .Values.pgbouncer_read.hpa.cputhreshold }}
+  {{- with .Values.pgbouncerRead.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -21,5 +21,5 @@ spec:
         averageUtilization: {{ . }}
   {{- end }}
   behavior:
-    {{ toYaml .Values.pgbouncer_read.hpa.behavior | nindent 4 }}
+    {{ toYaml .Values.pgbouncerRead.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-read-service.yaml
+++ b/charts/posthog/templates/pgbouncer-read-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.pgbouncer_read.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "posthog.fullname" . }}-pgbouncer-read
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+   {{- range $key, $value := .Values.pgbouncer_read.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  type: {{ .Values.pgbouncer_read.service.type }}
+  ports:
+  - name: {{ template "posthog.fullname" . }}-pgbouncer-read
+    port: 6543
+    targetPort: 6543
+  selector:
+    app: {{ template "posthog.fullname" . }}
+    role: pgbouncer-read
+{{- end }}

--- a/charts/posthog/templates/pgbouncer-read-service.yaml
+++ b/charts/posthog/templates/pgbouncer-read-service.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.pgbouncer_read.enabled -}}
+{{- if .Values.pgbouncerRead.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer-read
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
-   {{- range $key, $value := .Values.pgbouncer_read.service.annotations }}
+   {{- range $key, $value := .Values.pgbouncerRead.service.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
-  type: {{ .Values.pgbouncer_read.service.type }}
+  type: {{ .Values.pgbouncerRead.service.type }}
   ports:
   - name: {{ template "posthog.fullname" . }}-pgbouncer-read
     port: 6543

--- a/charts/posthog/tests/__snapshot__/pgbouncer-deployment-read.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/pgbouncer-deployment-read.yaml.snap
@@ -1,0 +1,58 @@
+should match snapshot data:
+  1: |
+    containers:
+    - env:
+      - name: POSTGRESQL_USERNAME
+        value: postgres
+      - name: POSTGRESQL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgresql-password
+            name: RELEASE-NAME-posthog-postgresql
+      - name: POSTGRESQL_DATABASE
+        value: posthog
+      - name: POSTGRESQL_HOST
+        value: RELEASE-NAME-posthog-postgresql
+      - name: POSTGRESQL_PORT
+        value: "5432"
+      - name: PGBOUNCER_DATABASE
+        value: posthog
+      - name: PGBOUNCER_PORT
+        value: "6543"
+      - name: PGBOUNCER_MAX_CLIENT_CONN
+        value: "1000"
+      - name: PGBOUNCER_POOL_MODE
+        value: transaction
+      - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
+        value: extra_float_digits
+      image: bitnami/pgbouncer:1.18.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - sh
+            - -c
+            - sleep 30 && kill -INT 1 && sleep 31
+      livenessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        successThreshold: 1
+        tcpSocket:
+          port: 6543
+        timeoutSeconds: 2
+      name: posthog-pgbouncer-read
+      ports:
+      - containerPort: 6543
+        name: pgbouncer
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        successThreshold: 1
+        tcpSocket:
+          port: 6543
+        timeoutSeconds: 2
+    serviceAccountName: RELEASE-NAME-posthog
+    terminationGracePeriodSeconds: 65

--- a/charts/posthog/tests/__snapshot__/pgbouncer-deployment-read.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/pgbouncer-deployment-read.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot data:
       - name: POSTGRESQL_DATABASE
         value: posthog
       - name: POSTGRESQL_HOST
-        value: RELEASE-NAME-posthog-postgresql
+        value: null
       - name: POSTGRESQL_PORT
         value: "5432"
       - name: PGBOUNCER_DATABASE

--- a/charts/posthog/tests/pgbouncer-deployment-read.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment-read.yaml
@@ -21,6 +21,19 @@ tests:
       - hasDocuments:
           count: 1
 
+  - it: should override the host env var
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncerRead.enabled: true
+      pgbouncerRead.host: "beepboop"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "beepboop"
+
   - it: should match snapshot data
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:

--- a/charts/posthog/tests/pgbouncer-deployment-read.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment-read.yaml
@@ -1,0 +1,215 @@
+suite: PostHog pgbouncer read deployment definition
+templates:
+  - templates/pgbouncer-read-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty by default
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be empty if enabled
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should match snapshot data
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchSnapshot:
+          path: spec.template.spec
+
+  - it: should be the correct kind
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read:
+        enabled: true
+        podSecurityContext: 
+          enabled: true
+          runAsUser: 1001
+          fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should have a container securityContext
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read:
+        enabled: true
+        securityContext:
+          enabled: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not have a pod securityContext
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+
+  - it: should not have a container securityContext
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: pgbouncer should have the correct resources if set
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read.resources:
+        requests:
+          cpu: 100m
+          memory: 50M
+        limits:
+          cpu: 512m
+          memory: 100M
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 50M
+            limits:
+              cpu: 512m
+              memory: 100M
+
+  - it: pgbouncer metrics exporter should have the correct resources if set
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read.enabled: true
+      pgbouncer_read.exporter:
+        enabled: true
+        resources:
+          requests:
+            cpu: 125m
+            memory: 100M
+          limits:
+            cpu: 250m
+            memory: 200M
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[1].resources
+          value:
+            requests:
+              cpu: 125m
+              memory: 100M
+            limits:
+              cpu: 250m
+              memory: 200M
+
+  - it: allows setting pgbouncer exporter pullSecrets only
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read:
+        enabled: true
+        exporter:
+          enabled: true
+          image:
+            pullSecrets: [foo]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: foo]
+
+  - it: allows setting pgbouncer pullSecrets only
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read:
+        enabled: true
+        image:
+          pullSecrets: [foo]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: foo]
+
+  - it: allows setting pgbouncer and exporter secrets
+    template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      pgbouncer_read:
+        enabled: true
+        image:
+          pullSecrets: [main]
+        exporter:
+          image:
+            pullSecrets: [exporter]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: 
+          - name: main
+          - name: exporter

--- a/charts/posthog/tests/pgbouncer-deployment-read.yaml
+++ b/charts/posthog/tests/pgbouncer-deployment-read.yaml
@@ -16,7 +16,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -25,7 +25,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -36,7 +36,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -47,8 +47,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read:
+      pgbouncerRead.enabled: true
+      pgbouncerRead:
         enabled: true
         podSecurityContext: 
           enabled: true
@@ -68,8 +68,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read:
+      pgbouncerRead.enabled: true
+      pgbouncerRead:
         enabled: true
         securityContext:
           enabled: true
@@ -89,8 +89,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read.podSecurityContext.enabled: false
+      pgbouncerRead.enabled: true
+      pgbouncerRead.podSecurityContext.enabled: false
     asserts:
       - hasDocuments:
           count: 1
@@ -102,8 +102,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read.securityContext.enabled: false
+      pgbouncerRead.enabled: true
+      pgbouncerRead.securityContext.enabled: false
     asserts:
       - hasDocuments:
           count: 1
@@ -114,8 +114,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read.resources:
+      pgbouncerRead.enabled: true
+      pgbouncerRead.resources:
         requests:
           cpu: 100m
           memory: 50M
@@ -139,8 +139,8 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read.enabled: true
-      pgbouncer_read.exporter:
+      pgbouncerRead.enabled: true
+      pgbouncerRead.exporter:
         enabled: true
         resources:
           requests:
@@ -166,7 +166,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read:
+      pgbouncerRead:
         enabled: true
         exporter:
           enabled: true
@@ -183,7 +183,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read:
+      pgbouncerRead:
         enabled: true
         image:
           pullSecrets: [foo]
@@ -198,7 +198,7 @@ tests:
     template: templates/pgbouncer-read-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
-      pgbouncer_read:
+      pgbouncerRead:
         enabled: true
         image:
           pullSecrets: [main]

--- a/charts/posthog/tests/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-read-hpa.yaml
@@ -8,26 +8,26 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should be empty if pgbouncer_read.enabled is true and pgbouncer_read.hpa.enabled is set to false
+  - it: should be empty if pgbouncerRead.enabled is true and pgbouncerRead.hpa.enabled is set to false
     set:
-      pgbouncer_read.enabled: true
-      pgbouncer_read.hpa.enabled: false
+      pgbouncerRead.enabled: true
+      pgbouncerRead.hpa.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: should be not empty if pgbouncer_read.enabled and pgbouncer_read.hpa.enabled are set to true
+  - it: should be not empty if pgbouncerRead.enabled and pgbouncerRead.hpa.enabled are set to true
     set:
-      pgbouncer_read.enabled: true
-      pgbouncer_read.hpa.enabled: true
+      pgbouncerRead.enabled: true
+      pgbouncerRead.hpa.enabled: true
     asserts:
       - hasDocuments:
           count: 1
 
   - it: should have the correct apiVersion
     set:
-      pgbouncer_read.enabled: true
-      pgbouncer_read.hpa.enabled: true
+      pgbouncerRead.enabled: true
+      pgbouncerRead.hpa.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -36,8 +36,8 @@ tests:
 
   - it: should be the correct kind
     set:
-      pgbouncer_read.enabled: true
-      pgbouncer_read.hpa.enabled: true
+      pgbouncerRead.enabled: true
+      pgbouncerRead.hpa.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -46,7 +46,7 @@ tests:
 
   - it: sets hpa spec
     set:
-      pgbouncer_read:
+      pgbouncerRead:
         enabled: true
         hpa:
           enabled: true

--- a/charts/posthog/tests/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-read-hpa.yaml
@@ -1,0 +1,78 @@
+suite: PostHog pgbouncer HPA definition
+templates:
+  - templates/pgbouncer-read-hpa.yaml
+
+tests:
+  - it: should be empty by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if pgbouncer_read.enabled is true and pgbouncer_read.hpa.enabled is set to false
+    set:
+      pgbouncer_read.enabled: true
+      pgbouncer_read.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if pgbouncer_read.enabled and pgbouncer_read.hpa.enabled are set to true
+    set:
+      pgbouncer_read.enabled: true
+      pgbouncer_read.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      pgbouncer_read.enabled: true
+      pgbouncer_read.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v2beta2
+
+  - it: should be the correct kind
+    set:
+      pgbouncer_read.enabled: true
+      pgbouncer_read.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+
+  - it: sets hpa spec
+    set:
+      pgbouncer_read:
+        enabled: true
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-pgbouncer-read
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/pgbouncer-read-service.yaml
+++ b/charts/posthog/tests/pgbouncer-read-service.yaml
@@ -8,16 +8,16 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not be empty if pgbouncer_read.enabled is set to true
+  - it: should not be empty if pgbouncerRead.enabled is set to true
     set:
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1
 
   - it: should have the correct apiVersion
     set:
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -26,7 +26,7 @@ tests:
 
   - it: should be the correct kind
     set:
-      pgbouncer_read.enabled: true
+      pgbouncerRead.enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/posthog/tests/pgbouncer-read-service.yaml
+++ b/charts/posthog/tests/pgbouncer-read-service.yaml
@@ -1,0 +1,34 @@
+suite: PostHog pgbouncer service definition
+templates:
+  - templates/pgbouncer-read-service.yaml
+
+tests:
+  - it: should be empty if not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be empty if pgbouncer_read.enabled is set to true
+    set:
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    set:
+      pgbouncer_read.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1217,7 +1217,8 @@ externalPostgresql:
 ### ---- PGBOUNCER ----
 ###
 ###
-pgbouncer:
+
+_pgbouncer: &_pgbouncer 
   # -- Whether to deploy a PgBouncer service to satisfy the applications requirements.
   enabled: true
 
@@ -1336,6 +1337,13 @@ pgbouncer:
 
   ## -- PgBouncer pod(s) annotation.
   podAnnotations: {}
+
+pgbouncer:
+  <<: *_pgbouncer
+
+pgbouncer_read:
+  <<: *_pgbouncer
+  enabled: false
 
 ###
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1341,7 +1341,7 @@ _pgbouncer: &_pgbouncer
 pgbouncer:
   <<: *_pgbouncer
 
-pgbouncer_read:
+pgbouncerRead:
   <<: *_pgbouncer
   enabled: false
 

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1343,6 +1343,11 @@ pgbouncer:
 
 pgbouncerRead:
   <<: *_pgbouncer
+
+  # Specify the host to use for a read-replica. This would usually be some sort of load balancer,
+  # and otherwise all credentials would be the same
+  host: ""
+
   enabled: false
 
 ###


### PR DESCRIPTION
This should be pointed to a read replica for a postgres cluster

1. Why not RDS proxy? A few reasons. Turns out, it's super expensive! Classic AWS. Otherwise, it's pretty opaque + things like decide really need to know how the pooling works
2. Why do we need another deployment? pgbouncer doesn't really have query routing :( There is a fork called [pgbouncer-rr](https://github.com/awslabs/pgbouncer-rr-patch) that does what we need, but I'm not that keen on using a fork. Plus, two deployments can reduce the risk of things going wrong and _totally_ bringing us down.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
