### PR TITLE
Add argo canary trafficrouting

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.42.0
+version: 30.43.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/web-deployment.yaml
+++ b/charts/posthog/templates/web-deployment.yaml
@@ -23,6 +23,11 @@ spec:
       maxUnavailable: {{ .Values.web.rollout.maxUnavailable }}
     {{- else if eq .Values.web.deployment.strategy "canary" }}
     canary:
+      plugins:
+        argoproj-labs/contour:
+          httpProxies:
+          - proxy
+          - proxy-direct
       steps:
       - setWeight: 1
       - pause: {duration: 60s}


### PR DESCRIPTION
## Description
Add trafficrouting plugin settings to canary deploys

This allows the canary to integrate with contour to properly set % weights on canaries

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
