### PR TITLE
Default to latest tag as we no longer push releases

### DIFF
--- a/charts/posthog/ALL_VALUES.md
+++ b/charts/posthog/ALL_VALUES.md
@@ -16,7 +16,7 @@ The following table lists the configurable parameters of the PostHog chart and t
 | image.repository | string | `"posthog/posthog"` | PostHog image repository to use. |
 | image.sha | string | `nil` | PostHog image SHA to use (example: `sha256:20af35fca6756d689d6705911a49dd6f2f6631e001ad43377b605cfc7c133eb4`). |
 | image.tag | string | `nil` | PostHog image tag to use (example: `release-1.43.0`). |
-| image.default | string | `":release-1.43.0"` | PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead. |
+| image.default | string | `":latest"` | PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead. |
 | image.pullPolicy | string | `"IfNotPresent"` | PostHog image pull policy. |
 | image.pullSecrets | list | `[]` |  |
 | sentryDSN | string | `nil` | Sentry endpoint to send errors to. |

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -16,9 +16,9 @@ image:
   # -- PostHog image tag to use (example: `release-1.43.0`).
   tag:
   # -- PostHog default image. Do not overwrite, use `image.sha` or `image.tag` instead.
-  default: ":release-1.43.0"
+  default: ":latest"
   # -- PostHog image pull policy.
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION

## Description
We haven't cut an image release in 5 months, switch default image to latest

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
