### PR TITLE
feat(capture): disable init container for event deployment

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.18.0
+version: 30.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -101,6 +101,12 @@ spec:
         # statsd env variables
         {{- include "snippet.statsd-env" . | indent 8 }}
 
+        # async migrations will be run by the migrate job
+        {{- if .Values.migrate.enabled -}}
+        - name: SKIP_ASYNC_MIGRATIONS_SETUP
+          value: 'True'
+        {{- end }}
+
         - name: DISABLE_SECURE_SSL_REDIRECT
           value: '1'
         - name: IS_BEHIND_PROXY

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -172,7 +172,6 @@ spec:
         {{- if .Values.events.securityContext.enabled }}
         securityContext: {{- omit .Values.events.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
-      initContainers:
-      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
-      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+      # No initContainers for that workload, we only need Kafka, and that one is a readiness check constraint.
+      # This should make event pods able to upscale if PG is unhealthy (and faster to come online too).
 {{- end }}

--- a/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
+++ b/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
@@ -1,6 +1,5 @@
 suite: _initContainers-wait-for-migrations
 templates:
-  - templates/events-deployment.yaml
   - templates/plugins-deployment.yaml
   - templates/web-deployment.yaml
   - templates/worker-deployment.yaml
@@ -10,7 +9,6 @@ templates:
 tests:
   - it: spec.template.spec.initContainers[1].env override via 'env' should work
     templates: # TODO: remove once secrets.yaml will be fixed/removed
-      - templates/events-deployment.yaml
       - templates/plugins-deployment.yaml
       - templates/web-deployment.yaml
       - templates/worker-deployment.yaml


### PR DESCRIPTION
## Description

Remove both the `wait-for-migrations` and `wait-for-service-dependencies` init containers for the events deployment.

We want event pods to be able to upscale even if the whole platform is on fire (including PG, CH and redis). Their only dependency is Kafka, and it is asserted in the readiness probe.

A bad deploy that kills the Kafka client should not go through, because the readiness probe will fail, triggering a rollback.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
