### PR TITLE
Update HPA apiVersion from v2beta2 to v2

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.18.1
+version: 30.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -171,7 +171,7 @@ spec:
 ---
 
 {{ if .params.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" .root }}-{{ .name }}

--- a/charts/posthog/templates/decide-hpa.yaml
+++ b/charts/posthog/templates/decide-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.decide.enabled .Values.decide.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-decide

--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.events.enabled .Values.events.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-events

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer

--- a/charts/posthog/templates/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-read-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pgbouncerRead.enabled .Values.pgbouncerRead.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-pgbouncer-read

--- a/charts/posthog/templates/temporal-py-worker-hpa.yaml
+++ b/charts/posthog/templates/temporal-py-worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.temporalPyWorker.enabled .Values.temporalPyWorker.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-worker

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.web.enabled .Values.web.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-web

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.worker.enabled .Values.worker.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "posthog.fullname" . }}-worker

--- a/charts/posthog/tests/events-hpa.yaml
+++ b/charts/posthog/tests/events-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/pgbouncer-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/tests/pgbouncer-read-hpa.yaml
@@ -32,7 +32,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/plugins-analytics-ingestion-hpa.yaml
+++ b/charts/posthog/tests/plugins-analytics-ingestion-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-async-hpa.yaml
+++ b/charts/posthog/tests/plugins-async-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-exports-hpa.yaml
+++ b/charts/posthog/tests/plugins-exports-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-hpa.yaml
+++ b/charts/posthog/tests/plugins-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-ingestion-hpa.yaml
+++ b/charts/posthog/tests/plugins-ingestion-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-ingestion-overflow-hpa.yaml
+++ b/charts/posthog/tests/plugins-ingestion-overflow-hpa.yaml
@@ -52,7 +52,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-jobs-hpa.yaml
+++ b/charts/posthog/tests/plugins-jobs-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/plugins-scheduler-hpa.yaml
+++ b/charts/posthog/tests/plugins-scheduler-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/recordings-ingestion-hpa.yaml
+++ b/charts/posthog/tests/recordings-ingestion-hpa.yaml
@@ -48,7 +48,7 @@ tests:
       - hasDocuments:
           count: 2
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
         documentIndex: 1
 
   - it: should be the correct kind

--- a/charts/posthog/tests/web-hpa.yaml
+++ b/charts/posthog/tests/web-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
 
   - it: should be the correct kind
     set:

--- a/charts/posthog/tests/worker-hpa.yaml
+++ b/charts/posthog/tests/worker-hpa.yaml
@@ -35,7 +35,7 @@ tests:
       - hasDocuments:
           count: 1
       - isAPIVersion:
-          of: autoscaling/v2beta2
+          of: autoscaling/v2
 
   - it: should be the correct kind
     set:


### PR DESCRIPTION
## Description
v2beta2 is deprecated and will be removed in 1.26

v2 has been available since 1.23 which is our lowest supported version

There are no changes with v2, so no further changes are needed, no resources will be destroyed or created from this change

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
