### PR TITLE
feat: add service account to backup cronjob

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.27.1
+version: 30.27.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/clickhouse-backup-cronjob.yaml
+++ b/charts/posthog/templates/clickhouse-backup-cronjob.yaml
@@ -16,6 +16,8 @@ spec:
           labels:
             job: clickhouse-backup
         spec:
+          serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+          
           {{- if or .Values.busybox.pullSecrets .Values.clickhouse.backup.image.pullSecrets }}
           imagePullSecrets:
             {{- if .Values.busybox.pullSecrets }}


### PR DESCRIPTION
## Description

The service account is needed during the backup process to allow automatic authentication and authorization in public clouds like AWS, GCP or Azure. e.g.: to use workload identity in GKE. This fix avoids mounting secrets with credentials to access to public clouds.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Deployed in a local environment.

```
$ helm template demo \
  --dependency-update \
  --namespace default \
  ./charts/posthog/          
```

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
