### PR TITLE
feat: Add Kubernetes-standard HPA naming convention aliases

### DIFF
--- a/charts/posthog/templates/decide-hpa.yaml
+++ b/charts/posthog/templates/decide-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-decide
-  minReplicas: {{ .Values.decide.hpa.minpods }}
-  maxReplicas: {{ .Values.decide.hpa.maxpods }}
+  minReplicas: {{ .Values.decide.hpa.minReplicas | default .Values.decide.hpa.minpods }}
+  maxReplicas: {{ .Values.decide.hpa.maxReplicas | default .Values.decide.hpa.maxpods }}
   metrics:
-  {{- with .Values.decide.hpa.cputhreshold }}
+  {{- with .Values.decide.hpa.targetCPUUtilizationPercentage | default .Values.decide.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.decide.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/events-hpa.yaml
+++ b/charts/posthog/templates/events-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-events
-  minReplicas: {{ .Values.events.hpa.minpods }}
-  maxReplicas: {{ .Values.events.hpa.maxpods }}
+  minReplicas: {{ .Values.events.hpa.minReplicas | default .Values.events.hpa.minpods }}
+  maxReplicas: {{ .Values.events.hpa.maxReplicas | default .Values.events.hpa.maxpods }}
   metrics:
-  {{- with .Values.events.hpa.cputhreshold }}
+  {{- with .Values.events.hpa.targetCPUUtilizationPercentage | default .Values.events.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.events.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/pgbouncer-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-pgbouncer
-  minReplicas: {{ .Values.pgbouncer.hpa.minpods }}
-  maxReplicas: {{ .Values.pgbouncer.hpa.maxpods }}
+  minReplicas: {{ .Values.pgbouncer.hpa.minReplicas | default .Values.pgbouncer.hpa.minpods }}
+  maxReplicas: {{ .Values.pgbouncer.hpa.maxReplicas | default .Values.pgbouncer.hpa.maxpods }}
   metrics:
-  {{- with .Values.pgbouncer.hpa.cputhreshold }}
+  {{- with .Values.pgbouncer.hpa.targetCPUUtilizationPercentage | default .Values.pgbouncer.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu

--- a/charts/posthog/templates/pgbouncer-read-hpa.yaml
+++ b/charts/posthog/templates/pgbouncer-read-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-pgbouncer-read
-  minReplicas: {{ .Values.pgbouncerRead.hpa.minpods }}
-  maxReplicas: {{ .Values.pgbouncerRead.hpa.maxpods }}
+  minReplicas: {{ .Values.pgbouncerRead.hpa.minReplicas | default .Values.pgbouncerRead.hpa.minpods }}
+  maxReplicas: {{ .Values.pgbouncerRead.hpa.maxReplicas | default .Values.pgbouncerRead.hpa.maxpods }}
   metrics:
-  {{- with .Values.pgbouncerRead.hpa.cputhreshold }}
+  {{- with .Values.pgbouncerRead.hpa.targetCPUUtilizationPercentage | default .Values.pgbouncerRead.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu

--- a/charts/posthog/templates/recordings-hpa.yaml
+++ b/charts/posthog/templates/recordings-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-recordings
-  minReplicas: {{ .Values.recordings.hpa.minpods }}
-  maxReplicas: {{ .Values.recordings.hpa.maxpods }}
+  minReplicas: {{ .Values.recordings.hpa.minReplicas | default .Values.recordings.hpa.minpods }}
+  maxReplicas: {{ .Values.recordings.hpa.maxReplicas | default .Values.recordings.hpa.maxpods }}
   metrics:
-  {{- with .Values.recordings.hpa.cputhreshold }}
+  {{- with .Values.recordings.hpa.targetCPUUtilizationPercentage | default .Values.recordings.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.recordings.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/temporal-py-worker-hpa.yaml
+++ b/charts/posthog/templates/temporal-py-worker-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-temporal-py-worker
-  minReplicas: {{ .Values.temporalPyWorker.hpa.minpods }}
-  maxReplicas: {{ .Values.temporalPyWorker.hpa.maxpods }}
+  minReplicas: {{ .Values.temporalPyWorker.hpa.minReplicas | default .Values.temporalPyWorker.hpa.minpods }}
+  maxReplicas: {{ .Values.temporalPyWorker.hpa.maxReplicas | default .Values.temporalPyWorker.hpa.maxpods }}
   metrics:
-  {{- with .Values.temporalPyWorker.hpa.cputhreshold }}
+  {{- with .Values.temporalPyWorker.hpa.targetCPUUtilizationPercentage | default .Values.temporalPyWorker.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.temporalPyWorker.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/web-hpa.yaml
+++ b/charts/posthog/templates/web-hpa.yaml
@@ -9,10 +9,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" . }}-web
-  minReplicas: {{ .Values.web.hpa.minpods }}
-  maxReplicas: {{ .Values.web.hpa.maxpods }}
+  minReplicas: {{ .Values.web.hpa.minReplicas | default .Values.web.hpa.minpods }}
+  maxReplicas: {{ .Values.web.hpa.maxReplicas | default .Values.web.hpa.maxpods }}
   metrics:
-  {{- with .Values.web.hpa.cputhreshold }}
+  {{- with .Values.web.hpa.targetCPUUtilizationPercentage | default .Values.web.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -20,6 +20,6 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml .Values.web.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/posthog/templates/worker-hpa.yaml
+++ b/charts/posthog/templates/worker-hpa.yaml
@@ -11,10 +11,10 @@ spec:
     kind: Deployment
     apiVersion: apps/v1
     name: {{ template "posthog.fullname" $ }}-worker-{{ .name }}
-  minReplicas: {{ ( .hpa | default dict ).minpods | default $.Values.worker.hpa.minpods  }}
-  maxReplicas: {{ ( .hpa | default dict ).maxpods | default $.Values.worker.hpa.maxpods  }}
+  minReplicas: {{ ( .hpa | default dict ).minReplicas | default ( .hpa | default dict ).minpods | default $.Values.worker.hpa.minReplicas | default $.Values.worker.hpa.minpods }}
+  maxReplicas: {{ ( .hpa | default dict ).maxReplicas | default ( .hpa | default dict ).maxpods | default $.Values.worker.hpa.maxReplicas | default $.Values.worker.hpa.maxpods }}
   metrics:
-  {{- with $.Values.worker.hpa.cputhreshold }}
+  {{- with $.Values.worker.hpa.targetCPUUtilizationPercentage | default $.Values.worker.hpa.cputhreshold }}
   - type: Resource
     resource:
       name: cpu
@@ -22,7 +22,7 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
-  behavior: 
+  behavior:
     {{ toYaml $.Values.worker.hpa.behavior | nindent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Add support for standard Kubernetes HPA naming conventions while maintaining backward compatibility with existing chart values:

| Standard (new) | Chart (existing) |
|----------------|------------------|
| `minReplicas` | `minpods` |
| `maxReplicas` | `maxpods` |
| `targetCPUUtilizationPercentage` | `cputhreshold` |

Users can now use either naming convention. The standard names take precedence if both are specified.

## Problem

When users configure HPAs using standard Kubernetes naming (which is intuitive and matches the actual HPA spec), the values are silently ignored and chart defaults are applied instead. This leads to unexpected scaling behavior.

## Changes

Updated 8 HPA template files to support both naming conventions:
- `web-hpa.yaml`
- `worker-hpa.yaml`
- `events-hpa.yaml`
- `decide-hpa.yaml`
- `recordings-hpa.yaml`
- `pgbouncer-hpa.yaml`
- `pgbouncer-read-hpa.yaml`
- `temporal-py-worker-hpa.yaml`

## Backward Compatibility

This is fully backward compatible. Existing deployments using `minpods`/`maxpods`/`cputhreshold` will continue to work unchanged.

## Testing

Verified template rendering produces correct HPA manifests with both naming conventions.

Fixes #801