### PR TITLE
Perform _pgbouncer testing as needed

### DIFF
--- a/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
+++ b/charts/posthog/templates/_snippet-initContainers-wait-for-service-dependencies.tpl
@@ -21,12 +21,14 @@
             echo "waiting for all ClickHouse nodes to be available"; sleep 1;
         done
         {{ end }}
-
+        
+        {{ if .Values._pgbouncer.enabled }}
         until (nc -vz "{{- default (printf "%s-pgbouncer" (include "posthog.fullname" .)) .Values.pgbouncer.fqdn -}}" {{ include "posthog.pgbouncer.port" . }});
         do
             echo "waiting for PgBouncer"; sleep 1;
         done
-
+        {{ end }}
+        
         {{ if .Values.postgresql.enabled }}
         until (nc -vz "{{ include "posthog.postgresql.host" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" {{ include "posthog.postgresql.port" . }});
         do


### PR DESCRIPTION
## Description
when '_pgbouncer.enable=false', the wait-for-service-dependencies container does not need to do a survival check on pgbouncer

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
local test

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
