### PR TITLE
fix: Correct podSecurityContext for blob ingester

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.17.1
+version: 30.17.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -832,7 +832,8 @@ recordingsBlobIngestion:
     enabled: false
   # -- Pod security context for the plugin-server stack deployment.
   podSecurityContext:
-    enabled: false
+    enabled: true
+    fsGroup: 1000
 
   livenessProbe:
     # -- The liveness probe failure threshold


### PR DESCRIPTION
## Description

We realised that PostHog's container runs in a non-root group (1000) so we need to set this default for the blob ingster.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
