### PR TITLE
feat(chart): add new externalKafka.tls value

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.14.2
+version: 30.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -43,4 +43,8 @@
 {{ else }}
   value: {{ join "," $hostsWithPrefix | quote }}
 {{- end }}
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.tls }}
+- name: KAFKA_SECURITY_PROTOCOL
+  value: SSL
+{{- end }}
 {{- end }}

--- a/charts/posthog/templates/recordings-ingestion-deployment.yaml
+++ b/charts/posthog/templates/recordings-ingestion-deployment.yaml
@@ -25,6 +25,7 @@ spec:
   triggers:
   {{ if .Values.recordingsIngestion.keda.kafkaTrigger.enabled }}
   - type: kafka
+    metricType: Value # Absolute lag target, not to be divided by deployment size
     metadata:
       bootstrapServers: {{ include "posthog.kafka.brokers" . }}
       consumerGroup: session-recordings  # TODO: pass this into the consumers as well to avoid them getting out of sync.

--- a/charts/posthog/templates/recordings-ingestion-deployment.yaml
+++ b/charts/posthog/templates/recordings-ingestion-deployment.yaml
@@ -31,6 +31,9 @@ spec:
       topic: session_recording_events  # TODO: pass this into the consumers as well to avoid them getting out of sync.
       allowIdleConsumers: "false"  # Don't scale past the number of partitions
       offsetResetPolicy: earliest  # If the consumer is new, get all the recordings in the topic.
+      {{- if and (not .Values.kafka.enabled) .Values.externalKafka.tls }}
+      tls: enable
+      {{ end }}
 {{ toYaml .Values.recordingsIngestion.keda.kafkaTrigger.metadata | indent 6 }}
   {{ end }}
 

--- a/charts/posthog/tests/kafka-settings.yaml
+++ b/charts/posthog/tests/kafka-settings.yaml
@@ -10,7 +10,7 @@ templates:
   - templates/secrets.yaml
 
 tests:
-  - it: should use internal Kafka as default
+  - it: should use internal Kafka without TLS as default
     templates: # TODO: remove once secrets.yaml will be fixed/removed
       - templates/web-deployment.yaml
       - templates/worker-deployment.yaml
@@ -29,7 +29,11 @@ tests:
           content:
             name: KAFKA_URL
             value: kafka://RELEASE-NAME-posthog-kafka:9092
-
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
 
   - it: should use internal Kafka when `kafka.enabled` is set to `true` and `externalKafka.brokers` is configured
     templates: # TODO: remove once secrets.yaml will be fixed/removed
@@ -45,6 +49,7 @@ tests:
         brokers:
           - "broker1:port1"
           - "broker2:port2"
+        tls: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -56,6 +61,11 @@ tests:
           content:
             name: KAFKA_URL
             value: kafka://RELEASE-NAME-posthog-kafka:9092
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
 
   - it: should use external Kafka when `kafka.enabled` is set to `false` and `externalKafka.brokers` is configured
     templates: # TODO: remove once secrets.yaml will be fixed/removed
@@ -81,6 +91,11 @@ tests:
           content:
             name: KAFKA_URL
             value: kafka://broker1:port1
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
 
   - it: should use external Kafka when `kafka.enabled` is set to `false` and `externalKafka.brokers` is configured (multiple brokers)
     templates: # TODO: remove once secrets.yaml will be fixed/removed
@@ -107,3 +122,39 @@ tests:
           content:
             name: KAFKA_URL
             value: kafka://broker1:port1,kafka://broker2:port2
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SSL
+
+  - it: should use TLS `kafka.enabled` is set to `false` and `externalKafka.tls` is set
+    templates: # TODO: remove once secrets.yaml will be fixed/removed
+      - templates/web-deployment.yaml
+      - templates/worker-deployment.yaml
+      - templates/events-deployment.yaml
+      - templates/migrate.job.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:port1
+        tls: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_HOSTS
+            value: "broker1:port1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_URL
+            value: kafka://broker1:port1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SSL

--- a/charts/posthog/tests/recordings-ingestion-keda.yaml
+++ b/charts/posthog/tests/recordings-ingestion-keda.yaml
@@ -88,6 +88,7 @@ tests:
           enabled: true
           kafkaTrigger:
             enabled: true
+            metricType: Value
             metadata:
               lagThreshold: "1234"
               activationLagThreshold: "2345"
@@ -141,6 +142,7 @@ tests:
           path: spec.triggers
           content:
             type: kafka
+            metricType: Value
             metadata:
               lagThreshold: "1234"
               activationLagThreshold: "2345"
@@ -172,7 +174,42 @@ tests:
           path: spec.triggers
           content:
             type: kafka
+            metricType: Value
             metadata:
+              lagThreshold: "1000"
+              activationLagThreshold: "0"
+              excludePersistentLag: "true"
+              bootstrapServers: broker1:1234,broker2:2345
+              consumerGroup: session-recordings
+              topic: session_recording_events
+              allowIdleConsumers: "false"
+              offsetResetPolicy: earliest
+        documentIndex: 1
+
+  - it: sets ScaledObject kafka bootstrap servers correctly if using externalKafka.brokers and TLS
+    templates:
+      - templates/recordings-ingestion-deployment.yaml
+    set:
+      cloud: private
+      kafka:
+        enabled: false
+      externalKafka:
+        tls: true
+        brokers:
+          - broker1:1234
+          - broker2:2345
+      recordingsIngestion:
+        enabled: true
+        keda:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.triggers
+          content:
+            type: kafka
+            metricType: Value
+            metadata:
+              tls: enable
               lagThreshold: "1000"
               activationLagThreshold: "0"
               excludePersistentLag: "true"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -681,8 +681,6 @@ recordingsIngestion:
     # -- KEDA trigger config for type kafka. This will be merged in with other
     # config such as consumer group id and topic which will be set
     # automatically.
-    #
-    # TODO: add support for all security protocol config.
     kafkaTrigger:
       enabled: true
 
@@ -1457,6 +1455,8 @@ kafka:
 externalKafka:
   # - External Kafka brokers. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided as array/list.
   brokers: []
+  # - Use TLS to connect to the external kafka cluster
+  tls: false
 
 ###
 ###


### PR DESCRIPTION
## Description

To run KEDA autoscaling on Kafka lag, we will need to set it to use TLS when needed. We currently set the `KAFKA_SECURITY_PROTOCOL` envvar in common values, but retrieving that value to setup KEDA is non-trivial. Instead:

- add a new `externalKafka.tls` value
- if it as set, and we don't use the chart's brokers, set the `KAFKA_SECURITY_PROTOCOL` envvar to `SSL`
- use the same value to setup `tls: enabled` on the KEDA Kafka trigger
- also set the KEDA Kafka trigger to use an absolute `Value` metric instead of the default `AverageValue` (we want to set an absolute acceptable lag value for the topic, not a lag per container)

This is expected to be a backwards-compatible change. Once this is released, we can change our values to not set the envvar, and set the new value instead.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Added a unit test case, and updated existing ones

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
