### PR TITLE
Add topology spread constraint snippet to all deployments

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.32.0
+version: 30.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/_snippet-plugins-deployment.tpl
+++ b/charts/posthog/templates/_snippet-plugins-deployment.tpl
@@ -44,6 +44,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "posthog.serviceAccountName" .root }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .params.affinity }}
       affinity:

--- a/charts/posthog/templates/_snippet-topologySpreadConstraints.tpl
+++ b/charts/posthog/templates/_snippet-topologySpreadConstraints.tpl
@@ -1,0 +1,36 @@
+{{/* Common topologySpreadConstraints definition */}}
+{{/*
+  matchLabelsKeys are the set of unique pod labels for which the constraints are applied
+  any missing labels are ignored.
+
+  pod-template-hash is added automatically by deployments and is unique for each rollout.
+  Including this means we don't get out of sync on rollouts as it ignores the locations
+  of existing pods that will be terminated after the rollout is finished.
+   */}}
+{{- define "_snippet-selectors" -}}
+labelSelector:
+  matchLabels: {}
+matchLabelKeys:
+- pod-template-hash
+- app
+- release
+- role
+- app.kubernetes.io/name
+- app.kubernetes.io/instance
+{{- end }}
+{{- define "_snippet-topologySpreadConstraints" }}
+{{- if .Values.includeDefaultTopologySpreadConstraints }}
+topologySpreadConstraints:
+- maxSkew: 1
+  minDomains: 3
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: DoNotSchedule
+  nodeTaintsPolicy: Honor
+  {{- include "_snippet-selectors" . | nindent 2 }}
+- maxSkew: 3
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+  nodeTaintsPolicy: Honor
+  {{- include "_snippet-selectors" . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/posthog/templates/decide-deployment.yaml
+++ b/charts/posthog/templates/decide-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.web.affinity }}
       affinity:

--- a/charts/posthog/templates/events-deployment.yaml
+++ b/charts/posthog/templates/events-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.web.affinity }}
       affinity:

--- a/charts/posthog/templates/pgbouncer-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-deployment.yaml
@@ -42,6 +42,7 @@ spec:
       terminationGracePeriodSeconds: 65
 
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.pgbouncer.affinity }}
       affinity: {{ toYaml .Values.pgbouncer.affinity | nindent 8 }}

--- a/charts/posthog/templates/pgbouncer-read-deployment.yaml
+++ b/charts/posthog/templates/pgbouncer-read-deployment.yaml
@@ -42,6 +42,7 @@ spec:
       terminationGracePeriodSeconds: 65
 
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.pgbouncerRead.affinity }}
       affinity: {{ toYaml .Values.pgbouncerRead.affinity | nindent 8 }}

--- a/charts/posthog/templates/recordings-deployment.yaml
+++ b/charts/posthog/templates/recordings-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.web.affinity }}
       affinity:

--- a/charts/posthog/templates/temporal-py-worker-deployment.yaml
+++ b/charts/posthog/templates/temporal-py-worker-deployment.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ .Values.temporalPyWorker.terminationGracePeriodSeconds }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.temporalPyWorker.affinity }}
       affinity:

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ include "snippet.web-deployments.terminationGracePeriodSeconds" . }}
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.web.affinity }}
       affinity:

--- a/charts/posthog/templates/worker-deployment.yaml
+++ b/charts/posthog/templates/worker-deployment.yaml
@@ -40,6 +40,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "posthog.serviceAccountName" . }}
+      {{- include "_snippet-topologySpreadConstraints" . | nindent 6 }}
 
       {{- if .Values.worker.affinity }}
       affinity:

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -3396,3 +3396,8 @@ busybox:
 
 # -- Kubernetes cluster domain name
 clusterDomain: cluster.local
+
+# Whether to set a topologySpreadConstraint on all deployments
+# to balance pods between availability zones and nodes
+includeDefaultTopologySpreadConstraints: false
+


### PR DESCRIPTION
## Description
Include a new "topologySpreadConstraint" snippet to all deployments

By default it won't be included, but if you set .Values.includeDefaultTopologySpreadConstraints it will add a [topologySpreadConstraint](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to all deployments to balance pods between availability zones and hosts

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
