### PR TITLE
feat: Add temporal and temporal worker to helm stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "charts/temporal"]
+	path = charts/temporal
+	url = git@github.com:temporalio/helm-charts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "charts/temporal"]
-	path = charts/temporal
+[submodule "charts/posthog/charts/temporal"]
+	path = charts/posthog/charts/temporal
 	url = git@github.com:temporalio/helm-charts.git

--- a/charts/posthog/Chart.lock
+++ b/charts/posthog/Chart.lock
@@ -17,6 +17,9 @@ dependencies:
 - name: redis
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 16.8.9
+- name: temporal
+  repository: ""
+  version: 0.20.1
 - name: zookeeper
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 7.0.5
@@ -47,5 +50,5 @@ dependencies:
 - name: prometheus-statsd-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 0.3.1
-digest: sha256:64a899e41608da7fc9bd0a8689b9f0005d1cfffbd83e4fb78e6f1cff1ba7d4ef
-generated: "2023-02-07T15:10:06.892265+01:00"
+digest: sha256:97e1a4b791b93a75468d4f6550e8c82dd12203942c498be384a3bdc00f49decd
+generated: "2023-04-13T09:18:52.549025-07:00"

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -48,6 +48,10 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: redis.enabled
 
+  - name: temporal
+    version: 0.20.1
+    condition: temporal.enabled
+
   - name: zookeeper
     version: 7.0.5
     repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
@@ -106,11 +110,7 @@ maintainers:
     email: tim@posthog.com
   - name: jams
     email: james.g@posthog.com
-  - name: macobo
-    email: karl@posthog.com
   - name: tiina
     email: tiina@posthog.com
-  - name: guido
-    email: guido@posthog.com
   - name: yakko
     email: yakko@posthog.com

--- a/charts/posthog/templates/_temporal.tpl
+++ b/charts/posthog/templates/_temporal.tpl
@@ -14,7 +14,7 @@
 {{/* Return the Temporal hosts as a comma separated list */}}
 {{- define "posthog.temporal.host"}}
 {{- if .Values.temporal.enabled -}}
-    {{- printf "%s:%d" (include "posthog.temporal.fullname" .) (.Values.temporal.service.port | int) }}
+    {{- printf "%s" (include "posthog.temporal.fullname" .) }}
 {{- else -}}
     {{ join "," .Values.externalTemporal.host | quote }}
 {{- end }}
@@ -23,13 +23,10 @@
 {{/* ENV used by PostHog deployments for connecting to Temporal */}}
 
 {{- define "snippet.temporal-env" }}
-
-{{- $hostsWithPrefix := list }}
-{{- $host := .Values.externalTemporal.host }}
-{{- end }}
 - name: TEMPORAL_SCHEDULER_HOST 
 {{- if .Values.temporal.enabled }}
   value: {{ ( include "posthog.temporal.host" . ) }}
 {{ else }}
   value: {{ .Values.externalTemporal.host | quote }}
+{{- end }}
 {{- end }}

--- a/charts/posthog/templates/_temporal.tpl
+++ b/charts/posthog/templates/_temporal.tpl
@@ -1,0 +1,35 @@
+{{/* Common Temporal ENV variables and helpers used by PostHog */}}
+
+{{/* Return the Temporal fullname */}}
+{{- define "posthog.temporal.fullname" }}
+{{- if .Values.temporal.fullnameOverride }}
+{{- .Values.temporal.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.temporal.nameOverride }}
+{{- printf "%s-%s" .Release.Name .Values.temporal.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- printf "%s-%s" (include "posthog.fullname" .) "temporal" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/* Return the Temporal hosts as a comma separated list */}}
+{{- define "posthog.temporal.host"}}
+{{- if .Values.temporal.enabled -}}
+    {{- printf "%s:%d" (include "posthog.temporal.fullname" .) (.Values.temporal.service.port | int) }}
+{{- else -}}
+    {{ join "," .Values.externalTemporal.host | quote }}
+{{- end }}
+{{- end }}
+
+{{/* ENV used by PostHog deployments for connecting to Temporal */}}
+
+{{- define "snippet.temporal-env" }}
+
+{{- $hostsWithPrefix := list }}
+{{- $host := .Values.externalTemporal.host }}
+{{- end }}
+- name: TEMPORAL_SCHEDULER_HOST 
+{{- if .Values.temporal.enabled }}
+  value: {{ ( include "posthog.temporal.host" . ) }}
+{{ else }}
+  value: {{ .Values.externalTemporal.host | quote }}
+{{- end }}

