### PR TITLE
Revert "fix(plugin-server): use /_health for liveness"

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.25.2
+version: 30.25.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.25.1
+version: 30.25.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -138,10 +138,10 @@ spec:
         {{- toYaml .params.env | nindent 8 }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /_health
-            port: 6738
-            scheme: HTTP
+          exec:
+            command:
+              # Just check that we can at least exec to the container
+              - "true"
           failureThreshold: {{ .params.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .params.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .params.livenessProbe.periodSeconds }}
@@ -150,7 +150,7 @@ spec:
         readinessProbe:
           failureThreshold: {{ .params.readinessProbe.failureThreshold }}
           httpGet:
-            path: /_ready
+            path: /_health
             port: 6738
             scheme: HTTP
           initialDelaySeconds: {{ .params.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
Reverts PostHog/charts-clickhouse#755

Switching back while checking _health endpoint on various endpoints.