### PR TITLE
(FIX) Fix unwanted space when pushing annotations to service

### DIFF
--- a/charts/posthog/Chart.yaml
+++ b/charts/posthog/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 30.46.0
+version: 30.47.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/posthog/templates/events-service.yaml
+++ b/charts/posthog/templates/events-service.yaml
@@ -4,9 +4,9 @@ kind: Service
 metadata:
   name: {{ template "posthog.fullname" . }}-events
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
-   {{- range $key, $value := .Values.service.annotations }}
-     {{ $key }}: {{ $value | quote }}
-   {{- end }}
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/posthog/templates/web-service.yaml
+++ b/charts/posthog/templates/web-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "_snippet-metadata-labels-common" . | nindent 4 }}
   annotations: {{- include "_snippet-metadata-annotations-common" . | nindent 4 }}
   {{- if .Values.service.annotations }}
-  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{ toYaml .Values.service.annotations | indent 2 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
## Description
Currently if we enable "service: annotations:" annotations are template with wrong indentation and display this error.
```Error: YAML parse error on posthog/templates/events-service.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key```
After fixing it (a bad space on the range declaration) we observed 
```Error: YAML parse error on posthog/templates/web-service.yaml: error converting YAML to JSON: yaml: line 14: did not find expected key```
And in fact the indentation isn't ok.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?
* Download chart locally
* ```helmfile template``` without changing the templates folder
* Updating events and web service
* ```helmfile template``` doesn't return any yaml error