### PR TITLE
add new recordings role for django

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.25.3
+version: 30.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/ingress.yaml
+++ b/charts/posthog/templates/ingress.yaml
@@ -139,12 +139,29 @@ spec:
             path: "/track"
             backend: *INGESTION
 
+          {{- if .Values.recordings.ingressEnabled}}
+          - pathType: Prefix
+            path: "/s/"
+            backend:
+              service:
+                name: {{ template "posthog.fullname" . }}-recordings
+                port:
+                  number: {{ .Values.service.externalPort }}
+          - pathType: Exact
+            path: "/s"
+            backend:
+              service:
+                name: {{ template "posthog.fullname" . }}-recordings
+                port:
+                  number: {{ .Values.service.externalPort }}
+          {{- else }}
           - pathType: Prefix
             path: "/s/"
             backend: *INGESTION
           - pathType: Exact
             path: "/s"
             backend: *INGESTION
+          {{- end }}
 
           {{- else }}
           - pathType: ImplementationSpecific

--- a/charts/posthog/templates/recordings-deployment.yaml
+++ b/charts/posthog/templates/recordings-deployment.yaml
@@ -1,0 +1,178 @@
+{{- if .Values.recordings.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "posthog.fullname" . }}-recordings
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: recordings
+  {{- if not .Values.recordings.hpa.enabled }}
+  replicas: {{ .Values.recordings.replicacount }}
+  {{- end }}
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.recordings.rollout.maxSurge }}
+      maxUnavailable: {{ .Values.recordings.rollout.maxUnavailable }}
+
+  template:
+    metadata:
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.web.podAnnotations }}
+{{ toYaml .Values.web.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "posthog.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: recordings
+        {{- if (eq (default .Values.image.tag "none") "latest") }}
+        date: "{{ now | unixEpoch }}"
+        {{- end }}
+        {{- if .Values.web.podLabels }}
+{{ toYaml .Values.web.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
+      serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+
+      {{- if .Values.web.affinity }}
+      affinity:
+{{ toYaml .Values.web.affinity | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.tolerations }}
+      tolerations:
+{{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.web.schedulerName }}
+      schedulerName: "{{ .Values.web.schedulerName }}"
+      {{- end }}
+
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+
+      # I do not know for sure if the old one has been used anywhere, so do both :(
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.recordings.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.recordings.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ .Chart.Name }}-recordings
+        image: {{ template "posthog.image.fullPath" . }}
+        command:
+          - ./bin/docker-server
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        # Expose the port on which Prometheus /metrics endpoint resides
+        - containerPort: 8001
+        env:
+        # Kafka env variables
+        {{- include "snippet.kafka-env" . | indent 8 }}
+
+        # Object Storage env variables
+        {{- include "snippet.objectstorage-env" . | indent 8 }}
+
+        # Redis env variables
+        {{- include "snippet.redis-env" . | indent 8 }}
+
+        # statsd env variables
+        {{- include "snippet.statsd-env" . | indent 8 }}
+
+        - name: DISABLE_SECURE_SSL_REDIRECT
+          value: '1'
+        - name: IS_BEHIND_PROXY
+          value: '1'
+      {{- if eq .Values.web.secureCookies false }}
+        - name: SECURE_COOKIES
+          value: '0'
+      {{- end }}
+        # PostHog app settings
+        {{- include "snippet.posthog-env" . | indent 8 }}
+        {{- include "snippet.posthog-sentry-env" . | indent 8 }}
+        - name: PRIMARY_DB
+          value: clickhouse
+        {{- include "snippet.postgresql-env" . | nindent 8 }}
+        {{- include "snippet.clickhouse-env" . | nindent 8 }}
+        {{- include "snippet.email-env" . | nindent 8 }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
+{{- if .Values.recordings.env }}
+{{ toYaml .Values.recordings.env | indent 8 }}
+{{- else if .Values.web.env }}
+{{ toYaml .Values.web.env | indent 8 }}
+{{- end }}
+
+        {{- include "snippet.web-deployments.lifecycle" . | nindent 8 }}
+
+        livenessProbe:
+          httpGet:
+            path: /_livez
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            # For readiness, we want to use the checks specific to the events
+            # role, which may be a subset of all the apps dependencies
+            path: /_readyz?role=events
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+        startupProbe:
+          httpGet:
+            # Now that capture's only external dependency is Kafka, let's use the
+            # reduced readiness check as its startupProbe. This means that we can
+            # deploy new configs / versions even when Postgres and Redis are down.
+            path: /_readyz?role=events
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.web.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.startupProbe.timeoutSeconds }}
+        resources:
+        {{ if not .Values.recordings.resources }}
+{{ toYaml .Values.web.resources | indent 12 }}
+        {{ else }}
+{{ toYaml .Values.recordings.resources | indent 12 }}
+        {{ end }}
+        {{- if .Values.recordings.securityContext.enabled }}
+        securityContext: {{- omit .Values.recordings.securityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+      initContainers:
+      {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
+      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
+{{- end }}

--- a/charts/posthog/templates/recordings-hpa.yaml
+++ b/charts/posthog/templates/recordings-hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.recordings.enabled .Values.recordings.hpa.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "posthog.fullname" . }}-recordings
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "posthog.fullname" . }}-recordings
+  minReplicas: {{ .Values.recordings.hpa.minpods }}
+  maxReplicas: {{ .Values.recordings.hpa.maxpods }}
+  metrics:
+  {{- with .Values.recordings.hpa.cputhreshold }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  behavior: 
+    {{ toYaml .Values.recordings.hpa.behavior | nindent 4 }}
+{{- end }}

--- a/charts/posthog/templates/recordings-service.yaml
+++ b/charts/posthog/templates/recordings-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.recordings.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "posthog.fullname" . }}-recordings
+  annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
+   {{- range $key, $value := .Values.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
+  labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "posthog.fullname" . }}
+    role: recordings
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/posthog/tests/__snapshot__/ingress.yaml.snap
+++ b/charts/posthog/tests/__snapshot__/ingress.yaml.snap
@@ -1,3 +1,209 @@
+the "spec" path should match the snapshot when splitting decide traffic out:
+  1: |
+    rules:
+    - http:
+        paths:
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-web
+              port:
+                number: 8000
+          path: /
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /batch
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /capture/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /capture
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-decide
+              port:
+                number: 8000
+          path: /decide/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-decide
+              port:
+                number: 8000
+          path: /decide
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /e/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /e
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /engage/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /engage
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /track/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /track
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /s/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /s
+          pathType: Exact
+the "spec" path should match the snapshot when splitting recordings traffic out:
+  1: |
+    rules:
+    - http:
+        paths:
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-web
+              port:
+                number: 8000
+          path: /
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /batch
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /capture/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /capture
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /decide/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /decide
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /e/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /e
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /engage/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /engage
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /track/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-events
+              port:
+                number: 8000
+          path: /track
+          pathType: Exact
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-recordings
+              port:
+                number: 8000
+          path: /s/
+          pathType: Prefix
+        - backend:
+            service:
+              name: RELEASE-NAME-posthog-recordings
+              port:
+                number: 8000
+          path: /s
+          pathType: Exact
 the "spec" path should match the snapshot when using default values:
   1: |
     rules:

