### PR TITLE
feat: add toolbox deploy

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.21.0
+version: 30.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_snippet-metadata-labels-common.tpl
+++ b/charts/posthog/templates/_snippet-metadata-labels-common.tpl
@@ -5,13 +5,14 @@
       - https://helm.sh/docs/chart_best_practices/labels/#standard-labels
       - https://kubernetes.io/docs/concepts/overview/_print/#labels
 */}}
-{{- define "_snippet-metadata-labels-common" }}
-{{- include "_snippet-metadata-labels-constants" }}
-"helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
-{{- end }}
 
 {{- define "_snippet-metadata-labels-constants" }}
 "app.kubernetes.io/name": {{ include "posthog.fullname" . | quote }}
 "app.kubernetes.io/instance": {{ .Release.Name | quote }}
 "app.kubernetes.io/managed-by": {{ .Release.Service | quote }}
+{{- end }}
+
+{{- define "_snippet-metadata-labels-common" }}
+{{- include "_snippet-metadata-labels-constants" . }}
+"helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}

--- a/charts/posthog/templates/_snippet-metadata-labels-common.tpl
+++ b/charts/posthog/templates/_snippet-metadata-labels-common.tpl
@@ -6,8 +6,12 @@
       - https://kubernetes.io/docs/concepts/overview/_print/#labels
 */}}
 {{- define "_snippet-metadata-labels-common" }}
+{{- include "_snippet-metadata-labels-constants" }}
+"helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
+{{- end }}
+
+{{- define "_snippet-metadata-labels-constants" }}
 "app.kubernetes.io/name": {{ include "posthog.fullname" . | quote }}
 "app.kubernetes.io/instance": {{ .Release.Name | quote }}
 "app.kubernetes.io/managed-by": {{ .Release.Service | quote }}
-"helm.sh/chart": {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}

--- a/charts/posthog/templates/toolbox-deployment.yaml
+++ b/charts/posthog/templates/toolbox-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "posthog.fullname" . }}-toolbox
-  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  labels: {{- include "_snippet-metadata-labels-constants" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
 spec:
   selector:
@@ -14,64 +14,16 @@ spec:
 
   template:
     metadata:
-      annotations:
-        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      {{- if .Values.web.podAnnotations }}
-{{ toYaml .Values.web.podAnnotations | indent 8 }}
-      {{- end }}
       labels:
         app: {{ template "posthog.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: web
-        {{- if (eq (default .Values.image.tag "none") "latest") }}
-        date: "{{ now | unixEpoch }}"
-        {{- end }}
-        {{- if .Values.web.podLabels }}
-{{ toYaml .Values.web.podLabels | indent 8 }}
-        {{- end }}
+        role: toolbox
     spec:
-      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
-
-      {{- if .Values.web.affinity }}
-      affinity:
-{{ toYaml .Values.web.affinity | indent 8 }}
-      {{- end }}
-
-      {{- if .Values.web.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.web.nodeSelector | indent 8 }}
-      {{- end }}
-
-      {{- if .Values.web.tolerations }}
-      tolerations:
-{{ toYaml .Values.web.tolerations | indent 8 }}
-      {{- end }}
-
-      {{- if .Values.web.schedulerName }}
-      schedulerName: "{{ .Values.web.schedulerName }}"
-      {{- end }}
-
-      {{- if .Values.image.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
-      {{- end }}
-
-      # I do not know for sure if the old one has been used anywhere, so do both :(
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-        {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-        {{- end }}
-      {{- end }}
-
-      {{- if .Values.web.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.web.podSecurityContext "enabled" | toYaml | nindent 8 }}
-      {{- end }}
-
       containers:
       - name: {{ .Chart.Name }}-toolbox
         # We are specifying the image by tag to avoid restarts on chart apply.
+        # Users will need to k delete pod to pull the newest image.
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         command:

--- a/charts/posthog/templates/toolbox-deployment.yaml
+++ b/charts/posthog/templates/toolbox-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.toolbox.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-toolbox
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: toolbox
+
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.web.podAnnotations }}
+{{ toYaml .Values.web.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: web
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.web.podLabels }}
+{{ toYaml .Values.web.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.web.affinity }}
+      affinity:
+{{ toYaml .Values.web.affinity | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.tolerations }}
+      tolerations:
+{{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.schedulerName }}
+      schedulerName: "{{ .Values.web.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      # I do not know for sure if the old one has been used anywhere, so do both :(
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.web.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.web.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ .Chart.Name }}-toolbox
+        # We are specifying the image by tag to avoid restarts on chart apply.
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: Always
+        command:
+          - sleep
+          - infinity
+        env:
+        {{- include "snippet.kafka-env" . | indent 8 }}
+        {{- include "snippet.objectstorage-env" . | indent 8 }}
+        {{- include "snippet.redis-env" . | indent 8 }}
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
+        - name: PRIMARY_DB
+          value: clickhouse
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.toolbox.env }}
+{{ toYaml .Values.toolbox.env | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.toolbox.resources | indent 12 }}
+{{- end }}

--- a/charts/posthog/tests/toolbox-deployment.yaml
+++ b/charts/posthog/tests/toolbox-deployment.yaml
@@ -1,0 +1,27 @@
+suite: PostHog toolbox deployment definition
+templates:
+  - templates/toolbox-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if toolbox.enabled is set to false
+    template: templates/toolbox-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      toolbox.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not use image by sha
+    template: templates/web-deployment.yaml
+    set:
+      cloud: local
+      toolbox.enabled: true
+      image.repository: posthog/posthog
+      sha: ignored
+      tag: latest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: posthog/posthog:latest

--- a/charts/posthog/tests/toolbox-deployment.yaml
+++ b/charts/posthog/tests/toolbox-deployment.yaml
@@ -19,8 +19,8 @@ tests:
       cloud: local
       toolbox.enabled: true
       image.repository: posthog/posthog
-      sha: ignored
-      tag: latest
+      image.sha: ignored
+      image.tag: latest
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/charts/posthog/tests/toolbox-deployment.yaml
+++ b/charts/posthog/tests/toolbox-deployment.yaml
@@ -14,7 +14,7 @@ tests:
           count: 0
 
   - it: should not use image by sha
-    template: templates/web-deployment.yaml
+    template: templates/toolbox-deployment.yaml
     set:
       cloud: local
       toolbox.enabled: true

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1087,6 +1087,14 @@ pluginsScheduler:
   # -- Sentry endpoint to send errors to. Falls back to global sentryDSN
   sentryDSN:
 
+toolbox:
+  # -- Whether to install the PostHog toolbox deployment
+  enabled: false
+  # -- Additional env variables to inject into the toolbox deployment.
+  env: []
+  # -- Resource limits for the toolbox deployment.
+  resources: {}
+
 temporalPyWorker:
   # -- Whether to install the PostHog Temporal Python worker stack or not.
   enabled: false


### PR DESCRIPTION
## Description

To execute django management commands in cluster, we need a stable pod that does not restart at every apply. I'm usually copying the celery deploy manually, but that's dangerous.

This PR add an optional `toolbox` deploy, that will NOT restart when:
  - we `helm upgrade`
  - we change the image sha
but will still restart if:
  - we change global envvars, which should be desirable to avoid pointing to bad endpoints

To refresh the code, users should just `k delete` the toolbox pod, to get a new one up. This pod will use the latest image due to `imagePullPolicy: Always`

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
