### PR TITLE
chore: Bump ClickHouse version to 23.4.2.11 as default

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -617,7 +617,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.secure | bool | `false` | Whether to use TLS connection connecting to ClickHouse |
 | clickhouse.verify | bool | `false` | Whether to verify TLS certificate on connection to ClickHouse |
 | clickhouse.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.image.tag | string | `"22.8.11.15"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.image.tag | string | `"23.4"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.image.pullSecrets | list | `[]` |  |
 | clickhouse.tolerations | list | `[]` | Toleration labels for clickhouse pod assignment |
@@ -645,7 +645,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.podAnnotations | string | `nil` |  |
 | clickhouse.podDistribution | string | `nil` |  |
 | clickhouse.client.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.client.image.tag | string | `"22.8.11.15"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.client.image.tag | string | `"23.4"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.client.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.client.image.pullSecrets | list | `[]` |  |
 | clickhouse.backup.enabled | bool | `false` |  |

--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -617,7 +617,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.secure | bool | `false` | Whether to use TLS connection connecting to ClickHouse |
 | clickhouse.verify | bool | `false` | Whether to verify TLS certificate on connection to ClickHouse |
 | clickhouse.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.image.tag | string | `"23.4"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.image.tag | string | `"23.4.2.11"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.image.pullSecrets | list | `[]` |  |
 | clickhouse.tolerations | list | `[]` | Toleration labels for clickhouse pod assignment |
@@ -645,7 +645,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | clickhouse.podAnnotations | string | `nil` |  |
 | clickhouse.podDistribution | string | `nil` |  |
 | clickhouse.client.image.repository | string | `"clickhouse/clickhouse-server"` | ClickHouse image repository. |
-| clickhouse.client.image.tag | string | `"23.4"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
+| clickhouse.client.image.tag | string | `"23.4.2.11"` | ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing. |
 | clickhouse.client.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | clickhouse.client.image.pullSecrets | list | `[]` |  |
 | clickhouse.backup.enabled | bool | `false` |  |

--- a/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
@@ -30,7 +30,7 @@ should match the snapshot when backup is true:
                   value: backup
                 - name: BACKUP_PASSWORD
                   value: backup_password
-                image: clickhouse/clickhouse-server:22.8.11.15
+                image: clickhouse/clickhouse-server:23.4
                 imagePullPolicy: IfNotPresent
                 name: run-backup-cron
                 volumeMounts:

--- a/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-backup-cronjob.yaml.snap
@@ -30,7 +30,7 @@ should match the snapshot when backup is true:
                   value: backup
                 - name: BACKUP_PASSWORD
                   value: backup_password
-                image: clickhouse/clickhouse-server:23.4
+                image: clickhouse/clickhouse-server:23.4.2.11
                 imagePullPolicy: IfNotPresent
                 name: run-backup-cron
                 volumeMounts:

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -75,7 +75,7 @@ the manifest should match the snapshot when using default values:
               - /bin/bash
               - -c
               - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-              image: clickhouse/clickhouse-server:23.4
+              image: clickhouse/clickhouse-server:23.4.2.11
               name: clickhouse
               ports:
               - containerPort: 8123

--- a/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/clickhouse-instance.yaml.snap
@@ -75,7 +75,7 @@ the manifest should match the snapshot when using default values:
               - /bin/bash
               - -c
               - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
-              image: clickhouse/clickhouse-server:22.8.11.15
+              image: clickhouse/clickhouse-server:23.4
               name: clickhouse
               ports:
               - containerPort: 8123

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -343,7 +343,7 @@ tests:
           count: 1
       - equal:
           path: spec.templates.podTemplates[0].spec.containers[0].image
-          value: "clickhouse/clickhouse-server:23.4"
+          value: "clickhouse/clickhouse-server:23.4.2.11"
 
   - it: allows modifying clickhouse-server version
     set:

--- a/charts/posthog/tests/clickhouse-instance.yaml
+++ b/charts/posthog/tests/clickhouse-instance.yaml
@@ -343,7 +343,7 @@ tests:
           count: 1
       - equal:
           path: spec.templates.podTemplates[0].spec.containers[0].image
-          value: "clickhouse/clickhouse-server:22.8.11.15"
+          value: "clickhouse/clickhouse-server:23.4"
 
   - it: allows modifying clickhouse-server version
     set:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1720,7 +1720,7 @@ clickhouse:
     # -- ClickHouse image repository.
     repository: clickhouse/clickhouse-server
     # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-    tag: "22.8.11.15"
+    tag: "23.4"
     # -- Image pull policy
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1845,7 +1845,7 @@ clickhouse:
       # -- ClickHouse image repository.
       repository: clickhouse/clickhouse-server
       # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-      tag: "22.8.11.15"
+      tag: "23.4"
       # -- Image pull policy
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1720,7 +1720,7 @@ clickhouse:
     # -- ClickHouse image repository.
     repository: clickhouse/clickhouse-server
     # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-    tag: "23.4"
+    tag: "23.4.2.11"
     # -- Image pull policy
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1845,7 +1845,7 @@ clickhouse:
       # -- ClickHouse image repository.
       repository: clickhouse/clickhouse-server
       # -- ClickHouse image tag. Note: PostHog does not support all versions of ClickHouse. Please override the default only if you know what you are doing.
-      tag: "23.4"
+      tag: "23.4.2.11"
       # -- Image pull policy
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -8,7 +8,7 @@ cloud: "local"
 
 clickhouse:
   image:
-    tag: 23.4-alpine
+    tag: 23.4.2.11-alpine
 """
 
 
@@ -18,4 +18,4 @@ def test_clickhouse_pod_image(kube):
 
     is_posthog_healthy(kube)
     pod_spec = get_clickhouse_pod_spec(kube)
-    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:23.4-alpine"
+    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:23.4.2.11-alpine"

--- a/ci/kubetest/test_clickhouse_different_image.py
+++ b/ci/kubetest/test_clickhouse_different_image.py
@@ -3,18 +3,12 @@ import pytest
 from helpers.clickhouse import get_clickhouse_pod_spec
 from helpers.utils import install_chart, is_posthog_healthy, wait_for_pods_to_be_ready
 
-# Setting a value for the tag here to 22.8.11.15-alpine
-# This version because it will be compatible going forward after we
-# require 22.3 for JSON Object datatype support
-# This tests to make sure that when specified clickhouse-operator
-# actually uses the image that you give it vs. some other tag that it
-# determines that it wants to pull.
 VALUES_WITH_DIFFERENT_CLICKHOUSE_IMAGE = """
 cloud: "local"
 
 clickhouse:
   image:
-    tag: 22.8.11.15-alpine
+    tag: 23.4-alpine
 """
 
 
@@ -24,4 +18,4 @@ def test_clickhouse_pod_image(kube):
 
     is_posthog_healthy(kube)
     pod_spec = get_clickhouse_pod_spec(kube)
-    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:22.8.11.15-alpine"
+    assert pod_spec.containers[0].image == "clickhouse/clickhouse-server:23.4-alpine"


### PR DESCRIPTION
## Description
We'd like to move to ClickHouse version 23.4.2.11 for a few reasons including lightweight deletes and other improvements. This sets the default to 23.4.2.11

We already are using 23.4.2.11 in local dev environments so this should be a very safe transition.

## Type of change
ClickHouse upgrade

## How has this been tested?

This has been running for everyone's local dev environment and in tests for some time

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
