### PR TITLE
Support readiness gates on web/events/recordings deployments

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.28.0
+version: 30.29.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -61,6 +61,11 @@ spec:
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}
 
+      {{- if .Values.events.readinessGates }}
+      readinessGates:
+{{ toYaml .Values.events.readinessGates | indent 8}}
+      {{- end }}
+
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}

--- a/charts/posthog/templates/recordings-deployment.yaml
+++ b/charts/posthog/templates/recordings-deployment.yaml
@@ -61,6 +61,11 @@ spec:
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}
 
+      {{- if .Values.recordings.readinessGates }}
+      readinessGates:
+{{ toYaml .Values.recordings.readinessGates | indent 8}}
+      {{- end }}
+
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -61,6 +61,11 @@ spec:
       schedulerName: "{{ .Values.web.schedulerName }}"
       {{- end }}
 
+      {{- if .Values.web.readinessGates }}
+      readinessGates:
+{{ toYaml .Values.web.readinessGates | indent 8}}
+      {{- end }}
+
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}

--- a/charts/posthog/tests/events-deployment.yaml
+++ b/charts/posthog/tests/events-deployment.yaml
@@ -251,5 +251,21 @@ tests:
           path: spec.template.spec.imagePullSecrets
           value: [name: secret]
 
+  - it: allows setting readinessGates
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      events.enabled: true
+      events:
+        readinessGates:
+          - conditionType: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_events_8000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_events_8000
+
 
 

--- a/charts/posthog/tests/recordings-deployment.yaml
+++ b/charts/posthog/tests/recordings-deployment.yaml
@@ -263,3 +263,19 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets
           value: [name: secret]
+
+  - it: allows setting readinessGates
+    template: templates/events-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      recordings.enabled: true
+      recordings:
+        readinessGates:
+          - conditionType: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_recordings_8000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_recordings_8000

--- a/charts/posthog/tests/web-deployment.yaml
+++ b/charts/posthog/tests/web-deployment.yaml
@@ -167,3 +167,31 @@ tests:
           content:
             name: POSTHOG_POSTGRES_READ_HOST
             value: beep-boop
+
+  - it: allows setting readinessGates
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      web.enabled: true
+      web:
+        readinessGates:
+          - conditionType: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_web_8000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.alb.ingress.k8s.aws/posthog_ingress_posthog_web_8000
+
+  - it: has no default readinessGates
+    template: templates/web-deployment.yaml # TODO: remove once secrets.yaml will be fixed/removed
+    set:
+      cloud: local
+      image.pullSecrets: [secret]
+      web.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isEmpty:
+          path: spec.template.spec.readinessGates


### PR DESCRIPTION
## Description
add "readinessGates" to web deployments so we can use the ALB controller readiness gates: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v1.1/guide/ingress/pod-conditions/

This means during rollouts we will always ensure the new pods are in the load balancer before terminating the old pods

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?
The features are behind `.Values` checks, we will roll out in dev first

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
