### PR TITLE
fix(plugin-server): use /_health for liveness

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.25.1
+version: 30.25.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -138,10 +138,10 @@ spec:
         {{- toYaml .params.env | nindent 8 }}
         {{- end }}
         livenessProbe:
-          exec:
-            command:
-              # Just check that we can at least exec to the container
-              - "true"
+          httpGet:
+            path: /_health
+            port: 6738
+            scheme: HTTP
           failureThreshold: {{ .params.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .params.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .params.livenessProbe.periodSeconds }}
@@ -150,7 +150,7 @@ spec:
         readinessProbe:
           failureThreshold: {{ .params.readinessProbe.failureThreshold }}
           httpGet:
-            path: /_health
+            path: /_ready
             port: 6738
             scheme: HTTP
           initialDelaySeconds: {{ .params.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
We were just using exec and `true` command before, but maybe this will
kill pods if they stop consuming on e.g. `exports`.

Has the potential to cause more issues than it solves without some 
tuning, but we could give it a go.

@danielxnj where do I make changes in the other chart?

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
