### PR TITLE
chore: Make Celery Queue Depth page less

### DIFF
--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -2528,12 +2528,12 @@ prometheus:
 
             - alert: CeleryQueueDepth
               expr: (max (posthog_celery_queue_depth)) > 1000
-              for: 10m
+              for: 60m
               labels:
                 rotation: common
                 severity: critical
               annotations:
-                summary: Celery job execution delayed for more than 10 minutes.
+                summary: Celery job execution delayed for more than 60 minutes.
                 description: |
                   The Celery jobs queue (stored in Redis) is filling up faster than it is consumed. This impacts our
                   monitoring, as some paging monitors depend on metrics exported by Celery jobs.


### PR DESCRIPTION
companion to https://github.com/PostHog/charts/pull/773

We've been paging for this daily for more than 10 days. In all of those cases there hasn't been any action and it resolves itself. This creates alert fatigue, so let's make the alert less sensitive. We can additionally add a non-paging alert, if this is deemed useful.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
