### PR TITLE
feat: add SASL configuration support for externalKafka

### DIFF
--- a/charts/posthog/templates/_kafka.tpl
+++ b/charts/posthog/templates/_kafka.tpl
@@ -53,9 +53,36 @@
 - name: SESSION_RECORDING_KAFKA_HOSTS
   value: {{ ( include "posthog.sessionRecordingKafka.brokers" . ) }}
 
-{{- if and (not .Values.kafka.enabled) .Values.externalKafka.tls }}
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.tls (not .Values.externalKafka.securityProtocol) }}
 - name: KAFKA_SECURITY_PROTOCOL
   value: SSL
+{{- end }}
+
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.securityProtocol }}
+- name: KAFKA_SECURITY_PROTOCOL
+  value: {{ .Values.externalKafka.securityProtocol | quote }}
+{{- end }}
+
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.saslMechanism }}
+- name: KAFKA_SASL_MECHANISM
+  value: {{ .Values.externalKafka.saslMechanism | quote }}
+{{- end }}
+
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.saslUser }}
+- name: KAFKA_SASL_USER
+  value: {{ .Values.externalKafka.saslUser | quote }}
+{{- end }}
+
+{{- if and (not .Values.kafka.enabled) (or .Values.externalKafka.saslPassword .Values.externalKafka.existingSecret) }}
+- name: KAFKA_SASL_PASSWORD
+{{- if .Values.externalKafka.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.existingSecret }}
+      key: {{ .Values.externalKafka.existingSecretPasswordKey | default "password" }}
+{{- else }}
+  value: {{ .Values.externalKafka.saslPassword | quote }}
+{{- end }}
 {{- end }}
 
 {{- if and (not .Values.kafka.enabled) .Values.externalSessionRecordingKafka.tls }}

--- a/charts/posthog/tests/kafka-settings.yaml
+++ b/charts/posthog/tests/kafka-settings.yaml
@@ -194,3 +194,84 @@ tests:
           content:
             name: SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL
             value: SSL
+
+  # Tests for Issue #595: SASL configuration support
+  - it: should set SASL configuration when externalKafka SASL is configured
+    templates:
+      - templates/web-deployment.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:9092
+        securityProtocol: SASL_SSL
+        saslMechanism: SCRAM-SHA-512
+        saslUser: myuser
+        saslPassword: mypassword
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SASL_SSL
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SASL_MECHANISM
+            value: SCRAM-SHA-512
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SASL_USER
+            value: myuser
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SASL_PASSWORD
+            value: mypassword
+
+  - it: should use existingSecret for SASL password when configured
+    templates:
+      - templates/web-deployment.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:9092
+        securityProtocol: SASL_SSL
+        saslMechanism: SCRAM-SHA-512
+        saslUser: myuser
+        existingSecret: my-kafka-secret
+        existingSecretPasswordKey: kafka-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SASL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-kafka-secret
+                key: kafka-password
+
+  - it: should use securityProtocol over legacy tls setting when both are set
+    templates:
+      - templates/web-deployment.yaml
+    set:
+      cloud: local
+      kafka:
+        enabled: false
+      externalKafka:
+        brokers:
+          - broker1:9092
+        tls: true
+        securityProtocol: SASL_PLAINTEXT
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KAFKA_SECURITY_PROTOCOL
+            value: SASL_PLAINTEXT

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1710,6 +1710,18 @@ externalKafka:
   brokers: []
   # - Use TLS to connect to the external kafka cluster
   tls: false
+  # -- Kafka security protocol. Options: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
+  securityProtocol: ""
+  # -- SASL mechanism for authentication. Options: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+  saslMechanism: ""
+  # -- SASL username for authentication
+  saslUser: ""
+  # -- SASL password for authentication. Either this or `externalKafka.existingSecret` must be set.
+  saslPassword: ""
+  # -- Name of an existing Kubernetes secret containing the SASL password
+  existingSecret: ""
+  # -- Key in the existing secret that contains the SASL password
+  existingSecretPasswordKey: "password"
 
 externalSessionRecordingKafka:
   # - External Kafka brokers for session recordings. Ignored if `kafka.enabled` is set to `true`. Multiple brokers can be provided as array/list.


### PR DESCRIPTION
## Summary
Fixes #595

Added support for SASL authentication when connecting to external Kafka clusters.

---

## Files Changed

### charts/posthog/values.yaml
Added 6 new settings under externalKafka section:
- securityProtocol: Kafka security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
- saslMechanism: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
- saslUser: SASL username
- saslPassword: SASL password (direct value)
- existingSecret: Name of Kubernetes secret containing SASL password
- existingSecretPasswordKey: Key in the secret for password

### charts/posthog/templates/_kafka.tpl
Added environment variable support for SASL settings:
- KAFKA_SECURITY_PROTOCOL
- KAFKA_SASL_MECHANISM
- KAFKA_SASL_USER
- KAFKA_SASL_PASSWORD (supports both direct value and secretKeyRef)

### charts/posthog/tests/kafka-settings.yaml
Added 3 test cases:
- should set SASL configuration when externalKafka SASL is configured
- should use existingSecret for SASL password when configured
- should use securityProtocol over legacy tls setting when both are set

---

## Considerations

1. Backwards compatible: All new settings have empty defaults
2. Legacy tls setting still works when securityProtocol is not set
3. securityProtocol takes precedence over tls when both are set
4. Password can be provided directly or via Kubernetes secret
5. Verified env variable names against PostHog backend source code

---

## Testing

- All 10 kafka-settings tests pass
- Verified with helm template that environment variables render correctly
- Verified backwards compatibility with existing tls setting

---

## Example Usage

```yaml
kafka:
  enabled: false

externalKafka:
  brokers:
    - kafka.example.com:9092
  securityProtocol: SASL_SSL
  saslMechanism: SCRAM-SHA-512
  saslUser: myuser
  existingSecret: my-kafka-secret
  existingSecretPasswordKey: password
```