### PR TITLE
Don't wait for migrations for capture pods

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.31.0
+version: 30.32.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -105,6 +105,8 @@ spec:
           value: '1'
         - name: IS_BEHIND_PROXY
           value: '1'
+        - name: POSTHOG_SKIP_MIGRATION_CHECKS
+          value: 'true'
       {{- if eq .Values.web.secureCookies false }}
         - name: SECURE_COOKIES
           value: '0'
@@ -174,5 +176,4 @@ spec:
         {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
-      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/templates/recordings-deployment.yaml
+++ b/charts/posthog/templates/recordings-deployment.yaml
@@ -105,6 +105,8 @@ spec:
           value: '1'
         - name: IS_BEHIND_PROXY
           value: '1'
+        - name: POSTHOG_SKIP_MIGRATION_CHECKS
+          value: 'true'
       {{- if eq .Values.web.secureCookies false }}
         - name: SECURE_COOKIES
           value: '0'
@@ -174,5 +176,4 @@ spec:
         {{- end }}
       initContainers:
       {{- include "_snippet-initContainers-wait-for-service-dependencies" . | indent 8 }}
-      {{- include "_snippet-initContainers-wait-for-migrations" . | indent 8 }}
 {{- end }}

--- a/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
+++ b/charts/posthog/tests/_initContainers-wait-for-migrations.yaml
@@ -1,6 +1,5 @@
 suite: _initContainers-wait-for-migrations
 templates:
-  - templates/events-deployment.yaml
   - templates/plugins-deployment.yaml
   - templates/web-deployment.yaml
   - templates/worker-deployment.yaml
@@ -10,7 +9,6 @@ templates:
 tests:
   - it: spec.template.spec.initContainers[1].env override via 'env' should work
     templates: # TODO: remove once secrets.yaml will be fixed/removed
-      - templates/events-deployment.yaml
       - templates/plugins-deployment.yaml
       - templates/web-deployment.yaml
       - templates/worker-deployment.yaml

--- a/ci/kubetest/helpers/utils.py
+++ b/ci/kubetest/helpers/utils.py
@@ -117,11 +117,12 @@ def wait_for_pods_to_be_ready(kube, labels=None, expected_count=None, namespace=
         job_pods = [pod for pod in pods.values() if "job-name" in pod.obj.metadata.labels]
 
         for job_pod in job_pods:
-            print("job logs")
-            try:
-                print([c.get_logs() for c in job_pod.get_containers()])
-            except Exception:
-                pass
+            if job_pod.status().phase == "Failed":
+                try:
+                    print("Job failure logs:")
+                    print("\n".join([c.get_logs() for c in job_pod.get_containers()]))
+                except Exception:
+                    pass
             print("job logs2")
             assert job_pod.status().phase != "Failed", f"Detected failed job {job_pod.obj.metadata.name}"
 


### PR DESCRIPTION

## Description
These pods don't care about migrations and waiting for them slows down scaling and deployments

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
