### PR TITLE
feat: make clickhouse log level configurable

### DIFF
--- a/charts/posthog/templates/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/templates/clickhouse-operator/configmap.yaml
@@ -276,7 +276,7 @@ data:
     <yandex>
         <logger>
             <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
-            <level>debug</level>
+            <level>{{ .Values.clickhouse.logLevel | default "information" }}</level>
             <log>/var/log/clickhouse-server/clickhouse-server.log</log>
             <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
             <size>1000M</size>

--- a/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
+++ b/charts/posthog/tests/clickhouse-operator/__snapshot__/configmap.yaml.snap
@@ -247,7 +247,7 @@ the manifest should match the snapshot when using default values:
         <yandex>
             <logger>
                 <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
-                <level>debug</level>
+                <level>information</level>
                 <log>/var/log/clickhouse-server/clickhouse-server.log</log>
                 <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
                 <size>1000M</size>

--- a/charts/posthog/tests/clickhouse-operator/configmap.yaml
+++ b/charts/posthog/tests/clickhouse-operator/configmap.yaml
@@ -175,3 +175,20 @@ tests:
             labels:
               app: clickhouse-operator
               clickhouse.altinity.com/chop: 0.18.4
+
+  # Tests for Issue #640: ClickHouse log level configuration
+  - it: should use default log level (information) when not specified
+    documentIndex: 2
+    asserts:
+      - matchRegex:
+          path: data["01-clickhouse-02-logger.xml"]
+          pattern: "<level>information</level>"
+
+  - it: should allow configuring clickhouse log level
+    set:
+      clickhouse.logLevel: "warning"
+    documentIndex: 2
+    asserts:
+      - matchRegex:
+          path: data["01-clickhouse-02-logger.xml"]
+          pattern: "<level>warning</level>"

--- a/charts/posthog/values.yaml
+++ b/charts/posthog/values.yaml
@@ -1792,6 +1792,8 @@ clickhouse:
   secure: false
   # -- Whether to verify TLS certificate on connection to ClickHouse
   verify: false
+  # -- ClickHouse server log level. Options: trace, debug, information, warning, error
+  logLevel: "information"
   # -- List of external Zookeeper servers to use.
   # externalZookeeper:
   #   servers:


### PR DESCRIPTION
Fixes #640

Hardcoded ClickHouse log level 'debug' caused excessive logs and storage costs.
Made it configurable via 'clickhouse.logLevel' in values.yaml, defaulting to 'information'.

Changes:
- Added 'logLevel' to values.yaml
- Updated configmap.yaml template to use new value
- Added unit tests covering default and custom log levels