### PR TITLE
Add support for IngressClassName

### DIFF
--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -33,6 +33,9 @@ metadata:
     {{- end }}
    {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- else }}
   {{- if or (eq (include "ingress.letsencrypt" .) "true") (or (.Values.ingress.secretName) (.Values.ingress.gcp.secretName)) }}
   tls:
   - hosts:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1097,6 +1097,8 @@ ingress:
   type:
   # -- URL to address your PostHog installation. You will need to set up DNS after installation
   hostname:
+  # -- Ingress controller that you want to use. Only available for Kubernetes >= 1.18
+  ingressClassName:
   gcp:
     # -- Specifies the name of the global IP address resource to be associated with the google clb
     ip_name: "posthog"


### PR DESCRIPTION
## Description
I was trying to set up the ingress for Posthog and I saw that this option wasn´t available in the helm chart, that´s why I decided to push this PR. The _ingressClassName_ is the recommended way to specify what Ingress controller do you want to use since Kubernetes > 1.18.

See this [URL](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for more info

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
To test this implementation I deployed locally Posthog and checked that the ingress was working fine with the new ingressClassName properly set in the ingress resource.
In case you use the annotation `kubernetes.io/ingress.class: nginx` for speciying the ingress controller that you want to use, you can delete it and add this line under ingress:
`ingressClassName: nginx`

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
