### PR TITLE
fix(recordings): fix types using in KEDA ScaledObject

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.11.0
+version: 30.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -11,12 +11,12 @@
 {{- end }}
 {{- end }}
 
-{{/* Return the Kafka hosts (brokers) */}}
+{{/* Return the Kafka hosts (brokers) as a comma separated list */}}
 {{- define "posthog.kafka.brokers"}}
 {{- if .Values.kafka.enabled -}}
     {{- printf "%s:%d" (include "posthog.kafka.fullname" .) (.Values.kafka.service.port | int) }}
 {{- else -}}
-    {{- printf "%s" .Values.externalKafka.brokers }}
+    {{ join "," .Values.externalKafka.brokers | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/posthog/templates/recordings-ingestion-deployment.yaml
+++ b/charts/posthog/templates/recordings-ingestion-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       bootstrapServers: {{ include "posthog.kafka.brokers" . }}
       consumerGroup: session-recordings  # TODO: pass this into the consumers as well to avoid them getting out of sync.
       topic: session_recording_events  # TODO: pass this into the consumers as well to avoid them getting out of sync.
-      allowIdleConsumers: false  # Don't scale past the number of partitions
+      allowIdleConsumers: "false"  # Don't scale past the number of partitions
       offsetResetPolicy: earliest  # If the consumer is new, get all the recordings in the topic.
 {{ toYaml .Values.recordingsIngestion.keda.kafkaTrigger.metadata | indent 6 }}
   {{ end }}

--- a/charts/posthog/tests/recordings-ingestion-keda.yaml
+++ b/charts/posthog/tests/recordings-ingestion-keda.yaml
@@ -91,7 +91,7 @@ tests:
             metadata:
               lagThreshold: "1234"
               activationLagThreshold: "2345"
-              excludePersistentLag: false
+              excludePersistentLag: "false"
           config:
             pollingInterval: 30
             cooldownPeriod: 300
@@ -102,7 +102,7 @@ tests:
               failureThreshold: 3
               replicas: 6
             advanced:
-              restoreToOriginalReplicaCount: true/false
+              restoreToOriginalReplicaCount: "true"
               horizontalPodAutoscalerConfig:
                 name: some-hpa
                 behavior:
@@ -120,7 +120,7 @@ tests:
       - equal:
           path: spec.advanced
           value:
-            restoreToOriginalReplicaCount: true/false
+            restoreToOriginalReplicaCount: "true"
             horizontalPodAutoscalerConfig:
               name: some-hpa
               behavior:
@@ -144,10 +144,41 @@ tests:
             metadata:
               lagThreshold: "1234"
               activationLagThreshold: "2345"
-              excludePersistentLag: false
+              excludePersistentLag: "false"
               bootstrapServers: RELEASE-NAME-posthog-kafka:9092
               consumerGroup: session-recordings
               topic: session_recording_events
-              allowIdleConsumers: false
+              allowIdleConsumers: "false"
+              offsetResetPolicy: earliest
+        documentIndex: 1
+
+  - it: sets ScaledObject kafka bootstrap servers correctly if using externalKafka.brokers
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:1234
+          - broker2:2345
+      recordingsIngestion:
+        enabled: true
+        keda:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.triggers
+          content:
+            type: kafka
+            metadata:
+              lagThreshold: "1000"
+              activationLagThreshold: "0"
+              excludePersistentLag: "true"
+              bootstrapServers: broker1:1234,broker2:2345
+              consumerGroup: session-recordings
+              topic: session_recording_events
+              allowIdleConsumers: "false"
               offsetResetPolicy: earliest
         documentIndex: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -691,7 +691,7 @@ recordingsIngestion:
         lagThreshold: "1000"
         # -- At what lag value should KEDA scale from 0 replicas.
         activationLagThreshold: "0"
-        excludePersistentLag: true # Don't include stuck partitions in autoscaling decisions.
+        excludePersistentLag: "true" # Don't include stuck partitions in autoscaling decisions.
 
   rollout:
     # The max surge in pods during a rollout


### PR DESCRIPTION
Previously I'd used booleans instead of strings as it expects. It was
also expecting a comma separated list for the brokers list. We were
being inconsistent here between chart internal an external Kafka
settings.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