--- a/charts/posthog/tests/ingress.yaml
+++ b/charts/posthog/tests/ingress.yaml
@@ -33,6 +33,28 @@ tests:
           # metadata values linked to the chart version
           path: spec
 
+  - it: the "spec" path should match the snapshot when splitting decide traffic out
+    set:
+      decide.ingressEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchSnapshot:
+          # Unfortunately we can't match the whole manifest as there are few
+          # metadata values linked to the chart version
+          path: spec
+
+  - it: the "spec" path should match the snapshot when splitting recordings traffic out
+    set:
+      recordings.ingressEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchSnapshot:
+          # Unfortunately we can't match the whole manifest as there are few
+          # metadata values linked to the chart version
+          path: spec
+
   - it: AWS - 'metadata.annotations' should match the default values
     set:
       cloud: "aws"

--- a/charts/posthog/tests/recordings-deployment.yaml
+++ b/charts/posthog/tests/recordings-deployment.yaml
@@ -1,0 +1,252 @@
+suite: PostHog recordings deployment definition
+templates:
+  - templates/recordings-deployment.yaml
+  - templates/secrets.yaml
+
+tests:
+  - it: should be empty if recordings.enabled is set to false
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have the correct apiVersion
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: should be the correct kind
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have a pod securityContext
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.podSecurityContext.enabled: true
+      recordings.podSecurityContext.runAsUser: 1001
+      recordings.podSecurityContext.fsGroup: 2000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should have a container securityContext
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.securityContext.enabled: true
+      recordings.securityContext.runAsUser: 1001
+      recordings.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not have a pod securityContext
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.podSecurityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.securityContext
+          value: 1001
+
+  - it: should not have a container securityContext
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.securityContext.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+
+  # NOTE: historically we have had the events pod use any resources specified
+  # for web. However, we would like to separate the connection and allow them to
+  # be set independently, while maintaining backwards compat. for installs that
+  # are setting the web resources.
+  - it: should set resources when specified
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      recordings:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: for backwards compat. should use the web resources if specified
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      web:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: should set resources when specified and override web resource settings
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      recordings:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 16Gi
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+      web:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 6Gi
+          requests:
+            cpu: 2000m
+            memory: 6Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 1000m
+              memory: 16Gi
+            requests:
+              cpu: 4000m
+              memory: 16Gi
+
+  - it: sets SENTRY_DSN env var
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      sentryDSN: sentry.endpoint
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SENTRY_DSN
+            value: sentry.endpoint
+
+  - it: uses web.env if recordings.env is empty
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+        - name: FIRST
+          value: one
+      web:
+        env:
+          - name: SECOND
+            value: two
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FIRST
+            value: one
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SECOND
+            value: two
+
+  - it: ignores web.env if recordings.env is set
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      env:
+        - name: FIRST
+          value: one
+      web:
+        env:
+          - name: SECOND
+            value: two
+      recordings:
+        env:
+          - name: THIRD
+            value: three
+    asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: FIRST
+          value: one
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: THIRD
+          value: three
+    - notContains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: SECOND
+          value: two
+
+  - it: allows setting imagePullSecrets
+    template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      recordings.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value: [name: secret]