--- a/charts/posthog/templates/temporal-py-worker-deployment.yaml
+++ b/charts/posthog/templates/temporal-py-worker-deployment.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.temporal_python_worker.enabled -}}
+{{- if .Values.temporalPyWorker.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "posthog.fullname" . }}-temporal-python-worker
+  name: {{ template "posthog.fullname" . }}-temporalPyWorker
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
@@ -10,55 +10,58 @@ spec:
     matchLabels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: temporal-python-worker 
-  {{- if not .Values.temporal_python_worker.hpa.enabled }}
-  replicas: {{ .Values.temporal_python_worker.replicacount }}
+        role: temporalPyWorker
+  {{- if not .Values.temporalPyWorker.hpa.enabled }}
+  replicas: {{ .Values.temporalPyWorker.replicacount }}
   {{- end }}
 
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.temporal_python_worker.rollout.maxSurge }}
-      maxUnavailable: {{ .Values.temporal_python_worker.rollout.maxUnavailable }}
+      maxSurge: {{ .Values.temporalPyWorker.rollout.maxSurge }}
+      maxUnavailable: {{ .Values.temporalPyWorker.rollout.maxUnavailable }}
 
   template:
     metadata:
       annotations:
         checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      {{- if .Values.temporal_python_worker.podAnnotations }}
