### PR TITLE
open port 8596 on temporal workers for prom metrics

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.27.2
+version: 30.27.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/temporal-py-worker-deployment.yaml
+++ b/charts/posthog/templates/temporal-py-worker-deployment.yaml
@@ -76,9 +76,11 @@ spec:
       securityContext: {{- omit .Values.temporalPyWorker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-temporal-py-workers
+      - name: {{ .Chart.Name }}-temporal-py-worker
         image: {{ template "posthog.image.fullPath" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 8596
         command:
         - ./bin/temporal-django-worker
         env:


### PR DESCRIPTION
## Description

Sibling PR to https://github.com/PostHog/posthog/pull/16803, to allow scraping internal metrics of the temporal workers.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