--- a/charts/posthog/tests/recordings-deployment.yaml
+++ b/charts/posthog/tests/recordings-deployment.yaml
@@ -17,6 +17,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -27,6 +28,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -37,6 +39,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       recordings.podSecurityContext.enabled: true
       recordings.podSecurityContext.runAsUser: 1001
       recordings.podSecurityContext.fsGroup: 2000
@@ -54,6 +57,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       recordings.securityContext.enabled: true
       recordings.securityContext.runAsUser: 1001
       recordings.securityContext.allowPrivilegeEscalation: false
@@ -71,6 +75,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       recordings.podSecurityContext.enabled: false
     asserts:
       - hasDocuments:
@@ -83,6 +88,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       recordings.securityContext.enabled: false
     asserts:
       - hasDocuments:
@@ -99,6 +105,7 @@ tests:
     set:
       cloud: local
       recordings:
+        enabled: true
         resources:
           limits:
             cpu: 1000m
@@ -121,6 +128,8 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local
+      recordings:
+        enabled: true
       web:
         resources:
           limits:
@@ -145,6 +154,7 @@ tests:
     set:
       cloud: local
       recordings:
+        enabled: true
         resources:
           limits:
             cpu: 1000m
@@ -175,6 +185,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       sentryDSN: sentry.endpoint
     asserts:
       - contains:
@@ -187,6 +198,7 @@ tests:
     template: templates/recordings-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
     set:
       cloud: local # TODO: remove once secrets.yaml will be fixed/removed
+      recordings.enabled: true
       env:
         - name: FIRST
           value: one
@@ -218,6 +230,7 @@ tests:
           - name: SECOND
             value: two
       recordings:
+        enabled: true
         env:
           - name: THIRD
             value: three

--- a/charts/posthog/tests/recordings-hpa.yaml
+++ b/charts/posthog/tests/recordings-hpa.yaml
@@ -1,0 +1,81 @@
+suite: PostHog recordings HPA definition
+templates:
+  - templates/recordings-hpa.yaml
+
+tests:
+  - it: should be empty if recordings.enabled and events.hpa.enabled are set to false
+    set:
+      recordings.enabled: false
+      recordings.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if recordings.enabled is true and recordings.hpa.enabled is set to false
+    set:
+      recordings.enabled: true
+      recordings.hpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if recordings.enabled and recordings.hpa.enabled are set to true
+    set:
+      recordings.enabled: true
+      recordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    set:
+      recordings.enabled: true
+      recordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: autoscaling/v2
+
+  - it: should be the correct kind
+    set:
+      recordings.enabled: true
+      recordings.hpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+
+  - it: sets hpa spec
+    set:
+      recordings.enabled: true
+      recordings:
+        hpa:
+          enabled: true
+          minpods: 2
+          maxpods: 10
+          cputhreshold: 70
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 3600
+    asserts:
+      - equal:
+          path: spec
+          value:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: RELEASE-NAME-posthog-recordings
+            minReplicas: 2
+            maxReplicas: 10
+            metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 70
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 3600

