### PR TITLE
chore(alerts): raise End2EndIngestionLag threshold to 10+5min

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.14.0
+version: 30.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2142,15 +2142,15 @@ prometheus:
                   needs to be rolled-back.
 
             - alert: End2EndIngestionLag
-              expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 300
+              expr: (max by(scenario) (posthog_celery_observed_ingestion_lag_seconds{scenario=~"ingestion_api|ingestion"})) > 600
               for: 5m
               labels:
                 rotation: common
                 severity: critical
               annotations:
-                summary: End-to-end analytics event ingestion lag exceeds 5 minutes for more than 5 minutes.
+                summary: End-to-end analytics event ingestion lag exceeds 10 minutes for more than 5 minutes.
                 description: |
-                  Our end-to-end probe measured an ingestion lag higher than 5 minutes for scenario {{ $labels.scenario }}.
+                  Our end-to-end probe measured an ingestion lag higher than 10 minutes for scenario {{ $labels.scenario }}.
                   Check the "Kafka (cluster overview)" dashboard to identify what topics and partitions are lagging and
                   follow the https://posthog.com/docs/runbook/services/plugin-server/ingestion-lag runbook for recovery
                   steps.
@@ -2246,7 +2246,7 @@ prometheus:
                 rotation: common
                 severity: critical
               annotations:
-                summary: Graphile jobs execution lag exceeds 10 minutes for more than 5 minutes.
+                summary: Graphile jobs execution lag exceeds 15 minutes for more than 5 minutes.
                 runbook_url: https://github.com/PostHog/product-internal/blob/main/infrastructure/runbooks/pipeline/graphile.md
                 description: |
                   Jobs of type {{ $labels.task_identifier }} have been sitting in the Graphile execution queue for more


### PR DESCRIPTION
## Description

With the traffic increasing, afternoon deploys trigger pages of End2EndIngestionLag. Let's raise the threshold while we mitigate this issue.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