-{{ toYaml .Values.temporal_python_worker.podAnnotations | indent 8 }}
+      {{- if .Values.temporalPyWorker.podAnnotations }}
+{{ toYaml .Values.temporalPyWorker.podAnnotations | indent 8 }}
       {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: temporal-python-worker
+        role: temporalPyWorker
         {{- if (eq (default .Values.image.tag "none") "latest") }}
         date: "{{ now | unixEpoch }}"
         {{- end }}
-        {{- if .Values.temporal_python_worker.podLabels }}
-{{ toYaml .Values.temporal_python_worker.podLabels | indent 8 }}
+        {{- if .Values.temporalPyWorker.podLabels }}
+{{ toYaml .Values.temporalPyWorker.podLabels | indent 8 }}
         {{- end }}
     spec:
-      terminationGracePeriodSeconds: {{ include "snippet.temporal_python_worker-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
 
-      {{- if .Values.temporal_python_worker.affinity }}
+      {{- if .Values.temporalPyWorker.affinity }}
       affinity:
-{{ toYaml .Values.temporal_python_worker.affinity | indent 8 }}
+{{ toYaml .Values.temporalPyWorker.affinity | indent 8 }}
       {{- end }}
 
-      {{- if .Values.temporal_python_worker.nodeSelector }}
+      {{- if .Values.temporalPyWorker.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.temporal_python_worker.nodeSelector | indent 8 }}
+{{ toYaml .Values.temporalPyWorker.nodeSelector | indent 8 }}
       {{- end }}
 
-      {{- if .Values.temporal_python_worker.tolerations }}
+      {{- if .Values.temporalPyWorker.tolerations }}
       tolerations:
-{{ toYaml .Values.temporal_python_worker.tolerations | indent 8 }}
+{{ toYaml .Values.temporalPyWorker.tolerations | indent 8 }}
       {{- end }}
 
-      {{- if .Values.temporal_python_worker.schedulerName }}
-      schedulerName: "{{ .Values.temporal_python_worker.schedulerName }}"
+      {{- if .Values.temporalPyWorker.schedulerName }}
+      schedulerName: "{{ .Values.temporalPyWorker.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.temporalPyWorker.priorityClassName }}
+      priorityClassName: "{{ .Values.temporalPyWorker.priorityClassName }}"
       {{- end }}
 
       {{- if .Values.image.imagePullSecrets }}
@@ -74,41 +77,47 @@ spec:
         {{- end }}
       {{- end }}
 
-      {{- if .Values.temporal_python_worker.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.temporal_python_worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- if .Values.temporalPyWorker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.temporalPyWorker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-
       containers:
-      - name: {{ .Chart.Name }}-temporal_python_worker
+      - name: {{ .Chart.Name }}-temporalPyWorkers
         image: {{ template "posthog.image.fullPath" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - ./bin/temporal-django-worker
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-        # Expose the port on which Prometheus /metrics endpoint resides
-        - containerPort: 8001
         env:
-        # Common settings 
+        # Common Configs 
+        {{- include "snippet.temporal-env" . | indent 8 }}
         {{- include "snippet.kafka-env" . | indent 8 }}
         {{- include "snippet.objectstorage-env" . | indent 8 }}
         {{- include "snippet.redis-env" . | indent 8 }}
         {{- include "snippet.statsd-env" . | indent 8 }}
+        {{- if index .Values "prometheus-pushgateway" "enabled" }}
+        - name: PROM_PUSHGATEWAY_ADDRESS
+          value: "posthog-prometheus-pushgateway:9091"
+        {{- end }}
 
-        # PostHog app settings
-        {{- include "snippet.posthog-env" . | indent 8 }}
-        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         - name: PRIMARY_DB
           value: clickhouse
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
         {{- include "snippet.postgresql-env" . | nindent 8 }}
         {{- include "snippet.clickhouse-env" . | nindent 8 }}
         {{- include "snippet.email-env" . | nindent 8 }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
 {{- end }}
-{{- if .Values.temporal_python_worker.env }}
-{{ toYaml .Values.temporal_python_worker.env | indent 8 }}
+{{- if .Values.temporalPyWorker.env }}
+{{ toYaml .Values.temporalPyWorker.env | indent 8 }}
 {{- end }}
+        resources:
+{{ toYaml .Values.temporalPyWorker.resources | indent 12 }}
+        {{- if .Values.temporalPyWorker.securityContext.enabled }}
+        securityContext: {{- omit .Values.temporalPyWorker.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
       {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}

--- a/charts/posthog/templates/temporal-py-worker-deployment.yaml
+++ b/charts/posthog/templates/temporal-py-worker-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "posthog.fullname" . }}-temporalPyWorker
+  name: {{ template "posthog.fullname" . }}-temporal-py-worker
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
@@ -81,7 +81,7 @@ spec:
       securityContext: {{- omit .Values.temporalPyWorker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-temporalPyWorkers
+      - name: {{ .Chart.Name }}-temporal-py-workers
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:

--- a/charts/posthog/templates/temporal-py-worker-hpa.yaml
+++ b/charts/posthog/templates/temporal-py-worker-hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.temporalPyWorker.enabled .Values.temporalPyWorker.hpa.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-worker
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-temporalPyWorker
+  minReplicas: {{ .Values.temporalPyWorker.hpa.minpods }}
+  maxReplicas: {{ .Values.temporalPyWorker.hpa.maxpods }}
+  metrics:
+  {{- with .Values.temporalPyWorker.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  behavior: 
+    {{ toYaml .Values.temporalPyWorker.hpa.behavior | nindent 4 }}
+{{- end }}

--- a/charts/posthog/templates/temporal-python-worker-deployment.yaml
+++ b/charts/posthog/templates/temporal-python-worker-deployment.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.temporal_python_worker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-temporal-python-worker
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: temporal-python-worker 
+  {{- if not .Values.temporal_python_worker.hpa.enabled }}
+  replicas: {{ .Values.temporal_python_worker.replicacount }}
+  {{- end }}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.temporal_python_worker.rollout.maxSurge }}
+      maxUnavailable: {{ .Values.temporal_python_worker.rollout.maxUnavailable }}
+
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.temporal_python_worker.podAnnotations }}
+{{ toYaml .Values.temporal_python_worker.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: temporal-python-worker
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.temporal_python_worker.podLabels }}
+{{ toYaml .Values.temporal_python_worker.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ include "snippet.temporal_python_worker-deployments.terminationGracePeriodSeconds" . }}
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.temporal_python_worker.affinity }}
+      affinity:
+{{ toYaml .Values.temporal_python_worker.affinity | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.temporal_python_worker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.temporal_python_worker.nodeSelector | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.temporal_python_worker.tolerations }}
+      tolerations:
+{{ toYaml .Values.temporal_python_worker.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.temporal_python_worker.schedulerName }}
+      schedulerName: "{{ .Values.temporal_python_worker.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      # I do not know for sure if the old one has been used anywhere, so do both :(
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.temporal_python_worker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.temporal_python_worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ .Chart.Name }}-temporal_python_worker
+        image: {{ template "posthog.image.fullPath" . }}
+        command:
+          - ./bin/temporal-django-worker
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        # Expose the port on which Prometheus /metrics endpoint resides
+        - containerPort: 8001
+        env:
+        # Common settings 
+        {{- include "snippet.kafka-env" . | indent 8 }}
+        {{- include "snippet.objectstorage-env" . | indent 8 }}
+        {{- include "snippet.redis-env" . | indent 8 }}
+        {{- include "snippet.statsd-env" . | indent 8 }}
+
+        # PostHog app settings
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
+        - name: PRIMARY_DB
+          value: clickhouse
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.temporal_python_worker.env }}
+{{ toYaml .Values.temporal_python_worker.env | indent 8 }}
+{{- end }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+{{- end }}

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1480,7 +1480,7 @@ temporal:
   fullnameOverride: ""
   schema:
     update:
-      enabled: false 
+      enabled: true 
   server:
     # -- The number of Temporal scheduler pods
     replicaCount: 1
@@ -1491,7 +1491,11 @@ temporal:
       cluster_size: 1
   elasticsearch:
     # -- Whether to deploy elasticsearch to help with the Temporal admin pages 
-    enabled: true
+    enabled: false
+  grafana:
+    enabled: false
+  prometheus:
+    enabled: false 
 
 
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -283,6 +283,55 @@ worker:
   podSecurityContext:
     enabled: false
 
+temporalPyWorker:
+  # -- Whether to install the PostHog Temporal Python worker stack or not.
+  enabled: true
+
+  # -- Count of worker pods to run. This setting is ignored if `worker.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the worker stack.
+    enabled: false
+    # -- CPU threshold percent for the worker stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the worker stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the worker stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  rollout:
+    # The max surge in pods during a rollout
+    maxSurge: 25%
+    # The max unavailable during a rollout
+    maxUnavailable: 25%
+
+  # -- Additional env variables to inject into the worker stack deployment.
+  env: []
+
+  # -- Resource limits for the worker stack deployment.
+  resources: {}
+
+  # -- Node labels for the worker stack deployment.
+  nodeSelector: {}
+  # -- Toleration labels for the worker stack deployment.
+  tolerations: []
+  # -- Affinity settings for the worker stack deployment.
+  affinity: {}
+
+  # -- Container security context for the worker stack deployment.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the worker stack deployment.
+  podSecurityContext:
+    enabled: false
+
+
+
 plugins:
   # -- Whether to install the PostHog plugin-server stack or not.
   # This service handles data ingestion into ClickHouse, running apps and async
@@ -1416,6 +1465,29 @@ externalRedis:
   existingSecret: ""
   # -- Name of the key pointing to the password in your Kubernetes secret.
   existingSecretPasswordKey: ""
+
+
+###
+###
+### ---- Temporal ----
+###
+###
+temporal:
+  # -- Whether to deploy Temporal scheduler and supporting services. To use an external Temporal instance set this to `false` and configure `externalTemporal` values. 
+  enabled: true
+  nameOverride: posthog-temporal
+  fullnameOverride: ""
+  server:
+    # -- The number of Temporal scheduler pods
+    replicaCount: 1
+  cassandra:
+    config:
+      # -- The number of Cassandra nodes to start for persisting Temporal scheduler tasks
+      cluster_size: 1
+  elasticsearch:
+    # -- Whether to deploy elasticsearch to help with the Temporal admin pages 
+    enabled: true
+
 
 ###
 ###

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1475,12 +1475,17 @@ externalRedis:
 temporal:
   # -- Whether to deploy Temporal scheduler and supporting services. To use an external Temporal instance set this to `false` and configure `externalTemporal` values. 
   enabled: true
+  debug: true 
   nameOverride: posthog-temporal
   fullnameOverride: ""
+  schema:
+    update:
+      enabled: false 
   server:
     # -- The number of Temporal scheduler pods
     replicaCount: 1
   cassandra:
+    enabled: true 
     config:
       # -- The number of Cassandra nodes to start for persisting Temporal scheduler tasks
       cluster_size: 1


### PR DESCRIPTION
This is very much a WIP - avert your eyes!

- feat: add temporal worker to helm
- checkpoint

## Description
Add a Temporal scheduler based on Temporal's helm chart
https://github.com/temporalio/helm-charts

In production we will be using Temporal Cloud's scheduler, but it's important to include Temporal scheduler in the helm chart for the Open Source users out there (and for testing!)

This also adds a python Temporal worker that will be used to execute workflows on our k8s stack.

## How has this been tested?
HAH - we test in prod.

Not really - there will be tests and this will have been tested extensively on DO both with local Temporal scheduler and with Temporal.cloud