--- a/charts/posthog/tests/recordings-hpa.yaml
+++ b/charts/posthog/tests/recordings-hpa.yaml
@@ -3,7 +3,7 @@ templates:
   - templates/recordings-hpa.yaml
 
 tests:
-  - it: should be empty if recordings.enabled and events.hpa.enabled are set to false
+  - it: should be empty if recordings.enabled and recordings.hpa.enabled are set to false
     set:
       recordings.enabled: false
       recordings.hpa.enabled: false

--- a/charts/posthog/tests/recordings-service.yaml
+++ b/charts/posthog/tests/recordings-service.yaml
@@ -1,0 +1,30 @@
+suite: PostHog recordings service definition
+templates:
+  - templates/recordings-service.yaml
+
+tests:
+  - it: should be empty if recordings.enabled is set to false
+    set:
+      recordings.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be not empty if recordings.enabled is set to true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should have the correct apiVersion
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: v1
+
+  - it: should be the correct kind
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service

--- a/charts/posthog/tests/recordings-service.yaml
+++ b/charts/posthog/tests/recordings-service.yaml
@@ -11,11 +11,15 @@ tests:
           count: 0
 
   - it: should be not empty if recordings.enabled is set to true
+    set:
+      recordings.enabled: true
     asserts:
       - hasDocuments:
           count: 1
 
   - it: should have the correct apiVersion
+    set:
+      recordings.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -23,6 +27,8 @@ tests:
           of: v1
 
   - it: should be the correct kind
+    set:
+      recordings.enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -91,6 +91,8 @@ events:
 recordings:
   # -- Whether to install the PostHog recordings stack or not.
   enabled: false
+  # -- Whether to route /s traffic to the recordings stack instead of the events stack
+  ingressEnabled: false
 
   # -- Count of recordings pods to run. This setting is ignored if `recordings.hpa.enabled` is set to `true`.
   replicacount: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -90,7 +90,7 @@ events:
 
 recordings:
   # -- Whether to install the PostHog recordings stack or not.
-  enabled: true
+  enabled: false
 
   # -- Count of recordings pods to run. This setting is ignored if `recordings.hpa.enabled` is set to `true`.
   replicacount: 1

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -88,6 +88,43 @@ events:
   podSecurityContext:
     enabled: false
 
+recordings:
+  # -- Whether to install the PostHog recordings stack or not.
+  enabled: true
+
+  # -- Count of recordings pods to run. This setting is ignored if `recordings.hpa.enabled` is set to `true`.
+  replicacount: 1
+
+  hpa:
+    # -- Whether to create a HorizontalPodAutoscaler for the recordings stack.
+    enabled: false
+    # -- CPU threshold percent for the recordings stack HorizontalPodAutoscaler.
+    cputhreshold: 60
+    # -- Min pods for the recordings stack HorizontalPodAutoscaler.
+    minpods: 1
+    # -- Max pods for the recordings stack HorizontalPodAutoscaler.
+    maxpods: 10
+    # -- Set the HPA behavior. See
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    # for configuration options
+    behavior:
+
+  rollout:
+    # The max surge in pods during a rollout
+    maxSurge: 25%
+    # The max unavailable during a rollout
+    maxUnavailable: 25%
+
+  # -- Additional env variables to inject into the recordings stack, uses `web.env` if empty.
+  env: []
+
+  # -- Container security context for the recordings stack HorizontalPodAutoscaler.
+  securityContext:
+    enabled: false
+  # -- Pod security context for the recordings stack HorizontalPodAutoscaler.
+  podSecurityContext:
+    enabled: false
+
 decide:
   # -- Whether to install the PostHog decide stack or not.
   enabled: false


### PR DESCRIPTION
## Description

We want to isolate failures between `/s` and `/e`, by running them in separate resource pools.

This PR:
- copies the specs and tests of the `events` deploy into a `recordings` deploy.
- adds the `recordings.ingressEnabled` value to route `/s` to the new deploy, mirroring how we implemented the decide split
- updates the kubetest values to avoid flakes caused by resource limits

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
