### PR TITLE
Use the correct read host

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.14.1
+version: 30.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_pgbouncer.tpl
+++ b/charts/posthog/templates/_pgbouncer.tpl
@@ -24,3 +24,17 @@ Set PgBouncer port
 {{- define "posthog.pgbouncer.port" -}}
     6543
 {{- end -}}
+
+{{/*
+Set Read PgBouncer host
+*/}}
+{{- define "posthog.pgbouncer-read.host" -}}
+    {{- template "posthog.fullname" . }}-pgbouncer-read
+{{- end -}}
+
+{{/*
+Set PgBouncer port
+*/}}
+{{- define "posthog.pgbouncer-read.port" -}}
+    6543
+{{- end -}}

--- a/charts/posthog/templates/_postgresql.tpl
+++ b/charts/posthog/templates/_postgresql.tpl
@@ -19,7 +19,7 @@
   value: 'true'
 {{ if .Values.pgbouncerRead.enabled -}}
 - name: POSTHOG_POSTGRES_READ_HOST
-  value: {{ .Values.pgbouncerRead.host -}}
+  value: {{ template "posthog.pgbouncer-read.host" . }}
 {{ end -}}
 {{- end }}
 

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -150,7 +150,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: POSTHOG_POSTGRES_READ_HOST
-            value: beep-boop
+            value: RELEASE-NAME-posthog-pgbouncer-read
 
   - it: do not set postgres read host unless configured
     template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed


### PR DESCRIPTION
The old config was trying to connect directly to postgres, and not via pgbouncer. Don't do that.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
