### PR TITLE
feat: Add support for external replay redis

### DIFF
--- a/charts/posthog/templates/_helpers.tpl
+++ b/charts/posthog/templates/_helpers.tpl
@@ -92,6 +92,18 @@ Return the Redis host
 {{- end -}}
 
 {{/*
+Return the Session Recording Redis host
+*/}}
+{{- define "posthog.sessionRecordingRedis.host" -}}
+{{- if .Values.externalSessionRecordingRedis.host }}
+    {{- printf "%s" .Values.externalSessionRecordingRedis.host -}}
+{{- else -}}
+    {{ include "posthog.redis.host" . }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Return the Redis port
 */}}
 {{- define "posthog.redis.port" -}}
@@ -101,6 +113,20 @@ Return the Redis port
     {{- .Values.externalRedis.port | quote -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return the Session Recording Redis port
+*/}}
+{{- define "posthog.sessionRecordingRedis.port" -}}
+{{- if .Values.externalSessionRecordingRedis.port }}
+    {{- .Values.externalSessionRecordingRedis.port | quote -}}
+{{- else -}}
+    {{ include "posthog.redis.port" . }}
+{{- end -}}
+{{- end -}}
+
+
 
 {{/*
 Return true if a secret object for Redis should be created

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -122,7 +122,7 @@ spec:
         # Redis env variables
         {{- include "snippet.redis-env" .root | nindent 8 }}
 
-        # Session Recoridng Redis env variables
+        # Session Recording Redis env variables
         {{- include "snippet.session-recording-redis-env" .root | nindent 8 }}
 
         # statsd env variables

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -122,6 +122,9 @@ spec:
         # Redis env variables
         {{- include "snippet.redis-env" .root | nindent 8 }}
 
+        # Session Recoridng Redis env variables
+        {{- include "snippet.session-recording-redis-env" .root | nindent 8 }}
+
         # statsd env variables
         {{- include "snippet.statsd-env" .root | nindent 8 }}
 

--- a/charts/posthog/templates/_snippet-redis-env.tpl
+++ b/charts/posthog/templates/_snippet-redis-env.tpl
@@ -14,5 +14,12 @@
       name: {{ include "posthog.redis.secretName" . }}
       key: {{ include "posthog.redis.secretPasswordKey" . }}
 {{- end }}
+{{- end }}
 
+{{- define "snippet.session-recording-redis-env" }}
+- name: POSTHOG_SESSION_RECORDING_REDIS_HOST
+  value: {{ include "posthog.sessionRecordingRedis.host" . }}
+
+- name: POSTHOG_SESSION_RECORDING_REDIS_PORT
+  value: {{ include "posthog.sessionRecordingRedis.port" . }}
 {{- end }}

--- a/charts/posthog/tests/recordings-blob-ingestion-deployment.yaml
+++ b/charts/posthog/tests/recordings-blob-ingestion-deployment.yaml
@@ -194,3 +194,32 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SESSION_RECORDING_LOCAL_DIRECTORY
+
+  - it: sets dedicated external redis if set
+    template: templates/recordings-blob-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      externalSessionRecordingRedis.host: "dedicated-redis-host.com"
+      externalSessionRecordingRedis.port: 1234
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_SESSION_RECORDING_REDIS_HOST
+            value: dedicated-redis-host.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_SESSION_RECORDING_REDIS_PORT
+            value: 1234
+      # - contains:
+      #     path: spec.template.spec.containers[0].env
+      #     content:
+      #       name: POSTHOG_REDIS_HOST
+      #       value: "wat"
+      # - contains:
+      #     path: spec.template.spec.containers[0].env
+      #     content:
+      #       name: POSTHOG_REDIS_PORT
+      #       value: "wat"
+      

--- a/charts/posthog/tests/recordings-blob-ingestion-deployment.yaml
+++ b/charts/posthog/tests/recordings-blob-ingestion-deployment.yaml
@@ -199,6 +199,7 @@ tests:
     template: templates/recordings-blob-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsBlobIngestion.enabled: true
       externalSessionRecordingRedis.host: "dedicated-redis-host.com"
       externalSessionRecordingRedis.port: 1234
     asserts:
@@ -206,20 +207,36 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: POSTHOG_SESSION_RECORDING_REDIS_HOST
-            value: dedicated-redis-host.com
+            value: "dedicated-redis-host.com"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: POSTHOG_SESSION_RECORDING_REDIS_PORT
-            value: 1234
-      # - contains:
-      #     path: spec.template.spec.containers[0].env
-      #     content:
-      #       name: POSTHOG_REDIS_HOST
-      #       value: "wat"
-      # - contains:
-      #     path: spec.template.spec.containers[0].env
-      #     content:
-      #       name: POSTHOG_REDIS_PORT
-      #       value: "wat"
+            value: "1234"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_REDIS_HOST
+            value: RELEASE-NAME-posthog-redis-master
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_REDIS_PORT
+            value: "6379"
       
+  - it: uses default redis if not set
+    template: templates/recordings-blob-ingestion-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordingsBlobIngestion.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_SESSION_RECORDING_REDIS_HOST
+            value: RELEASE-NAME-posthog-redis-master
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTHOG_SESSION_RECORDING_REDIS_PORT
+            value: "6379"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1588,6 +1588,13 @@ externalRedis:
   # -- Name of the key pointing to the password in your Kubernetes secret.
   existingSecretPasswordKey: ""
 
+externalSessionRecordingRedis: {}
+  # -- External Redis host to use.
+  # host: ""
+  # -- External Redis port to use.
+  # port: 6379
+
+
 ###
 ###
 ### ---- KAFKA ----


### PR DESCRIPTION
## Description

For cloud we want to use a different external redis just for session recording. Kept it simple and added only host / port support

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
Tests

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
