### PR TITLE
Allow setting replica host env var on pods

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.12.0
+version: 30.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_postgresql.tpl
+++ b/charts/posthog/templates/_postgresql.tpl
@@ -17,6 +17,10 @@
       key: {{ include "posthog.postgresql.secretPasswordKey" . }}
 - name: USING_PGBOUNCER
   value: 'true'
+{{ if .Values.pgbouncerRead.enabled -}}
+- name: POSTHOG_POSTGRES_READ_HOST
+  value: {{ .Values.pgbouncerRead.host -}}
+{{ end -}}
 {{- end }}
 
 {{/* ENV used by migrate job for connecting to postgresql */}}

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -134,3 +134,36 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets
           value: [name: secret]
+
+  - it: allows setting pgbouncer read env
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      pgbouncerRead:
+        enabled: true
+        host: beep-boop
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_POSTGRES_READ_HOST
+            value: beep-boop
+
+  - it: do not set postgres read host unless configured
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      pgbouncerRead:
+        host: beep-boop
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_POSTGRES_READ_HOST
+            value: beep-boop


### PR DESCRIPTION
## Description
I will follow up with a PR to posthog/posthog tomorrow! This means we can configure a database router in Django

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
